### PR TITLE
Add test coverage for v3 get methods returning null on 404

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -417,12 +417,19 @@ describe('RuleClient', () => {
       expect(result).toBeNull();
     });
 
-    it('should still throw RuleApiError for non-404 errors on v3 get methods', async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Server error' }, 500));
-
+    it('should still throw RuleApiError for non-404 errors on all v3 get methods', async () => {
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const getMethods = [
+        (id: number) => client.getAutomail(id),
+        (id: number) => client.getMessage(id),
+        (id: number) => client.getTemplate(id),
+        (id: number) => client.getDynamicSet(id),
+      ];
 
-      await expect(client.getAutomail(123)).rejects.toThrow(RuleApiError);
+      for (const getMethod of getMethods) {
+        mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Server error' }, 500));
+        await expect(getMethod(123)).rejects.toThrow(RuleApiError);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- The 404-returns-null behavior was already correctly implemented for all v3 get methods
- Added missing unit tests for `getAutomail`, `getMessage`, `getTemplate`, and `getDynamicSet` 404 handling
- Added test verifying non-404 errors still throw `RuleApiError`

## Test plan
- [x] `getAutomail` returns null on 404
- [x] `getMessage` returns null on 404
- [x] `getTemplate` returns null on 404
- [x] `getDynamicSet` returns null on 404
- [x] Non-404 errors still throw
- [x] All 265 tests pass, type-check clean

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)