### PR TITLE
fix: use DELETE method for unsuppress endpoint

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1461,10 +1461,6 @@ export class RuleClient {
    * The request is processed asynchronously by the Rule.io API. If `message_types`
    * is omitted, all channel suppressions are removed for the specified subscribers.
    *
-   * **API quirk:** Despite the OpenAPI spec documenting `DELETE /suppressions/`,
-   * the live API returns 405 for that method. The actual endpoint is
-   * `POST /suppressions/delete`.
-   *
    * @param request - Unsuppression request with subscriber identifiers and optional filters
    * @returns A success response (actual processing happens asynchronously)
    *
@@ -1490,8 +1486,8 @@ export class RuleClient {
     if (request.subscribers.length > 1000) {
       throw new RuleConfigError('subscribers array must not exceed 1000 items');
     }
-    await this.fetchV3('/suppressions/delete', {
-      method: 'POST',
+    await this.fetchV3('/suppressions/', {
+      method: 'DELETE',
       body: JSON.stringify(request),
     });
     return { success: true };

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1343,7 +1343,7 @@ describe('RuleClient', () => {
       expect(body.message_types).toEqual(['email']);
     });
 
-    it('should delete suppressions with POST to /suppressions/delete', async () => {
+    it('should delete suppressions with DELETE /suppressions/', async () => {
       mockFetch.mockResolvedValueOnce(createMock204Response());
 
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
@@ -1355,8 +1355,8 @@ describe('RuleClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
-      expect(options.method).toBe('POST');
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/');
+      expect(options.method).toBe('DELETE');
       expect(options.headers['Content-Type']).toBe('application/json;charset=utf-8');
 
       const body = JSON.parse(options.body);
@@ -1374,8 +1374,8 @@ describe('RuleClient', () => {
       });
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
-      expect(options.method).toBe('POST');
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/');
+      expect(options.method).toBe('DELETE');
       const body = JSON.parse(options.body);
       expect(body.callback_url).toBe('https://example.com/webhook/done');
     });
@@ -1403,8 +1403,8 @@ describe('RuleClient', () => {
       });
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://app.rule.io/api/v3/suppressions/delete');
-      expect(options.method).toBe('POST');
+      expect(url).toBe('https://app.rule.io/api/v3/suppressions/');
+      expect(options.method).toBe('DELETE');
       const body = JSON.parse(options.body);
       expect(body.message_types).toEqual(['email']);
     });


### PR DESCRIPTION
## Summary
- Changed `deleteSuppressions` from `POST /suppressions/delete` to `DELETE /suppressions/`
- The SDK previously used a POST workaround because the Rule.io API returned 405 for DELETE — that bug has been fixed server-side
- Removed outdated "API quirk" JSDoc comment
- Updated all 3 related test cases to expect the correct method and URL

## Verification
- All 337 unit tests pass
- Live-tested against Rule.io API: `DELETE /suppressions/` returns 204 and successfully unsuppresses subscribers

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` — 337 passed
- [x] Live API verification: unsuppress returns `{"success": true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)