### PR TITLE
fix: add URL sanitization to low-level RCML element builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,15 +44,16 @@ function createTemplate(config: TemplateConfig) { ... }
 
 ### 5. URL Sanitization
 
-RCML element builders that accept URL parameters (`href`, `src`) should
-sanitize those values with `sanitizeUrl()` from `src/rcml/utils.ts` when
-wiring them into RCML output. This prevents `javascript:` and `data:`
-URI injection.
+RCML element builders `createButton`, `createImage`, and `createVideo`
+sanitize URL parameters (`href`, `src`) with `sanitizeUrl()` from
+`src/rcml/utils.ts`. This prevents `javascript:` and `data:` URI
+injection. New URL-accepting builders should follow the same pattern.
 
-Text content does NOT need `escapeHtml()` — RCML is structured JSON
-(ProseMirror nodes), not raw HTML. Rule.io's renderer handles text
-encoding. `escapeHtml()` remains available for consumers who build
-raw HTML outside of RCML.
+Text content placed into RCML/ProseMirror text nodes does NOT need
+`escapeHtml()` — RCML is structured JSON, not raw HTML, and Rule.io's
+renderer handles text encoding for those nodes. This does NOT change the
+guidance for raw HTML generation: use `escapeHtml()` when embedding
+user-provided content into raw HTML outside of RCML.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,14 @@ sanitize URL parameters (`href`, `src`) with `sanitizeUrl()` from
 `src/rcml/utils.ts`. This prevents `javascript:` and `data:` URI
 injection. New URL-accepting builders should follow the same pattern.
 
-Text content placed into RCML/ProseMirror text nodes does NOT need
-`escapeHtml()` — RCML is structured JSON, not raw HTML, and Rule.io's
-renderer handles text encoding for those nodes. This does NOT change the
-guidance for raw HTML generation: use `escapeHtml()` when embedding
-user-provided content into raw HTML outside of RCML. Note: the `escapeHtml()`
-docstring in `src/rcml/utils.ts` scopes its guidance to raw HTML only —
-it does not apply to structured RCML/ProseMirror text nodes.
+Text content placed into RCML/ProseMirror text nodes should NOT be
+pre-escaped with `escapeHtml()` — RCML is structured JSON, not raw HTML,
+and Rule.io's renderer handles text encoding for those nodes. Pre-escaping
+those values can produce double-escaped output (`&amp;`, `&lt;`, etc.).
+This is consistent with the README security guidance: use `escapeHtml()`
+when interpolating user-provided content into raw HTML or custom HTML
+templates, but not for structured RCML/ProseMirror text nodes. Note: the
+`escapeHtml()` docstring in `src/rcml/utils.ts` is scoped to raw HTML only.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,16 @@ function createTemplate(config: TemplateConfig) { ... }
 - All public functions must have explicit return types
 - All public types must be exported from `src/index.ts`
 
-### 5. XSS Protection
+### 5. URL Sanitization
 
-All user-provided content rendered in email templates must be escaped.
-Use `escapeHtml()` and `sanitizeUrl()` from `src/rcml/utils.ts`.
+All URL parameters (`href`, `src`) in RCML element builders must be
+sanitized with `sanitizeUrl()` from `src/rcml/utils.ts`. This prevents
+`javascript:` and `data:` URI injection.
+
+Text content does NOT need `escapeHtml()` — RCML is structured JSON
+(ProseMirror nodes), not raw HTML. Rule.io's renderer handles text
+encoding. `escapeHtml()` remains available for consumers who build
+raw HTML outside of RCML.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ function createTemplate(config: TemplateConfig) { ... }
 
 ### 5. URL Sanitization
 
-All URL parameters (`href`, `src`) in RCML element builders must be
-sanitized with `sanitizeUrl()` from `src/rcml/utils.ts`. This prevents
-`javascript:` and `data:` URI injection.
+RCML element builders that accept URL parameters (`href`, `src`) should
+sanitize those values with `sanitizeUrl()` from `src/rcml/utils.ts` when
+wiring them into RCML output. This prevents `javascript:` and `data:`
+URI injection.
 
 Text content does NOT need `escapeHtml()` — RCML is structured JSON
 (ProseMirror nodes), not raw HTML. Rule.io's renderer handles text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Text content placed into RCML/ProseMirror text nodes does NOT need
 `escapeHtml()` — RCML is structured JSON, not raw HTML, and Rule.io's
 renderer handles text encoding for those nodes. This does NOT change the
 guidance for raw HTML generation: use `escapeHtml()` when embedding
-user-provided content into raw HTML outside of RCML.
+user-provided content into raw HTML outside of RCML. Note: the `escapeHtml()`
+docstring in `src/rcml/utils.ts` scopes its guidance to raw HTML only —
+it does not apply to structured RCML/ProseMirror text nodes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -880,14 +880,18 @@ try {
 
 ## Security
 
-All user-provided content rendered in templates is automatically escaped by the pre-built templates. If you build custom templates, use the security utilities:
+The pre-built RCML template builders handle security automatically — URLs are sanitized to block `javascript:` and `data:` URIs, and text content is placed into structured ProseMirror nodes (not raw HTML) so it doesn't need escaping.
+
+If you build custom raw HTML templates outside of RCML, use the security utilities:
 
 ```typescript
 import { escapeHtml, sanitizeUrl } from 'rule-io-sdk';
 
-const safeName = escapeHtml(userInput);          // Prevents XSS
-const safeUrl = sanitizeUrl(userProvidedUrl);     // Blocks javascript: URLs
+const safeName = escapeHtml(userInput);          // For raw HTML interpolation
+const safeUrl = sanitizeUrl(userProvidedUrl);     // Blocks javascript:/data: URLs
 ```
+
+> **Note:** Do NOT use `escapeHtml()` on text passed to RCML builders like `createText()` or `createHeading()` — these produce structured JSON, not HTML, and pre-escaping will result in double-escaped output (`&amp;` instead of `&`).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ try {
 
 ## Security
 
-The pre-built RCML template builders handle security automatically — URLs are sanitized to block `javascript:` and `data:` URIs, and text content is placed into structured ProseMirror nodes (not raw HTML) so it doesn't need escaping.
+The RCML element builders `createButton`, `createImage`, and `createVideo` sanitize URL parameters to block `javascript:` and `data:` URIs. Text content is placed into structured ProseMirror nodes (not raw HTML) so it doesn't need escaping.
 
 If you build custom raw HTML templates outside of RCML, use the security utilities:
 

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -484,7 +484,7 @@ export function createButton(
 ): RCMLButton {
   const sanitizedHref = sanitizeUrl(href);
   if (!sanitizedHref) {
-    throw new RuleConfigError('createButton: invalid or unsafe URL');
+    throw new RuleConfigError('createButton: invalid or unsafe URL for `href`');
   }
   return {
     tagName: 'rc-button',
@@ -516,12 +516,16 @@ export interface CreateImageOptions {
 /**
  * Create an image element
  *
+ * `src` is sanitized and must be a valid http/https URL.
+ * If `options.href` is provided, it is also sanitized and will be omitted
+ * from the generated element when invalid or unsafe.
+ *
  * @throws {RuleConfigError} If `src` is not a valid http/https URL
  */
 export function createImage(src: string, options?: CreateImageOptions): RCMLImage {
   const sanitizedSrc = sanitizeUrl(src);
   if (!sanitizedSrc) {
-    throw new RuleConfigError('createImage: invalid or unsafe URL');
+    throw new RuleConfigError('createImage: invalid or unsafe `src` URL');
   }
   return {
     tagName: 'rc-image',
@@ -708,12 +712,16 @@ export interface CreateVideoOptions {
 /**
  * Create a video element (shows thumbnail with play button overlay)
  *
+ * `src` must be a valid http/https URL or this function throws. Optional
+ * `options.href` and `options.buttonUrl` are also sanitized; if either value
+ * is invalid or unsafe, it is silently omitted from the returned element.
+ *
  * @throws {RuleConfigError} If `src` is not a valid http/https URL
  */
 export function createVideo(src: string, options?: CreateVideoOptions): RCMLVideo {
   const sanitizedSrc = sanitizeUrl(src);
   if (!sanitizedSrc) {
-    throw new RuleConfigError('createVideo: invalid or unsafe URL');
+    throw new RuleConfigError('createVideo: invalid or unsafe `src` URL');
   }
   return {
     tagName: 'rc-video',

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -26,6 +26,8 @@ import type {
   RCMLFont,
   RCMLPlainText,
 } from '../types';
+import { sanitizeUrl } from './utils';
+import { RuleConfigError } from '../errors';
 
 // ============================================================================
 // Internal Defaults
@@ -478,10 +480,14 @@ export function createButton(
   href: string,
   options?: CreateButtonOptions
 ): RCMLButton {
+  const sanitizedHref = sanitizeUrl(href);
+  if (!sanitizedHref) {
+    throw new RuleConfigError('createButton: invalid or unsafe URL');
+  }
   return {
     tagName: 'rc-button',
     attributes: {
-      href,
+      href: sanitizedHref,
       align: options?.align || 'center',
       'background-color': options?.backgroundColor || ELEMENT_DEFAULTS.BUTTON_BG_COLOR,
       color: options?.color || ELEMENT_DEFAULTS.BUTTON_TEXT_COLOR,
@@ -509,14 +515,18 @@ export interface CreateImageOptions {
  * Create an image element
  */
 export function createImage(src: string, options?: CreateImageOptions): RCMLImage {
+  const sanitizedSrc = sanitizeUrl(src);
+  if (!sanitizedSrc) {
+    throw new RuleConfigError('createImage: invalid or unsafe URL');
+  }
   return {
     tagName: 'rc-image',
     attributes: {
-      src,
+      src: sanitizedSrc,
       alt: options?.alt || '',
       width: options?.width,
       height: options?.height,
-      href: options?.href,
+      href: options?.href ? sanitizeUrl(options.href) || undefined : undefined,
       align: options?.align || 'center',
       padding: options?.padding || '0 0 20px 0',
       'border-radius': options?.borderRadius,
@@ -695,15 +705,19 @@ export interface CreateVideoOptions {
  * Create a video element (shows thumbnail with play button overlay)
  */
 export function createVideo(src: string, options?: CreateVideoOptions): RCMLVideo {
+  const sanitizedSrc = sanitizeUrl(src);
+  if (!sanitizedSrc) {
+    throw new RuleConfigError('createVideo: invalid or unsafe URL');
+  }
   return {
     tagName: 'rc-video',
     attributes: {
-      src,
+      src: sanitizedSrc,
       alt: options?.alt || '',
       width: options?.width,
       height: options?.height,
-      href: options?.href,
-      'button-url': options?.buttonUrl,
+      href: options?.href ? sanitizeUrl(options.href) || undefined : undefined,
+      'button-url': options?.buttonUrl ? sanitizeUrl(options.buttonUrl) || undefined : undefined,
       align: options?.align || 'center',
       padding: options?.padding || '0 0 20px 0',
       'border-radius': options?.borderRadius,

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -467,6 +467,8 @@ export interface CreateButtonOptions {
 /**
  * Create a button element
  *
+ * @throws {RuleConfigError} If `href` is not a valid http/https URL
+ *
  * @example
  * ```typescript
  * createButton('View Order', 'https://example.com/orders/123', {
@@ -513,6 +515,8 @@ export interface CreateImageOptions {
 
 /**
  * Create an image element
+ *
+ * @throws {RuleConfigError} If `src` is not a valid http/https URL
  */
 export function createImage(src: string, options?: CreateImageOptions): RCMLImage {
   const sanitizedSrc = sanitizeUrl(src);
@@ -703,6 +707,8 @@ export interface CreateVideoOptions {
 
 /**
  * Create a video element (shows thumbnail with play button overlay)
+ *
+ * @throws {RuleConfigError} If `src` is not a valid http/https URL
  */
 export function createVideo(src: string, options?: CreateVideoOptions): RCMLVideo {
   const sanitizedSrc = sanitizeUrl(src);

--- a/src/rcml/utils.ts
+++ b/src/rcml/utils.ts
@@ -7,7 +7,11 @@
 /**
  * Escape HTML special characters to prevent XSS.
  * Use when embedding user-provided content into raw HTML strings.
- * NOT needed for RCML/ProseMirror text nodes (structured JSON, not raw HTML).
+ *
+ * This helper is for HTML-string contexts only (e.g., custom HTML templates).
+ * For structured RCML/ProseMirror text nodes, do NOT pre-escape — Rule.io's
+ * renderer handles text encoding, and pre-escaping produces double-escaped
+ * output (`&amp;`, `&lt;`, etc.).
  *
  * @param text - The text to escape
  * @returns Escaped text safe for HTML

--- a/src/rcml/utils.ts
+++ b/src/rcml/utils.ts
@@ -5,8 +5,9 @@
  */
 
 /**
- * Escape HTML special characters to prevent XSS in email templates.
- * This should be applied to all user-provided content before interpolation.
+ * Escape HTML special characters to prevent XSS.
+ * Use when embedding user-provided content into raw HTML strings.
+ * NOT needed for RCML/ProseMirror text nodes (structured JSON, not raw HTML).
  *
  * @param text - The text to escape
  * @returns Escaped text safe for HTML

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -21,7 +21,9 @@ import {
   createLoop,
   createBrandLoop,
   createLoopFieldPlaceholder,
+  createVideo,
 } from '../src/rcml';
+import { RuleConfigError } from '../src/errors';
 
 describe('RCML Utils', () => {
   describe('escapeHtml', () => {
@@ -330,6 +332,14 @@ describe('RCML Elements', () => {
       expect(button.attributes?.['background-color']).toBe('#00FF00');
       expect(button.attributes?.['border-radius']).toBe('4px');
     });
+
+    it('should reject javascript: URLs', () => {
+      expect(() => createButton('Click', 'javascript:alert(1)')).toThrow(RuleConfigError);
+    });
+
+    it('should reject data: URLs', () => {
+      expect(() => createButton('Click', 'data:text/html,<h1>xss</h1>')).toThrow(RuleConfigError);
+    });
   });
 
   describe('createImage', () => {
@@ -350,6 +360,17 @@ describe('RCML Elements', () => {
       expect(image.attributes.alt).toBe('Description');
       expect(image.attributes.width).toBe('100%');
       expect(image.attributes.href).toBe('https://example.com');
+    });
+
+    it('should reject javascript: URLs', () => {
+      expect(() => createImage('javascript:alert(1)')).toThrow(RuleConfigError);
+    });
+
+    it('should strip unsafe href option', () => {
+      const image = createImage('https://example.com/img.jpg', {
+        href: 'javascript:alert(1)',
+      });
+      expect(image.attributes.href).toBeUndefined();
     });
   });
 
@@ -402,6 +423,26 @@ describe('RCML Elements', () => {
       expect(divider.attributes?.['border-color']).toBe('#FF0000');
       expect(divider.attributes?.['border-style']).toBe('dashed');
       expect(divider.attributes?.['border-width']).toBe('2px');
+    });
+  });
+
+  describe('createVideo', () => {
+    it('should create video with src', () => {
+      const video = createVideo('https://example.com/video.mp4');
+
+      expect(video.tagName).toBe('rc-video');
+      expect(video.attributes.src).toBe('https://example.com/video.mp4');
+    });
+
+    it('should reject javascript: URLs', () => {
+      expect(() => createVideo('javascript:alert(1)')).toThrow(RuleConfigError);
+    });
+
+    it('should strip unsafe href option', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        href: 'javascript:alert(1)',
+      });
+      expect(video.attributes.href).toBeUndefined();
     });
   });
 

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -366,9 +366,31 @@ describe('RCML Elements', () => {
       expect(() => createImage('javascript:alert(1)')).toThrow(RuleConfigError);
     });
 
-    it('should strip unsafe href option', () => {
+    it('should reject data: URLs', () => {
+      expect(() => createImage('data:text/html,<h1>xss</h1>')).toThrow(RuleConfigError);
+    });
+
+    it('should reject invalid URLs', () => {
+      expect(() => createImage('not a valid url')).toThrow(RuleConfigError);
+    });
+
+    it('should strip unsafe javascript: href option', () => {
       const image = createImage('https://example.com/img.jpg', {
         href: 'javascript:alert(1)',
+      });
+      expect(image.attributes.href).toBeUndefined();
+    });
+
+    it('should strip unsafe data: href option', () => {
+      const image = createImage('https://example.com/img.jpg', {
+        href: 'data:text/html,<h1>xss</h1>',
+      });
+      expect(image.attributes.href).toBeUndefined();
+    });
+
+    it('should strip invalid href option', () => {
+      const image = createImage('https://example.com/img.jpg', {
+        href: 'not a valid url',
       });
       expect(image.attributes.href).toBeUndefined();
     });
@@ -438,11 +460,31 @@ describe('RCML Elements', () => {
       expect(() => createVideo('javascript:alert(1)')).toThrow(RuleConfigError);
     });
 
+    it('should reject data: URLs for required src', () => {
+      expect(() =>
+        createVideo('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')
+      ).toThrow(RuleConfigError);
+    });
+
     it('should strip unsafe href option', () => {
       const video = createVideo('https://example.com/video.mp4', {
         href: 'javascript:alert(1)',
       });
       expect(video.attributes.href).toBeUndefined();
+    });
+
+    it('should strip unsafe data: href option', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        href: 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      });
+      expect(video.attributes.href).toBeUndefined();
+    });
+
+    it('should strip unsafe buttonUrl option', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        buttonUrl: 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      });
+      expect(video.attributes['button-url']).toBeUndefined();
     });
   });
 

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -340,6 +340,10 @@ describe('RCML Elements', () => {
     it('should reject data: URLs', () => {
       expect(() => createButton('Click', 'data:text/html,<h1>xss</h1>')).toThrow(RuleConfigError);
     });
+
+    it('should reject invalid URLs', () => {
+      expect(() => createButton('Click', 'not a valid url')).toThrow(RuleConfigError);
+    });
   });
 
   describe('createImage', () => {
@@ -464,6 +468,10 @@ describe('RCML Elements', () => {
       expect(() =>
         createVideo('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')
       ).toThrow(RuleConfigError);
+    });
+
+    it('should reject invalid URLs for required src', () => {
+      expect(() => createVideo('not a valid url')).toThrow(RuleConfigError);
     });
 
     it('should strip unsafe href option', () => {

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -494,6 +494,20 @@ describe('RCML Elements', () => {
       });
       expect(video.attributes['button-url']).toBeUndefined();
     });
+
+    it('should strip invalid href option', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        href: 'not a valid url',
+      });
+      expect(video.attributes.href).toBeUndefined();
+    });
+
+    it('should strip invalid buttonUrl option', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        buttonUrl: 'not a valid url',
+      });
+      expect(video.attributes['button-url']).toBeUndefined();
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## Summary
- Adds `sanitizeUrl()` to `createButton`, `createImage`, and `createVideo` in `src/rcml/elements.ts`, rejecting `javascript:` and `data:` URIs
- Required URLs (`src`, `href`) throw `RuleConfigError`; optional URLs are silently stripped
- Updates CLAUDE.md rule 5 to clarify that URL sanitization (not text escaping) is the XSS boundary for RCML

## Test plan
- [x] New tests for `createButton` rejecting `javascript:` and `data:` URLs
- [x] New tests for `createImage` rejecting unsafe `src` and stripping unsafe optional `href`
- [x] New tests for `createVideo` rejecting unsafe `src` and stripping unsafe optional `href`
- [x] All 344 existing tests still pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)