### PR TITLE
fix: add UTC docs, validate empty sections, and minor polish

### DIFF
--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -171,6 +171,10 @@ function createAttributesFromStyles(styles: EmailStyleConfig): RCMLAttributes {
  * ```
  */
 export function createRCMLDocument(options: CreateRCMLDocumentOptions): RCMLDocument {
+  if (options.sections.length === 0) {
+    throw new RuleConfigError('createRCMLDocument: at least one section is required');
+  }
+
   const headChildren: (RCMLAttributes | RCMLBrandStyle | RCMLPreview | RCMLFont | RCMLPlainText)[] =
     [];
 

--- a/src/rcml/utils.ts
+++ b/src/rcml/utils.ts
@@ -62,7 +62,8 @@ export function sanitizeUrl(url: string): string {
 }
 
 /**
- * Format a date for Rule.io (YYYY-MM-DD)
+ * Format a date for Rule.io (YYYY-MM-DD).
+ * Uses UTC — a local date near midnight may format as the next/previous day.
  *
  * @param date - Date to format
  * @returns Date string in YYYY-MM-DD format

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -104,10 +104,21 @@ describe('RCML Document', () => {
       expect(doc.children[1].tagName).toBe('rc-body');
     });
 
+    it('should throw RuleConfigError for empty sections', () => {
+      expect(() =>
+        createRCMLDocument({ sections: [] })
+      ).toThrow(RuleConfigError);
+      expect(() =>
+        createRCMLDocument({ sections: [] })
+      ).toThrow('at least one section is required');
+    });
+
     it('should include preheader in head', () => {
       const doc = createRCMLDocument({
         preheader: 'Preview text',
-        sections: [],
+        sections: [
+          createCenteredSection({ children: [createText('Content')] }),
+        ],
       });
 
       const head = doc.children[0];
@@ -121,7 +132,9 @@ describe('RCML Document', () => {
     it('should include brand style ID (legacy support)', () => {
       const doc = createRCMLDocument({
         brandStyleId: '123',
-        sections: [],
+        sections: [
+          createCenteredSection({ children: [createText('Content')] }),
+        ],
       });
 
       const head = doc.children[0];
@@ -139,7 +152,9 @@ describe('RCML Document', () => {
           primaryColor: '#2D5016',
           backgroundColor: '#FDF5E6',
         },
-        sections: [],
+        sections: [
+          createCenteredSection({ children: [createText('Content')] }),
+        ],
       });
 
       const head = doc.children[0];
@@ -180,7 +195,9 @@ describe('RCML Document', () => {
           brandStyleId: '456', // This one should be used
           logoUrl: 'https://example.com/logo.png',
         },
-        sections: [],
+        sections: [
+          createCenteredSection({ children: [createText('Content')] }),
+        ],
       });
 
       const head = doc.children[0];
@@ -201,7 +218,9 @@ describe('RCML Document', () => {
       const doc = createRCMLDocument({
         backgroundColor: '#FFFFFF',
         width: '800px',
-        sections: [],
+        sections: [
+          createCenteredSection({ children: [createText('Content')] }),
+        ],
       });
 
       const body = doc.children[1];


### PR DESCRIPTION
## Summary
- **7A**: Document that `formatDateForRule` uses UTC — a local date near midnight may format as the next/previous day
- **7B**: `createRCMLDocument` now throws `RuleConfigError` when `sections` is empty, preventing invalid RCML documents
- **7C**: Deferred — greeting punctuation (`!` / `,`) is hardcoded in ~10 template functions across 3 files; making it configurable requires an optional field on each template config interface, which is too invasive for a polish pass

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` passes (356 tests, 0 failures)
- [x] Existing tests updated to use non-empty sections where required
- [x] New test verifies `createRCMLDocument({ sections: [] })` throws `RuleConfigError`

Generated with [Claude Code](https://claude.com/claude-code)