### PR TITLE
test: add comprehensive campaign API test coverage

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1147,7 +1147,11 @@ describe('RuleClient', () => {
     it('should create a campaign with minimal fields (message_type only)', async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          data: { id: 20, name: null, message_type: 1 },
+          data: {
+            id: 20,
+            name: 'Untitled',
+            message_type: { value: 1, key: 'email', description: 'Email' },
+          },
         })
       );
 
@@ -1175,20 +1179,23 @@ describe('RuleClient', () => {
           { id: 2, negative: true },
         ],
         segments: [{ id: 10, negative: false }],
-        subscribers: ['user@example.com'],
+        subscribers: [101, 202],
       });
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.tags).toHaveLength(2);
       expect(body.tags[1].negative).toBe(true);
       expect(body.segments).toEqual([{ id: 10, negative: false }]);
-      expect(body.subscribers).toEqual(['user@example.com']);
+      expect(body.subscribers).toEqual([101, 202]);
     });
 
     it('should create a text message campaign', async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          data: { id: 22, message_type: 2 },
+          data: {
+            id: 22,
+            message_type: { value: 2, key: 'text_message', description: 'Text Message' },
+          },
         })
       );
 
@@ -1231,13 +1238,13 @@ describe('RuleClient', () => {
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
       await client.updateCampaign(10, {
         tags: [{ id: 99, negative: false }],
-        subscribers: ['a@b.com'],
+        subscribers: [101],
       });
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body).toEqual({
         tags: [{ id: 99, negative: false }],
-        subscribers: ['a@b.com'],
+        subscribers: [101],
       });
       expect(body).not.toHaveProperty('name');
       expect(body).not.toHaveProperty('sendout_type');
@@ -1249,7 +1256,13 @@ describe('RuleClient', () => {
 
       const client = new RuleClient({ apiKey: 'bad-key', fetch: mockFetch });
 
-      await expect(client.createCampaign({ message_type: 1 })).rejects.toThrow(RuleApiError);
+      try {
+        await client.createCampaign({ message_type: 1 });
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(RuleApiError);
+        expect((error as RuleApiError).isAuthError()).toBe(true);
+      }
     });
 
     it('should throw RuleApiError on 429 rate limit for listCampaigns', async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -445,6 +445,7 @@ describe('RuleClient', () => {
         (id: number) => client.getMessage(id),
         (id: number) => client.getTemplate(id),
         (id: number) => client.getDynamicSet(id),
+        (id: number) => client.getCampaign(id),
       ];
 
       for (const getMethod of getMethods) {
@@ -1141,6 +1142,152 @@ describe('RuleClient', () => {
       expect(options.method).toBe('POST');
       const body = JSON.parse(options.body);
       expect(body.type).toBeNull();
+    });
+
+    it('should create a campaign with minimal fields (message_type only)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 20, name: null, message_type: 1 },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.createCampaign({ message_type: 1 });
+
+      expect(result.data?.id).toBe(20);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toEqual({ message_type: 1 });
+    });
+
+    it('should create a campaign with all recipient types', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 21, name: 'Full Recipients' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.createCampaign({
+        message_type: 1,
+        sendout_type: 1,
+        tags: [
+          { id: 1, negative: false },
+          { id: 2, negative: true },
+        ],
+        segments: [{ id: 10, negative: false }],
+        subscribers: ['user@example.com'],
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.tags).toHaveLength(2);
+      expect(body.tags[1].negative).toBe(true);
+      expect(body.segments).toEqual([{ id: 10, negative: false }]);
+      expect(body.subscribers).toEqual(['user@example.com']);
+    });
+
+    it('should create a text message campaign', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 22, message_type: 2 },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.createCampaign({ message_type: 2 });
+
+      expect(result.data?.id).toBe(22);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.message_type).toBe(2);
+    });
+
+    it('should handle empty campaign list', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listCampaigns();
+
+      expect(result.data).toEqual([]);
+    });
+
+    it('should list campaigns with only page params', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.listCampaigns({ page: 1, per_page: 5 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('page=1');
+      expect(url).toContain('per_page=5');
+      expect(url).not.toContain('message_type');
+    });
+
+    it('should update a campaign with recipients only', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: 10, name: 'Sale' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.updateCampaign(10, {
+        tags: [{ id: 99, negative: false }],
+        subscribers: ['a@b.com'],
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toEqual({
+        tags: [{ id: 99, negative: false }],
+        subscribers: ['a@b.com'],
+      });
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('sendout_type');
+      expect(body).not.toHaveProperty('segments');
+    });
+
+    it('should throw RuleApiError on 401 for createCampaign', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Unauthorized' }, 401));
+
+      const client = new RuleClient({ apiKey: 'bad-key', fetch: mockFetch });
+
+      await expect(client.createCampaign({ message_type: 1 })).rejects.toThrow(RuleApiError);
+    });
+
+    it('should throw RuleApiError on 429 rate limit for listCampaigns', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Rate limited' }, 429));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      try {
+        await client.listCampaigns();
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(RuleApiError);
+        expect((error as RuleApiError).isRateLimited()).toBe(true);
+      }
+    });
+
+    it('should throw RuleApiError on 500 for updateCampaign', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Server error' }, 500));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(client.updateCampaign(10, { name: 'Fail' })).rejects.toThrow(RuleApiError);
+    });
+
+    it('should throw RuleApiError on 500 for deleteCampaign', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Server error' }, 500));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(client.deleteCampaign(10)).rejects.toThrow(RuleApiError);
+    });
+
+    it('should throw RuleApiError on 500 for copyCampaign', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'Server error' }, 500));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(client.copyCampaign(10)).rejects.toThrow(RuleApiError);
     });
   });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -457,7 +457,10 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
 
     afterEach(async () => {
       if (!campaignId) return;
-      await client.deleteCampaign(campaignId).catch(() => {});
+      await client.deleteCampaign(campaignId).catch((e: unknown) => {
+        if (e instanceof RuleApiError && e.isNotFound()) return;
+        throw e;
+      });
       campaignId = 0;
     });
 
@@ -552,7 +555,10 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
         campaignId = copy.data!.id;
       } finally {
         // Clean up source campaign
-        await client.deleteCampaign(sourceId).catch(() => {});
+        await client.deleteCampaign(sourceId).catch((e: unknown) => {
+          if (e instanceof RuleApiError && e.isNotFound()) return;
+          throw e;
+        });
       }
     });
   });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -517,7 +517,19 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
     });
 
     it('should return null for non-existent campaign', async () => {
-      const result = await client.getCampaign(999999999);
+      // Create then delete to get a guaranteed-missing ID
+      const created = await client.createCampaign({
+        message_type: 1,
+        name: `Deleted Campaign ${RUN_ID}`,
+        sendout_type: 1,
+        tags: [],
+        segments: [],
+        subscribers: [],
+      });
+      const deletedCampaignId = created.data!.id;
+      await client.deleteCampaign(deletedCampaignId);
+
+      const result = await client.getCampaign(deletedCampaignId);
       expect(result).toBeNull();
     });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -499,18 +499,20 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
       expect(fetched!.data!.id).toBe(campaignId);
 
       // Update
+      const updatedName = `Updated Campaign ${RUN_ID}`;
       const updated = await client.updateCampaign(campaignId, {
-        name: `Updated Campaign ${RUN_ID}`,
+        name: updatedName,
         sendout_type: 1,
         tags: [],
         segments: [],
         subscribers: [],
       });
       expect(updated.data).toBeDefined();
+      expect(updated.data!.name).toBe(updatedName);
 
       // Delete (afterEach handles cleanup, but test the return value)
       const deleted = await client.deleteCampaign(campaignId);
-      expect(deleted).toBeDefined();
+      expect(deleted.success).toBe(true);
       campaignId = 0; // prevent afterEach double-delete
     });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -529,10 +529,11 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
         segments: [],
         subscribers: [],
       });
-      const deletedCampaignId = created.data!.id;
-      await client.deleteCampaign(deletedCampaignId);
+      campaignId = created.data!.id;
+      await client.deleteCampaign(campaignId);
+      campaignId = 0;
 
-      const result = await client.getCampaign(deletedCampaignId);
+      const result = await client.getCampaign(created.data!.id);
       expect(result).toBeNull();
     });
 
@@ -550,9 +551,9 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
 
       try {
         const copy = await client.copyCampaign(sourceId);
+        campaignId = copy.data?.id ?? 0;
         expect(copy.data).toBeDefined();
         expect(copy.data!.id).not.toBe(sourceId);
-        campaignId = copy.data!.id;
       } finally {
         // Clean up source campaign
         await client.deleteCampaign(sourceId).catch((e: unknown) => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -453,9 +453,93 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
   // ==========================================================================
 
   describe('v3 Campaigns API', () => {
+    let campaignId = 0;
+
+    afterEach(async () => {
+      if (!campaignId) return;
+      await client.deleteCampaign(campaignId).catch(() => {});
+      campaignId = 0;
+    });
+
     it('should list campaigns', async () => {
       const result = await client.listCampaigns();
       expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should list campaigns with pagination', async () => {
+      const result = await client.listCampaigns({ page: 1, per_page: 5 });
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should list campaigns filtered by message_type', async () => {
+      const result = await client.listCampaigns({ message_type: 1 });
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should create, get, update, and delete a campaign', async () => {
+      // Create
+      const created = await client.createCampaign({
+        message_type: 1,
+        name: `Integration Campaign ${RUN_ID}`,
+        sendout_type: 1,
+        tags: [],
+        segments: [],
+        subscribers: [],
+      });
+      expect(created.data).toBeDefined();
+      expect(created.data!.id).toBeGreaterThan(0);
+      campaignId = created.data!.id;
+
+      // Get
+      const fetched = await client.getCampaign(campaignId);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.data!.id).toBe(campaignId);
+
+      // Update
+      const updated = await client.updateCampaign(campaignId, {
+        name: `Updated Campaign ${RUN_ID}`,
+        sendout_type: 1,
+        tags: [],
+        segments: [],
+        subscribers: [],
+      });
+      expect(updated.data).toBeDefined();
+
+      // Delete (afterEach handles cleanup, but test the return value)
+      const deleted = await client.deleteCampaign(campaignId);
+      expect(deleted).toBeDefined();
+      campaignId = 0; // prevent afterEach double-delete
+    });
+
+    it('should return null for non-existent campaign', async () => {
+      const result = await client.getCampaign(999999999);
+      expect(result).toBeNull();
+    });
+
+    it('should copy a campaign', async () => {
+      // Create a source campaign
+      const source = await client.createCampaign({
+        message_type: 1,
+        name: `Copy Source ${RUN_ID}`,
+        sendout_type: 1,
+        tags: [],
+        segments: [],
+        subscribers: [],
+      });
+      const sourceId = source.data!.id;
+
+      try {
+        const copy = await client.copyCampaign(sourceId);
+        expect(copy.data).toBeDefined();
+        expect(copy.data!.id).not.toBe(sourceId);
+        campaignId = copy.data!.id;
+      } finally {
+        // Clean up source campaign
+        await client.deleteCampaign(sourceId).catch(() => {});
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Add 11 unit tests for campaign error cases (401, 429, 500), edge cases (minimal create, all recipient types, text message, empty list, partial update), and include `getCampaign` in the shared non-404 error test loop
- Expand integration tests from 1 smoke test to 6: list variations, full CRUD lifecycle, null for non-existent ID, and copy with cleanup
- All campaign methods manually verified against live API (create → get → update → copy → list → delete)

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` — 313 passed, 168 in client.test.ts
- [x] Integration tests verified against live Rule.io API
- [x] Cleanup confirmed — no orphaned campaigns after test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)