### PR TITLE
Add Analytics endpoint (dispatcher statistics)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -73,6 +73,8 @@ import type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAnalyticsParams,
+  RuleAnalyticsResponse,
 } from './types';
 
 /** Flat query-param bag accepted by `buildQueryString`. */
@@ -1630,6 +1632,58 @@ export class RuleClient {
       }
     );
     return { success: true };
+  }
+
+  // ==========================================================================
+  // v3 Analytics API
+  // ==========================================================================
+
+  /**
+   * Retrieve email performance analytics for one or more objects.
+   *
+   * Array query parameters (`object_ids[]`, `metrics[]`) are serialised in
+   * bracket notation as required by the Rule.io API.
+   *
+   * @param params - Analytics query parameters including date range, object type/IDs, and metrics
+   * @returns Analytics response containing metric data for each requested object
+   *
+   * @example
+   * ```typescript
+   * const analytics = await client.getAnalytics({
+   *   date_from: '2024-01-01',
+   *   date_to: '2024-01-31',
+   *   object_type: 'CAMPAIGN',
+   *   object_ids: [101, 102],
+   *   metrics: ['sent', 'open_uniq', 'click_uniq'],
+   * });
+   * console.log(analytics.data); // [{ object_id: 101, sent: 500, ... }, ...]
+   * ```
+   */
+  async getAnalytics(params: RuleAnalyticsParams): Promise<RuleAnalyticsResponse> {
+    // Build query string manually because buildQueryString does not handle array params
+    const parts: string[] = [
+      `date_from=${encodeURIComponent(params.date_from)}`,
+      `date_to=${encodeURIComponent(params.date_to)}`,
+      `object_type=${encodeURIComponent(params.object_type)}`,
+    ];
+
+    for (const id of params.object_ids) {
+      parts.push(`object_ids[]=${encodeURIComponent(String(id))}`);
+    }
+
+    for (const metric of params.metrics) {
+      parts.push(`metrics[]=${encodeURIComponent(metric)}`);
+    }
+
+    if (params.message_type) {
+      parts.push(`message_type=${encodeURIComponent(params.message_type)}`);
+    }
+
+    const qs = `?${parts.join('&')}`;
+
+    return this.requestV3<RuleAnalyticsResponse>(`/analytics${qs}`, {
+      method: 'GET',
+    });
   }
 
   // ==========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,12 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAnalyticsObjectType,
+  RuleAnalyticsMetric,
+  RuleAnalyticsMessageType,
+  RuleAnalyticsParams,
+  RuleAnalyticsRecord,
+  RuleAnalyticsResponse,
 } from './types';
 
 // Types - RCML

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -695,6 +695,95 @@ export interface RuleSubscriberTagsV3Request {
 }
 
 // ============================================================================
+// v3 Analytics API Types
+// ============================================================================
+
+/**
+ * Object types available for analytics queries.
+ */
+export type RuleAnalyticsObjectType =
+  | 'AB_TEST'
+  | 'CAMPAIGN'
+  | 'AUTOMAIL'
+  | 'TRANSACTIONAL_NAME'
+  | 'JOURNEY';
+
+/**
+ * Metric names available for analytics queries.
+ */
+export type RuleAnalyticsMetric =
+  | 'open'
+  | 'open_uniq'
+  | 'sent'
+  | 'delivered'
+  | 'click_uniq'
+  | 'spam'
+  | 'unsubscribe'
+  | 'total_bounce'
+  | 'soft_bounce'
+  | 'hard_bounce';
+
+/**
+ * Message types available for analytics queries.
+ */
+export type RuleAnalyticsMessageType = 'email' | 'text_message';
+
+/**
+ * Parameters for the analytics endpoint.
+ *
+ * @example
+ * ```typescript
+ * const params: RuleAnalyticsParams = {
+ *   date_from: '2024-01-01',
+ *   date_to: '2024-01-31',
+ *   object_type: 'CAMPAIGN',
+ *   object_ids: [101, 102],
+ *   metrics: ['sent', 'open_uniq', 'click_uniq'],
+ * };
+ * ```
+ */
+export interface RuleAnalyticsParams {
+  /** Start date for the analytics range (e.g. '2024-01-01') */
+  date_from: string;
+  /** End date for the analytics range (e.g. '2024-01-31') */
+  date_to: string;
+  /** Type of object to retrieve analytics for */
+  object_type: RuleAnalyticsObjectType;
+  /** IDs of the objects to retrieve analytics for */
+  object_ids: number[];
+  /** Metrics to include in the response */
+  metrics: RuleAnalyticsMetric[];
+  /** Optional message type filter */
+  message_type?: RuleAnalyticsMessageType;
+}
+
+/**
+ * A single analytics record containing metric values for one object.
+ *
+ * Each requested metric appears as an optional numeric field.
+ */
+export interface RuleAnalyticsRecord {
+  object_id?: number;
+  open?: number;
+  open_uniq?: number;
+  sent?: number;
+  delivered?: number;
+  click_uniq?: number;
+  spam?: number;
+  unsubscribe?: number;
+  total_bounce?: number;
+  soft_bounce?: number;
+  hard_bounce?: number;
+}
+
+/**
+ * Response from the analytics endpoint.
+ */
+export interface RuleAnalyticsResponse extends RuleApiResponse {
+  data?: RuleAnalyticsRecord[];
+}
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,12 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAnalyticsObjectType,
+  RuleAnalyticsMetric,
+  RuleAnalyticsMessageType,
+  RuleAnalyticsParams,
+  RuleAnalyticsRecord,
+  RuleAnalyticsResponse,
 } from './api';
 
 // RCML types

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1277,4 +1277,136 @@ describe('RuleClient', () => {
       );
     });
   });
+
+  // ============================================================================
+  // Analytics API
+  // ============================================================================
+
+  describe('getAnalytics', () => {
+    it('should fetch analytics with correct query parameters', async () => {
+      const mockData = {
+        data: [
+          { object_id: 101, sent: 500, open_uniq: 200, click_uniq: 50 },
+          { object_id: 102, sent: 300, open_uniq: 120, click_uniq: 30 },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAnalytics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+        object_type: 'CAMPAIGN',
+        object_ids: [101, 102],
+        metrics: ['sent', 'open_uniq', 'click_uniq'],
+      });
+
+      expect(result.data).toEqual(mockData.data);
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/analytics?');
+      expect(url).toContain('date_from=2024-01-01');
+      expect(url).toContain('date_to=2024-01-31');
+      expect(url).toContain('object_type=CAMPAIGN');
+      expect(url).toContain('object_ids[]=101');
+      expect(url).toContain('object_ids[]=102');
+      expect(url).toContain('metrics[]=sent');
+      expect(url).toContain('metrics[]=open_uniq');
+      expect(url).toContain('metrics[]=click_uniq');
+      expect(url).not.toContain('message_type');
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.method).toBe('GET');
+    });
+
+    it('should include message_type when provided', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.getAnalytics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+        object_type: 'AUTOMAIL',
+        object_ids: [42],
+        metrics: ['sent', 'delivered'],
+        message_type: 'email',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('message_type=email');
+      expect(url).toContain('object_type=AUTOMAIL');
+    });
+
+    it('should handle empty data response', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAnalytics({
+        date_from: '2024-06-01',
+        date_to: '2024-06-30',
+        object_type: 'JOURNEY',
+        object_ids: [999],
+        metrics: ['open'],
+      });
+
+      expect(result.data).toEqual([]);
+    });
+
+    it('should throw RuleApiError on 401', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Unauthorized' }, 401)
+      );
+
+      const client = new RuleClient({ apiKey: 'bad-key', fetch: mockFetch });
+
+      await expect(
+        client.getAnalytics({
+          date_from: '2024-01-01',
+          date_to: '2024-01-31',
+          object_type: 'CAMPAIGN',
+          object_ids: [1],
+          metrics: ['sent'],
+        })
+      ).rejects.toThrow(RuleApiError);
+    });
+
+    it('should throw RuleApiError on rate limit (429)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Too many requests' }, 429)
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.getAnalytics({
+          date_from: '2024-01-01',
+          date_to: '2024-01-31',
+          object_type: 'CAMPAIGN',
+          object_ids: [1],
+          metrics: ['sent'],
+        })
+      ).rejects.toThrow(RuleApiError);
+    });
+
+    it('should handle single object and single metric', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: [{ object_id: 5, hard_bounce: 3 }] })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAnalytics({
+        date_from: '2024-03-01',
+        date_to: '2024-03-31',
+        object_type: 'TRANSACTIONAL_NAME',
+        object_ids: [5],
+        metrics: ['hard_bounce'],
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data![0].hard_bounce).toBe(3);
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('object_type=TRANSACTIONAL_NAME');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `getAnalytics()` method to `RuleClient` for email performance metrics
- Supports all object types (AB_TEST, CAMPAIGN, AUTOMAIL, TRANSACTIONAL_NAME, JOURNEY)
- Supports all metrics (open, sent, delivered, click_uniq, spam, unsubscribe, bounces, etc.)
- Array query params (`object_ids[]`, `metrics[]`) properly serialized

## Test plan
- [x] 6 new tests covering query serialization, optional params, error handling
- [x] All 220 tests pass
- [x] Type-check clean

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)