### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,11 @@ jobs:
 
           const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
           const dependencies = Object.keys(pkg.dependencies || {});
+          const optionalDependencies = Object.keys(pkg.optionalDependencies || {});
+          const runtimeDependencies = [...dependencies, ...optionalDependencies];
 
-          if (dependencies.length > 0) {
-            console.error(`ERROR: package.json must not declare runtime dependencies: ${dependencies.join(', ')}`);
+          if (runtimeDependencies.length > 0) {
+            console.error(`ERROR: package.json must not declare runtime dependencies: ${runtimeDependencies.join(', ')}`);
             process.exit(1);
           }
 
@@ -107,6 +109,9 @@ jobs:
               addIfExternal(file, match[1]);
             }
             for (const match of source.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+              addIfExternal(file, match[1]);
+            }
+            for (const match of source.matchAll(/\bexport\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]/g)) {
               addIfExternal(file, match[1]);
             }
           }


### PR DESCRIPTION
## Summary
- Adds CI workflow that runs on PRs to main and pushes to main
- Tests across Node 18, 20, and 22 (SDK targets Node 18+)
- Validates type-check, tests, build, dist outputs (CJS/ESM/types), and zero runtime dependencies

## Test plan
- [ ] CI runs successfully on this PR itself
- [ ] Verify all 3 matrix jobs (Node 18, 20, 22) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)