### PR TITLE
Add Enterprise Export endpoints (dispatchers, statistics, subscribers)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -68,6 +68,12 @@ import type {
   RuleCustomFieldDataResponse,
   RuleCustomFieldDataSingleResponse,
   RuleSuppressionRequest,
+  RuleExportDispatcherParams,
+  RuleExportDispatcherResponse,
+  RuleExportStatisticsParams,
+  RuleExportStatisticsResponse,
+  RuleExportSubscriberParams,
+  RuleExportSubscriberResponse,
   RuleSubscriberV3CreateRequest,
   RuleSubscriberV3Response,
   RuleBulkSubscriberIdentifier,
@@ -1630,6 +1636,95 @@ export class RuleClient {
       }
     );
     return { success: true };
+  }
+
+  // ==========================================================================
+  // v3 Enterprise Export API
+  // ==========================================================================
+
+  /**
+   * Export dispatcher (send) records for a given date range.
+   *
+   * **Important:** The maximum date range is 1 day. The API will reject
+   * requests where `date_to` is more than 1 day after `date_from`.
+   *
+   * These endpoints may return large datasets. Use `page` and `limit`
+   * parameters to paginate through the results.
+   *
+   * @param params - Date range (max 1 day) and optional pagination
+   * @returns Dispatcher export records
+   *
+   * @example
+   * ```typescript
+   * const result = await client.exportDispatchers({
+   *   date_from: '2024-06-15',
+   *   date_to: '2024-06-15',
+   *   page: 1,
+   *   limit: 100,
+   * });
+   * console.log(result.data); // RuleDispatcherExportRecord[]
+   * ```
+   */
+  async exportDispatchers(
+    params: RuleExportDispatcherParams
+  ): Promise<RuleExportDispatcherResponse> {
+    const qs = RuleClient.buildQueryString({ ...params });
+    return this.requestV3<RuleExportDispatcherResponse>(`/export/dispatcher${qs}`, {
+      method: 'GET',
+    });
+  }
+
+  /**
+   * Export statistics records for a given date range.
+   *
+   * Records are sorted by ID. Each event may have multiple stat records.
+   * Use `page` and `limit` parameters to paginate through large datasets.
+   *
+   * @param params - Date range and optional pagination
+   * @returns Statistics export records
+   *
+   * @example
+   * ```typescript
+   * const result = await client.exportStatistics({
+   *   date_from: '2024-06-01',
+   *   date_to: '2024-06-30',
+   *   page: 1,
+   *   limit: 50,
+   * });
+   * console.log(result.data); // RuleStatisticsExportRecord[]
+   * ```
+   */
+  async exportStatistics(
+    params: RuleExportStatisticsParams
+  ): Promise<RuleExportStatisticsResponse> {
+    const qs = RuleClient.buildQueryString({ ...params });
+    return this.requestV3<RuleExportStatisticsResponse>(`/export/statistics${qs}`, {
+      method: 'GET',
+    });
+  }
+
+  /**
+   * Export subscriber records with optional pagination.
+   *
+   * This endpoint may return large datasets. Use `page` and `limit`
+   * parameters to paginate through the results.
+   *
+   * @param params - Optional pagination parameters
+   * @returns Subscriber export records
+   *
+   * @example
+   * ```typescript
+   * const result = await client.exportSubscribers({ page: 1, limit: 100 });
+   * console.log(result.data); // RuleSubscriberExportRecord[]
+   * ```
+   */
+  async exportSubscribers(
+    params?: RuleExportSubscriberParams
+  ): Promise<RuleExportSubscriberResponse> {
+    const qs = params ? RuleClient.buildQueryString({ ...params }) : '';
+    return this.requestV3<RuleExportSubscriberResponse>(`/export/subscriber${qs}`, {
+      method: 'GET',
+    });
   }
 
   // ==========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,16 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleExportDateParams,
+  RuleExportDispatcherParams,
+  RuleDispatcherExportRecord,
+  RuleExportDispatcherResponse,
+  RuleExportStatisticsParams,
+  RuleStatisticsExportRecord,
+  RuleExportStatisticsResponse,
+  RuleExportSubscriberParams,
+  RuleSubscriberExportRecord,
+  RuleExportSubscriberResponse,
 } from './types';
 
 // Types - RCML

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -695,6 +695,131 @@ export interface RuleSubscriberTagsV3Request {
 }
 
 // ============================================================================
+// v3 Enterprise Export API Types
+// ============================================================================
+
+/**
+ * Common date range parameters for export endpoints.
+ */
+export interface RuleExportDateParams {
+  /** Start date (inclusive), e.g. '2024-01-01' */
+  date_from: string;
+  /** End date (inclusive), e.g. '2024-01-01' */
+  date_to: string;
+}
+
+/**
+ * Query parameters for the dispatcher export endpoint.
+ *
+ * **Important:** The maximum date range is 1 day. The API will reject
+ * requests where `date_to` is more than 1 day after `date_from`.
+ *
+ * @example
+ * ```typescript
+ * const params: RuleExportDispatcherParams = {
+ *   date_from: '2024-06-15',
+ *   date_to: '2024-06-15',
+ *   page: 1,
+ *   limit: 100,
+ * };
+ * ```
+ */
+export interface RuleExportDispatcherParams extends RuleExportDateParams {
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * A single dispatcher record from the export endpoint.
+ * All fields are optional as the API may omit them.
+ */
+export interface RuleDispatcherExportRecord {
+  id?: number;
+  type?: string;
+  name?: string;
+  status?: string;
+  sent_at?: string;
+}
+
+/**
+ * Response from the dispatcher export endpoint.
+ */
+export interface RuleExportDispatcherResponse extends RuleApiResponse {
+  data?: RuleDispatcherExportRecord[];
+}
+
+/**
+ * Query parameters for the statistics export endpoint.
+ *
+ * @example
+ * ```typescript
+ * const params: RuleExportStatisticsParams = {
+ *   date_from: '2024-06-01',
+ *   date_to: '2024-06-30',
+ *   page: 1,
+ *   limit: 50,
+ * };
+ * ```
+ */
+export interface RuleExportStatisticsParams extends RuleExportDateParams {
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * A single statistics record from the export endpoint.
+ * Each event may have multiple stat records. Records are sorted by ID.
+ * All fields are optional as the API may omit them.
+ */
+export interface RuleStatisticsExportRecord {
+  id?: number;
+  dispatcher_id?: number;
+  event_type?: string;
+}
+
+/**
+ * Response from the statistics export endpoint.
+ */
+export interface RuleExportStatisticsResponse extends RuleApiResponse {
+  data?: RuleStatisticsExportRecord[];
+}
+
+/**
+ * Query parameters for the subscriber export endpoint.
+ *
+ * @example
+ * ```typescript
+ * const params: RuleExportSubscriberParams = {
+ *   page: 1,
+ *   limit: 100,
+ * };
+ * ```
+ */
+export interface RuleExportSubscriberParams {
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * A single subscriber record from the export endpoint.
+ * All fields are optional as the API may omit them.
+ */
+export interface RuleSubscriberExportRecord {
+  id?: number;
+  email?: string;
+  phone?: string;
+  status?: string;
+  created_at?: string;
+}
+
+/**
+ * Response from the subscriber export endpoint.
+ */
+export interface RuleExportSubscriberResponse extends RuleApiResponse {
+  data?: RuleSubscriberExportRecord[];
+}
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,16 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleExportDateParams,
+  RuleExportDispatcherParams,
+  RuleDispatcherExportRecord,
+  RuleExportDispatcherResponse,
+  RuleExportStatisticsParams,
+  RuleStatisticsExportRecord,
+  RuleExportStatisticsResponse,
+  RuleExportSubscriberParams,
+  RuleSubscriberExportRecord,
+  RuleExportSubscriberResponse,
 } from './api';
 
 // RCML types

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1277,4 +1277,126 @@ describe('RuleClient', () => {
       );
     });
   });
+
+  describe('v3 Enterprise Export API', () => {
+    it('should export dispatchers with date range and pagination', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [
+            { id: 1, type: 'campaign', name: 'Summer Sale', status: 'sent', sent_at: '2024-06-15T10:00:00Z' },
+            { id: 2, type: 'automail', name: 'Welcome', status: 'sent', sent_at: '2024-06-15T12:00:00Z' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportDispatchers({
+        date_from: '2024-06-15',
+        date_to: '2024-06-15',
+        page: 1,
+        limit: 100,
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data![0].name).toBe('Summer Sale');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/export/dispatcher?');
+      expect(url).toContain('date_from=2024-06-15');
+      expect(url).toContain('date_to=2024-06-15');
+      expect(url).toContain('page=1');
+      expect(url).toContain('limit=100');
+
+      const options = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(options.method).toBe('GET');
+    });
+
+    it('should export dispatchers with only required date params', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.exportDispatchers({
+        date_from: '2024-06-15',
+        date_to: '2024-06-15',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('date_from=2024-06-15');
+      expect(url).toContain('date_to=2024-06-15');
+      expect(url).not.toContain('page=');
+      expect(url).not.toContain('limit=');
+    });
+
+    it('should export statistics with date range and pagination', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [
+            { id: 10, dispatcher_id: 1, event_type: 'open' },
+            { id: 11, dispatcher_id: 1, event_type: 'click' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-06-01',
+        date_to: '2024-06-30',
+        page: 1,
+        limit: 50,
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data![0].event_type).toBe('open');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/export/statistics?');
+      expect(url).toContain('date_from=2024-06-01');
+      expect(url).toContain('date_to=2024-06-30');
+      expect(url).toContain('page=1');
+      expect(url).toContain('limit=50');
+    });
+
+    it('should export subscribers with pagination', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [
+            { id: 100, email: 'user@example.com', status: 'active', created_at: '2024-01-01' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportSubscribers({ page: 1, limit: 100 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data![0].email).toBe('user@example.com');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/export/subscriber?');
+      expect(url).toContain('page=1');
+      expect(url).toContain('limit=100');
+    });
+
+    it('should export subscribers without params', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.exportSubscribers();
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/export/subscriber');
+      expect(url).not.toContain('?');
+    });
+
+    it('should throw RuleApiError on export failure', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Unauthorized' }, 401)
+      );
+
+      const client = new RuleClient({ apiKey: 'bad-key', fetch: mockFetch });
+      await expect(
+        client.exportDispatchers({ date_from: '2024-06-15', date_to: '2024-06-15' })
+      ).rejects.toThrow(RuleApiError);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `exportDispatchers()`, `exportStatistics()`, and `exportSubscribers()` methods to `RuleClient`
- Dispatcher export documents the 1-day max date range limitation
- All endpoints support pagination (page, limit)

## Test plan
- [x] 6 new tests covering full params, required-only params, pagination, error handling
- [x] All 220 tests pass
- [x] Type-check clean

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)