### PR TITLE
Add Recipients endpoints (list segments, subscribers, tags)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -73,6 +73,12 @@ import type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleSegmentListParams,
+  RuleSegmentListResponse,
+  RuleRecipientSubscriberListParams,
+  RuleRecipientSubscriberListResponse,
+  RuleRecipientTagListParams,
+  RuleRecipientTagListResponse,
 } from './types';
 
 /** Flat query-param bag accepted by `buildQueryString`. */
@@ -1276,6 +1282,76 @@ export class RuleClient {
     return this.requestV3<RuleApiResponse>(`/editor/campaign/${id}/schedule`, {
       method: 'POST',
       body: JSON.stringify(schedule),
+    });
+  }
+
+  // ==========================================================================
+  // v3 Editor API - Recipients
+  // ==========================================================================
+
+  /**
+   * List available segments for targeting recipients.
+   *
+   * @param params - Optional pagination parameters
+   * @returns List of segments
+   *
+   * @example
+   * ```typescript
+   * // List all segments
+   * const all = await client.listSegments();
+   *
+   * // Paginate
+   * const page2 = await client.listSegments({ page: 2, per_page: 20 });
+   * ```
+   */
+  async listSegments(params?: RuleSegmentListParams): Promise<RuleSegmentListResponse> {
+    const qs = params ? RuleClient.buildQueryString({ ...params }) : '';
+    return this.requestV3<RuleSegmentListResponse>(`/editor/recipients/segments${qs}`, {
+      method: 'GET',
+    });
+  }
+
+  /**
+   * List subscribers available as recipients.
+   *
+   * @param params - Optional pagination and search parameters
+   * @returns List of recipient subscribers
+   *
+   * @example
+   * ```typescript
+   * // List all recipient subscribers
+   * const all = await client.listRecipientSubscribers();
+   *
+   * // Search by email
+   * const filtered = await client.listRecipientSubscribers({ query: 'anna@' });
+   * ```
+   */
+  async listRecipientSubscribers(params?: RuleRecipientSubscriberListParams): Promise<RuleRecipientSubscriberListResponse> {
+    const qs = params ? RuleClient.buildQueryString({ ...params }) : '';
+    return this.requestV3<RuleRecipientSubscriberListResponse>(`/editor/recipients/subscribers${qs}`, {
+      method: 'GET',
+    });
+  }
+
+  /**
+   * List tags available for targeting recipients.
+   *
+   * @param params - Optional pagination parameters
+   * @returns List of recipient tags
+   *
+   * @example
+   * ```typescript
+   * // List all recipient tags
+   * const all = await client.listRecipientTags();
+   *
+   * // Paginate
+   * const page2 = await client.listRecipientTags({ page: 2, per_page: 10 });
+   * ```
+   */
+  async listRecipientTags(params?: RuleRecipientTagListParams): Promise<RuleRecipientTagListResponse> {
+    const qs = params ? RuleClient.buildQueryString({ ...params }) : '';
+    return this.requestV3<RuleRecipientTagListResponse>(`/editor/recipients/tags${qs}`, {
+      method: 'GET',
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,15 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleSegment,
+  RuleSegmentListParams,
+  RuleSegmentListResponse,
+  RuleRecipientSubscriber,
+  RuleRecipientSubscriberListParams,
+  RuleRecipientSubscriberListResponse,
+  RuleRecipientTag,
+  RuleRecipientTagListParams,
+  RuleRecipientTagListResponse,
 } from './types';
 
 // Types - RCML

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -695,6 +695,82 @@ export interface RuleSubscriberTagsV3Request {
 }
 
 // ============================================================================
+// v3 Editor API Types - Recipients
+// ============================================================================
+
+/**
+ * A segment as returned by the recipients/segments endpoint.
+ */
+export interface RuleSegment {
+  id: number;
+  name: string;
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Query parameters for listing segments.
+ *
+ * @example
+ * ```typescript
+ * const segments = await client.listSegments({ page: 1, per_page: 20 });
+ * ```
+ */
+export type RuleSegmentListParams = RulePaginationParams;
+
+export type RuleSegmentListResponse = RuleListResponse<RuleSegment>;
+
+/**
+ * A subscriber as returned by the recipients/subscribers endpoint.
+ */
+export interface RuleRecipientSubscriber {
+  id: number;
+  email?: string | null;
+  phone_number?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Query parameters for listing recipient subscribers.
+ *
+ * @example
+ * ```typescript
+ * const subs = await client.listRecipientSubscribers({ page: 1, per_page: 50 });
+ * ```
+ */
+export interface RuleRecipientSubscriberListParams extends RulePaginationParams {
+  /** Full-text search by email or phone number */
+  query?: string;
+}
+
+export type RuleRecipientSubscriberListResponse = RuleListResponse<RuleRecipientSubscriber>;
+
+/**
+ * A tag as returned by the recipients/tags endpoint.
+ */
+export interface RuleRecipientTag {
+  id: number;
+  name: string;
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Query parameters for listing recipient tags.
+ *
+ * @example
+ * ```typescript
+ * const tags = await client.listRecipientTags({ page: 1, per_page: 20 });
+ * ```
+ */
+export type RuleRecipientTagListParams = RulePaginationParams;
+
+export type RuleRecipientTagListResponse = RuleListResponse<RuleRecipientTag>;
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,15 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleSegment,
+  RuleSegmentListParams,
+  RuleSegmentListResponse,
+  RuleRecipientSubscriber,
+  RuleRecipientSubscriberListParams,
+  RuleRecipientSubscriberListResponse,
+  RuleRecipientTag,
+  RuleRecipientTagListParams,
+  RuleRecipientTagListResponse,
 } from './api';
 
 // RCML types

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -860,6 +860,99 @@ describe('RuleClient', () => {
     });
   });
 
+  describe('v3 Recipients API', () => {
+    it('should list segments without params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [{ id: 1, name: 'Active Users' }, { id: 2, name: 'VIP' }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSegments();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data![0].name).toBe('Active Users');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/editor/recipients/segments');
+      expect(mockFetch.mock.calls[0][1].method).toBe('GET');
+    });
+
+    it('should list segments with pagination params', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listSegments({ page: 2, per_page: 10 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/editor/recipients/segments?');
+      expect(url).toContain('page=2');
+      expect(url).toContain('per_page=10');
+    });
+
+    it('should list recipient subscribers without params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [{ id: 100, email: 'anna@example.com' }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listRecipientSubscribers();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data![0].email).toBe('anna@example.com');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/editor/recipients/subscribers');
+      expect(mockFetch.mock.calls[0][1].method).toBe('GET');
+    });
+
+    it('should list recipient subscribers with query and pagination', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listRecipientSubscribers({ query: 'anna@', page: 1, per_page: 50 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/editor/recipients/subscribers?');
+      expect(url).toContain('query=anna%40');
+      expect(url).toContain('page=1');
+      expect(url).toContain('per_page=50');
+    });
+
+    it('should list recipient tags without params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [{ id: 10, name: 'Newsletter' }, { id: 20, name: 'VIP' }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listRecipientTags();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data![1].name).toBe('VIP');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/editor/recipients/tags');
+      expect(mockFetch.mock.calls[0][1].method).toBe('GET');
+    });
+
+    it('should list recipient tags with pagination params', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listRecipientTags({ page: 3, per_page: 5 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/editor/recipients/tags?');
+      expect(url).toContain('page=3');
+      expect(url).toContain('per_page=5');
+    });
+  });
+
   describe('v3 Suppressions API', () => {
     it('should create suppressions with POST to /suppressions/', async () => {
       mockFetch.mockResolvedValueOnce(createMock204Response());


### PR DESCRIPTION
## Summary
- Adds `listSegments()`, `listRecipientSubscribers()`, and `listRecipientTags()` methods to `RuleClient`
- 3 read-only v3 endpoints for querying targeting recipients
- 9 new types added (`RuleSegment`, `RuleRecipientSubscriber`, `RuleRecipientTag` + params/response types)

## Test plan
- [x] 6 new tests covering happy path with/without query params for each endpoint
- [x] All 220 tests pass
- [x] Type-check clean

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)