### PR TITLE
fix: use POST /suppressions/delete instead of DELETE (#58)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1419,6 +1419,10 @@ export class RuleClient {
    * The request is processed asynchronously by the Rule.io API. If `message_types`
    * is omitted, all channel suppressions are removed for the specified subscribers.
    *
+   * **API quirk:** Despite the OpenAPI spec documenting `DELETE /suppressions/`,
+   * the live API returns 405 for that method. The actual endpoint is
+   * `POST /suppressions/delete`.
+   *
    * @param request - Unsuppression request with subscriber identifiers and optional filters
    * @returns A success response (actual processing happens asynchronously)
    *
@@ -1444,8 +1448,8 @@ export class RuleClient {
     if (request.subscribers.length > 1000) {
       throw new RuleConfigError('subscribers array must not exceed 1000 items');
     }
-    await this.fetchV3('/suppressions/', {
-      method: 'DELETE',
+    await this.fetchV3('/suppressions/delete', {
+      method: 'POST',
       body: JSON.stringify(request),
     });
     return { success: true };

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1213,7 +1213,10 @@ describe('RuleClient', () => {
         callback_url: 'https://example.com/webhook/done',
       });
 
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
+      expect(options.method).toBe('POST');
+      const body = JSON.parse(options.body);
       expect(body.callback_url).toBe('https://example.com/webhook/done');
     });
 
@@ -1239,8 +1242,22 @@ describe('RuleClient', () => {
         message_types: ['email'],
       });
 
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
+      expect(options.method).toBe('POST');
+      const body = JSON.parse(options.body);
       expect(body.message_types).toEqual(['email']);
+    });
+
+    it('should throw RuleApiError when deleteSuppressions fails', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Rate limited' }, 429),
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await expect(
+        client.deleteSuppressions({ subscribers: [{ email: 'user@example.com' }] }),
+      ).rejects.toThrow(RuleApiError);
     });
 
     it('should reject createSuppressions with empty subscribers array', async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1183,7 +1183,7 @@ describe('RuleClient', () => {
       expect(body.message_types).toEqual(['email']);
     });
 
-    it('should delete suppressions with DELETE and request body', async () => {
+    it('should delete suppressions with POST to /suppressions/delete', async () => {
       mockFetch.mockResolvedValueOnce(createMock204Response());
 
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
@@ -1195,8 +1195,8 @@ describe('RuleClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://app.rule.io/api/v3/suppressions/');
-      expect(options.method).toBe('DELETE');
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
+      expect(options.method).toBe('POST');
       expect(options.headers['Content-Type']).toBe('application/json;charset=utf-8');
 
       const body = JSON.parse(options.body);


### PR DESCRIPTION
## Summary
- `deleteSuppressions()` was sending `DELETE /api/v3/suppressions/` which returns 405 Method Not Allowed
- Changed to `POST /api/v3/suppressions/delete` which is the actual working endpoint
- Documented the API quirk in JSDoc and `.claude/RULE_IO_API_REFERENCE.md`

Closes #58

## Test plan
- [x] Existing test updated to assert `POST` method and `/suppressions/delete` URL
- [x] All 296 tests pass
- [x] Type-check passes
- [ ] Manual verification with live API (requires `RULE_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)