### PR TITLE
chore: add CHANGELOG, version scripts, and release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-04-07
+
+### Added
+- Campaign email API support (`createCampaignEmail` helper)
+- RCML template builders for hospitality and e-commerce verticals
+- Brand style integration for consistent email theming (`brandStyleId` option)
+- Editor-compatible RCML auto-built from brand styles
+- Comprehensive campaign API test coverage
+
+### Fixed
+- URL sanitization for RCML element builders (`createButton`, `createImage`, `createVideo`)
+- DELETE method for unsuppress endpoint
+- Brand builder return types assignable to `RCMLColumnChild`
+- Suppression endpoint uses POST `/suppressions/delete` instead of DELETE
+
+## [0.2.0] - 2026-04-06
+
+### Added
+- Automation API support (v2) with `createAutomationEmail` helper
+- Subscriber management (v3 API)
+- Single-step automail creation per API developer feedback
+- GitHub Actions CI workflow
+
+### Changed
+- Renamed automail methods to automation (`createAutomail` -> `createAutomation`)
+
+## [0.1.0] - 2026-04-06
+
+### Added
+- Initial release
+- `RuleClient` with v2 and v3 API support (81 methods)
+- Basic RCML document creation and element builders
+- Type-safe request/response types for all endpoints
+- `RuleApiError` and `RuleConfigError` error handling
+- Zero runtime dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - URL sanitization for RCML element builders (`createButton`, `createImage`, `createVideo`)
-- DELETE method for unsuppress endpoint
+- Unsuppress endpoint now uses `DELETE /suppressions/` instead of `POST`
 - Brand builder return types assignable to `RCMLColumnChild`
-- Suppression endpoint uses POST `/suppressions/delete` instead of DELETE
 
 ## [0.2.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI workflow
 
 ### Changed
-- Renamed automail methods to automation (`createAutomail` -> `createAutomation`)
+- Introduced automation-named methods (`createAutomation`, etc.); automail-named methods kept as deprecated aliases
 
 ## [0.1.0] - 2026-04-06
 
@@ -42,3 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type-safe request/response types for all endpoints
 - `RuleApiError` and `RuleConfigError` error handling
 - Zero runtime dependencies
+
+[Unreleased]: https://github.com/rulecom/rule-io-sdk/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rulecom/rule-io-sdk/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/rulecom/rule-io-sdk/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/rulecom/rule-io-sdk/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-04-06
 
 ### Added
-- Automation API support (v2) with `createAutomationEmail` helper
+- Automation API support (v3 editor endpoints) with `createAutomationEmail` helper
 - Subscriber management (v3 API)
 - Single-step automail creation per API developer feedback
 - GitHub Actions CI workflow

--- a/README.md
+++ b/README.md
@@ -893,6 +893,13 @@ const safeUrl = sanitizeUrl(userProvidedUrl);     // Blocks javascript:/data: UR
 
 > **Note:** Do NOT use `escapeHtml()` on text passed to RCML builders like `createText()` or `createHeading()` — these produce structured JSON, not HTML, and pre-escaping will result in double-escaped output (`&amp;` instead of `&`).
 
+## Releasing
+
+1. Update `CHANGELOG.md` with the new version's changes
+2. Run `npm version patch|minor|major` (runs type-check + tests automatically)
+3. Push with tags: `git push && git push --tags`
+4. Publish: `npm publish`
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -896,7 +896,7 @@ const safeUrl = sanitizeUrl(userProvidedUrl);     // Blocks javascript:/data: UR
 ## Releasing
 
 1. Update `CHANGELOG.md` with the new version's changes
-2. Run `npm version patch|minor|major` (runs type-check + tests automatically)
+2. Run `npm version <patch|minor|major>` (runs type-check + tests automatically)
 3. Push with tags: `git push && git push --tags`
 4. Publish: `npm publish`
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
+    "preversion": "npm run type-check && npm run test",
     "prepare": "[ -f node_modules/.bin/tsup ] && npm run build || true",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
## Summary
- Create `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) format with entries for v0.1.0, v0.2.0, and v0.3.0 derived from git history
- Add `preversion` script to `package.json` that gates `npm version` behind passing type-check and tests
- Document release process in README before the Development section

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` passes (355 passed, 50 skipped integration)
- [x] Verify `preversion` script is present in package.json
- [x] Verify CHANGELOG.md follows Keep a Changelog format
- [x] Verify README has Releasing section before Development

🤖 Generated with [Claude Code](https://claude.com/claude-code)