### PR TITLE
Add Account management endpoints (CRUD)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -73,6 +73,10 @@ import type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAccountCreateRequest,
+  RuleAccountResponse,
+  RuleAccountListResponse,
+  RuleAccountListParams,
 } from './types';
 
 /** Flat query-param bag accepted by `buildQueryString`. */
@@ -1629,6 +1633,114 @@ export class RuleClient {
         method: 'DELETE',
       }
     );
+    return { success: true };
+  }
+
+  // ==========================================================================
+  // v3 Account API
+  // ==========================================================================
+
+  /**
+   * List all accounts accessible with the current user-level API key.
+   *
+   * Supports the `includes[]` query parameter to fetch additional relations
+   * (e.g., `sitoo_credentials`).
+   *
+   * @param params - Optional query parameters (includes)
+   * @returns List of accounts
+   *
+   * @example
+   * ```typescript
+   * // List all accounts
+   * const accounts = await client.listAccounts();
+   * console.log(accounts.data);
+   *
+   * // Include additional relations
+   * const withCreds = await client.listAccounts({ includes: ['sitoo_credentials'] });
+   * ```
+   */
+  async listAccounts(params?: RuleAccountListParams): Promise<RuleAccountListResponse> {
+    let qs = '';
+    if (params?.includes?.length) {
+      const parts = params.includes.map(
+        (inc) => `includes[]=${encodeURIComponent(inc)}`
+      );
+      qs = '?' + parts.join('&');
+    }
+    return this.requestV3<RuleAccountListResponse>(`/accounts${qs}`, {
+      method: 'GET',
+    });
+  }
+
+  /**
+   * Create a new account.
+   *
+   * **Requires Super Admin role.** This endpoint uses user-level API keys,
+   * not account-level keys.
+   *
+   * @param account - Account creation request
+   * @returns Created account data
+   *
+   * @example
+   * ```typescript
+   * const result = await client.createAccount({ name: 'New Sub-Account' });
+   * console.log(result.data?.id);
+   * ```
+   */
+  async createAccount(account: RuleAccountCreateRequest): Promise<RuleAccountResponse> {
+    return this.requestV3<RuleAccountResponse>('/accounts', {
+      method: 'POST',
+      body: JSON.stringify(account),
+    });
+  }
+
+  /**
+   * Get an account by ID, or pass `"show"` to retrieve the current account.
+   *
+   * @param accountId - Numeric account ID, or the string `"show"` for the current account
+   * @returns Account data, or null if not found
+   *
+   * @example
+   * ```typescript
+   * // Get current account
+   * const current = await client.getAccount('show');
+   *
+   * // Get a specific account
+   * const account = await client.getAccount(42);
+   * ```
+   */
+  async getAccount(accountId: number | 'show'): Promise<RuleAccountResponse | null> {
+    try {
+      return await this.requestV3<RuleAccountResponse>(`/accounts/${accountId}`, {
+        method: 'GET',
+      });
+    } catch (error) {
+      if (error instanceof RuleApiError && error.statusCode === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Delete an account by ID.
+   *
+   * **Requires Super Admin role.** The deletion is queued and processed
+   * asynchronously — the account is not removed immediately.
+   *
+   * @param accountId - Account ID to delete
+   * @returns API response confirming the deletion was queued
+   *
+   * @example
+   * ```typescript
+   * // Requires Super Admin role; deletion is queued, not immediate
+   * await client.deleteAccount(42);
+   * ```
+   */
+  async deleteAccount(accountId: number): Promise<RuleApiResponse> {
+    await this.fetchV3(`/accounts/${accountId}`, {
+      method: 'DELETE',
+    });
     return { success: true };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,11 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAccount,
+  RuleAccountCreateRequest,
+  RuleAccountResponse,
+  RuleAccountListResponse,
+  RuleAccountListParams,
 } from './types';
 
 // Types - RCML

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -695,6 +695,51 @@ export interface RuleSubscriberTagsV3Request {
 }
 
 // ============================================================================
+// v3 Account API Types
+// ============================================================================
+
+/**
+ * Account as returned by the Rule.io v3 API.
+ */
+export interface RuleAccount {
+  id?: number;
+  name?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Request body for creating an account.
+ *
+ * Requires Super Admin role.
+ */
+export interface RuleAccountCreateRequest {
+  name: string;
+}
+
+/**
+ * Response from account endpoints that return a single account.
+ */
+export interface RuleAccountResponse extends RuleApiResponse {
+  data?: RuleAccount;
+}
+
+/**
+ * Response from the list accounts endpoint.
+ */
+export interface RuleAccountListResponse extends RuleApiResponse {
+  data?: RuleAccount[];
+}
+
+/**
+ * Query parameters for listing accounts.
+ */
+export interface RuleAccountListParams {
+  /** Include additional relations (e.g., 'sitoo_credentials') */
+  includes?: string[];
+}
+
+// ============================================================================
 // Client Configuration
 // ============================================================================
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,11 @@ export type {
   RuleBulkSubscriberIdentifier,
   RuleBulkTagsRequest,
   RuleSubscriberTagsV3Request,
+  RuleAccount,
+  RuleAccountCreateRequest,
+  RuleAccountResponse,
+  RuleAccountListResponse,
+  RuleAccountListParams,
 } from './api';
 
 // RCML types

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1277,4 +1277,138 @@ describe('RuleClient', () => {
       );
     });
   });
+
+  describe('v3 Account API', () => {
+    it('should list accounts', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [
+            { id: 1, name: 'Account 1' },
+            { id: 2, name: 'Account 2' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listAccounts();
+
+      expect(result.data).toHaveLength(2);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v3/accounts');
+      expect(options.method).toBe('GET');
+    });
+
+    it('should list accounts with includes[] query param', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listAccounts({ includes: ['sitoo_credentials'] });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe(
+        'https://app.rule.io/api/v3/accounts?includes[]=sitoo_credentials'
+      );
+    });
+
+    it('should list accounts with multiple includes', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listAccounts({ includes: ['sitoo_credentials', 'other'] });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('includes[]=sitoo_credentials');
+      expect(url).toContain('includes[]=other');
+    });
+
+    it('should list accounts without includes when array is empty', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listAccounts({ includes: [] });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/accounts');
+      expect(url).not.toContain('?');
+    });
+
+    it('should create an account', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 5, name: 'New Account' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.createAccount({ name: 'New Account' });
+
+      expect(result.data?.id).toBe(5);
+      expect(result.data?.name).toBe('New Account');
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v3/accounts');
+      expect(options.method).toBe('POST');
+      const body = JSON.parse(options.body);
+      expect(body.name).toBe('New Account');
+    });
+
+    it('should get an account by ID', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 42, name: 'My Account' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAccount(42);
+
+      expect(result?.data?.id).toBe(42);
+      expect(result?.data?.name).toBe('My Account');
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/accounts/42');
+    });
+
+    it('should get the current account with "show"', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 1, name: 'Current Account' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAccount('show');
+
+      expect(result?.data?.id).toBe(1);
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://app.rule.io/api/v3/accounts/show');
+    });
+
+    it('should return null for non-existent account', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Not found' }, 404));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getAccount(99999);
+
+      expect(result).toBeNull();
+    });
+
+    it('should delete an account', async () => {
+      mockFetch.mockResolvedValueOnce(createMock204Response());
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.deleteAccount(42);
+
+      expect(result).toEqual({ success: true });
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v3/accounts/42');
+      expect(options.method).toBe('DELETE');
+    });
+
+    it('should throw RuleApiError on 401 for account endpoints', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Unauthorized' }, 401));
+
+      const client = new RuleClient({ apiKey: 'bad-key', fetch: mockFetch });
+
+      await expect(client.listAccounts()).rejects.toThrow('Invalid Rule.io API key');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `listAccounts()`, `createAccount()`, `getAccount()`, and `deleteAccount()` to `RuleClient`
- `getAccount()` supports `'show'` param to get current account
- `listAccounts()` supports `includes[]` query param (e.g., `sitoo_credentials`)
- JSDoc documents Super Admin role requirement for create/delete
- Delete queues deletion (not immediate)

## Test plan
- [x] 10 new tests covering happy paths, edge cases (empty includes, "show" param, 404 null), error cases
- [x] All 224 tests pass
- [x] Type-check clean

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)