### PR TITLE
Add API feedback document for Rule.io v3+

### DIFF
--- a/API_FEEDBACK_V3.md
+++ b/API_FEEDBACK_V3.md
@@ -69,7 +69,7 @@ v2 accepts `application/json`; v3 requires `application/json;charset=utf-8`. Mos
 ### 11. DELETE requests with JSON bodies
 `DELETE /api/v3/suppressions/` and `DELETE /api/v3/subscribers/tags` require JSON request bodies. DELETE request bodies have no generally defined semantics and are inconsistently supported across HTTP clients, servers, and intermediaries (see RFC 9110), which makes these endpoints less interoperable.
 
-**Suggestion:** Use `POST /suppressions/delete` or `POST /subscribers/tags/remove` patterns instead.
+**Suggestion:** Use `POST /api/v3/suppressions/delete` or `POST /api/v3/subscribers/tags/remove` patterns instead.
 
 ### 12. No batch tag removal in v2
 Removing N tags from a subscriber requires N separate `DELETE /api/v2/subscribers/{email}/tags/{tag}` calls. The SDK parallelizes them, but it's wasteful.
@@ -97,7 +97,7 @@ When the date range exceeds 1 day, the API exhibits inconsistent failure behavio
 **Suggestion:** Document the constraint and return a clear validation error with the allowed range.
 
 ### 17. Async operations return 204 with no tracking
-Bulk operations (suppressions, block/unblock, bulk tags) return `204 No Content` and process asynchronously. There's an optional `callbackUrl` but no job ID or polling endpoint.
+Bulk operations (suppressions, block/unblock, bulk tags) return `204 No Content` and process asynchronously. There's an optional `callback_url` but no job ID or polling endpoint.
 
 **Suggestion:** Return a job ID and provide a status polling endpoint.
 


### PR DESCRIPTION
## Summary
- Adds `API_FEEDBACK_V3.md` cataloging 20 API friction points discovered while building the SDK
- Organized by severity: Critical (4), High (6), Medium (7), Wishlist (3)
- Each item includes a concrete suggestion for the Rule.io API team

## Highlights
- Misleading uppercase/lowercase error messages on trigger types
- Two-step automail creation forcing rollback logic
- Cross-version dependency (v3 triggers need v2 tag IDs)
- Inconsistent response shapes, field names, and validation errors

## Test plan
- [ ] Review document for accuracy and tone before sharing with Rule.io team
- [ ] No code changes — SDK behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)