### PR TITLE
test: add missing coverage for elements, client methods, and shared fixtures

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -2911,6 +2911,244 @@ describe('RuleClient', () => {
     });
   });
 
+  // ==========================================================================
+  // v2 Tags API
+  // ==========================================================================
+
+  describe('getTags', () => {
+    it('should return tags from API', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          tags: [
+            { id: 1, name: 'newsletter' },
+            { id: 2, name: 'vip' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getTags();
+
+      expect(result.tags).toHaveLength(2);
+      expect(result.tags?.[0].name).toBe('newsletter');
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://app.rule.io/api/v2/tags');
+      expect(options.method).toBe('GET');
+    });
+
+    it('should handle empty tags response', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ tags: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getTags();
+
+      expect(result.tags).toEqual([]);
+    });
+  });
+
+  describe('getTagIdByName', () => {
+    it('should return tag ID when found', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          tags: [
+            { id: 10, name: 'order-confirmed' },
+            { id: 20, name: 'newsletter' },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getTagIdByName('newsletter');
+
+      expect(result).toBe(20);
+    });
+
+    it('should return null when tag not found', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          tags: [{ id: 10, name: 'order-confirmed' }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getTagIdByName('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when tags list is undefined', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getTagIdByName('anything');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // v2 Subscriber Management
+  // ==========================================================================
+
+  describe('deleteSubscriber', () => {
+    it('should send DELETE request with email', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ success: true }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.deleteSubscriber('old@example.com');
+
+      expect(result.success).toBe(true);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://app.rule.io/api/v2/subscribers/old%40example.com?identified_by=email'
+      );
+      expect(options.method).toBe('DELETE');
+    });
+
+    it('should encode special characters in email', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ success: true }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      await client.deleteSubscriber('user+tag@example.com');
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('user%2Btag%40example.com');
+    });
+  });
+
+  describe('getSubscriberTags', () => {
+    it('should return tag names for subscriber', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          tags: [{ name: 'vip' }, { name: 'newsletter' }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getSubscriberTags('test@example.com');
+
+      expect(result).toEqual(['vip', 'newsletter']);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://app.rule.io/api/v2/subscribers/test%40example.com/tags?identified_by=email'
+      );
+    });
+
+    it('should return empty array when tags is undefined', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getSubscriberTags('test@example.com');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array on 404', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Not found' }, 404)
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getSubscriberTags('unknown@example.com');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // Network Error Handling
+  // ==========================================================================
+
+  describe('network error handling', () => {
+    it('should wrap fetch rejection in RuleApiError (v2)', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      try {
+        await client.getTags();
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(RuleApiError);
+        expect((error as RuleApiError).message).toContain('fetch failed');
+        expect((error as RuleApiError).statusCode).toBe(0);
+      }
+    });
+
+    it('should wrap DNS/network failure in RuleApiError (v2)', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND app.rule.io'));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(client.syncSubscriber({
+        email: 'test@example.com',
+        fields: {},
+        tags: ['test'],
+      })).rejects.toThrow(RuleApiError);
+    });
+
+    it('should wrap fetch rejection in RuleApiError (v3)', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(client.listAutomations()).rejects.toThrow(RuleApiError);
+    });
+  });
+
+  // ==========================================================================
+  // createAutomationEmail cleanup-on-failure
+  // ==========================================================================
+
+  describe('createAutomationEmail cleanup-on-failure', () => {
+    it('should clean up created resources when template creation fails', async () => {
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      const fakeTemplate = { tagName: 'rcml', children: [] };
+
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse({ data: { id: 100 } })) // createAutomation
+        .mockResolvedValueOnce(createMockResponse({ data: { id: 200 } })) // createMessage
+        .mockRejectedValueOnce(new Error('Template creation failed'))     // createTemplate fails
+        .mockResolvedValueOnce(createMock204Response())                   // delete message cleanup
+        .mockResolvedValueOnce(createMock204Response());                  // delete automation cleanup
+
+      await expect(
+        client.createAutomationEmail({
+          name: 'Test Automation',
+          subject: 'Test',
+          template: fakeTemplate as never,
+        })
+      ).rejects.toThrow('Template creation failed');
+
+      // Verify cleanup calls happened (message deleted first, then automation — reverse order)
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('should clean up automation when message creation fails', async () => {
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      const fakeTemplate = { tagName: 'rcml', children: [] };
+
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse({ data: { id: 100 } })) // createAutomation
+        .mockRejectedValueOnce(new Error('Message creation failed'))      // createMessage fails
+        .mockResolvedValueOnce(createMock204Response());                  // delete automation cleanup
+
+      await expect(
+        client.createAutomationEmail({
+          name: 'Test Automation',
+          subject: 'Test',
+          template: fakeTemplate as never,
+        })
+      ).rejects.toThrow('Message creation failed');
+
+      // Verify: 1 create + 1 fail + 1 cleanup = 3 calls
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe('Deprecated automail method aliases', () => {
     it('createAutomail() should delegate to createAutomation()', async () => {
       mockFetch.mockResolvedValueOnce(

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -3125,6 +3125,8 @@ describe('RuleClient', () => {
         client.createAutomationEmail({
           name: 'Test Automation',
           subject: 'Test',
+          triggerType: 'segment',
+          triggerValue: '12345',
           template: minimalTemplate,
         })
       ).rejects.toThrow('Template creation failed');
@@ -3145,6 +3147,8 @@ describe('RuleClient', () => {
         client.createAutomationEmail({
           name: 'Test Automation',
           subject: 'Test',
+          triggerType: 'segment',
+          triggerValue: '12345',
           template: minimalTemplate,
         })
       ).rejects.toThrow('Message creation failed');

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -5,7 +5,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RuleClient } from '../src/client';
 import { RuleApiError, RuleConfigError } from '../src/errors';
-import type { RuleAnalyticsParams } from '../src/types';
+import type { RuleAnalyticsParams, RCMLDocument } from '../src/types';
+
+/** Minimal valid RCMLDocument for tests that need a template value. */
+const minimalTemplate: RCMLDocument = {
+  tagName: 'rcml',
+  children: [
+    { tagName: 'rc-head', children: [] },
+    { tagName: 'rc-body', children: [] },
+  ],
+};
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -2683,7 +2692,7 @@ describe('RuleClient', () => {
           triggerType: 'tag',
           triggerValue: 'Newsletter',
           subject: 'Test',
-          template: { tagName: 'rcml', id: '1', children: [] } as never,
+          template: { ...minimalTemplate, id: '1' },
           brandStyleId: 976,
         })
       ).rejects.toThrow(RuleConfigError);
@@ -2782,7 +2791,7 @@ describe('RuleClient', () => {
         client.createCampaignEmail({
           name: 'Test',
           subject: 'Test',
-          template: { tagName: 'rcml', id: '1', children: [] } as never,
+          template: { ...minimalTemplate, id: '1' },
           brandStyleId: 976,
         })
       ).rejects.toThrow(RuleConfigError);
@@ -2858,7 +2867,7 @@ describe('RuleClient', () => {
     it('should use provided template directly without brandStyleId', async () => {
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
 
-      const fakeTemplate = {
+      const fakeTemplate: RCMLDocument = {
         tagName: 'rcml',
         id: 'test-id',
         children: [
@@ -2877,7 +2886,7 @@ describe('RuleClient', () => {
       const result = await client.createCampaignEmail({
         name: 'Direct Template',
         subject: 'Test',
-        template: fakeTemplate as never,
+        template: fakeTemplate,
       });
 
       expect(result.campaignId).toBe(100);
@@ -3105,8 +3114,6 @@ describe('RuleClient', () => {
     it('should clean up created resources when template creation fails', async () => {
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
 
-      const fakeTemplate = { tagName: 'rcml', children: [] };
-
       mockFetch
         .mockResolvedValueOnce(createMockResponse({ data: { id: 100 } })) // createAutomation
         .mockResolvedValueOnce(createMockResponse({ data: { id: 200 } })) // createMessage
@@ -3118,7 +3125,7 @@ describe('RuleClient', () => {
         client.createAutomationEmail({
           name: 'Test Automation',
           subject: 'Test',
-          template: fakeTemplate as never,
+          template: minimalTemplate,
         })
       ).rejects.toThrow('Template creation failed');
 
@@ -3129,8 +3136,6 @@ describe('RuleClient', () => {
     it('should clean up automation when message creation fails', async () => {
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
 
-      const fakeTemplate = { tagName: 'rcml', children: [] };
-
       mockFetch
         .mockResolvedValueOnce(createMockResponse({ data: { id: 100 } })) // createAutomation
         .mockRejectedValueOnce(new Error('Message creation failed'))      // createMessage fails
@@ -3140,7 +3145,7 @@ describe('RuleClient', () => {
         client.createAutomationEmail({
           name: 'Test Automation',
           subject: 'Test',
-          template: fakeTemplate as never,
+          template: minimalTemplate,
         })
       ).rejects.toThrow('Message creation failed');
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared test fixtures and assertion helpers.
+ *
+ * Centralises duplicated constants (TEST_BRAND_STYLE, assertValidRCMLDocument,
+ * docToString) so every test file that needs them imports from one place.
+ */
+
+import { expect } from 'vitest';
+import type { RCMLDocument } from '../src/types';
+import type { BrandStyleConfig } from '../src/rcml';
+
+// ============================================================================
+// Shared brand-style fixture
+// ============================================================================
+
+export const TEST_BRAND_STYLE: BrandStyleConfig = {
+  brandStyleId: '99999',
+  logoUrl: 'https://example.com/logo.png',
+  buttonColor: '#0066CC',
+  bodyBackgroundColor: '#f3f3f3',
+  sectionBackgroundColor: '#ffffff',
+  brandColor: '#f6f8f9',
+  headingFont: "'Helvetica Neue', sans-serif",
+  headingFontUrl: 'https://app.rule.io/brand-style/99999/font/1/css',
+  bodyFont: "'Arial', sans-serif",
+  bodyFontUrl: 'https://app.rule.io/brand-style/99999/font/2/css',
+  textColor: '#1A1A1A',
+};
+
+// ============================================================================
+// Assertion helpers
+// ============================================================================
+
+/**
+ * Assert that a value is a structurally valid RCML document (rcml root with
+ * rc-head + rc-body, and at least one child in the body).
+ */
+export function assertValidRCMLDocument(doc: RCMLDocument): void {
+  expect(doc.tagName).toBe('rcml');
+  expect(doc.children).toHaveLength(2);
+  expect(doc.children[0].tagName).toBe('rc-head');
+  expect(doc.children[1].tagName).toBe('rc-body');
+  expect(doc.children[1].children.length).toBeGreaterThan(0);
+}
+
+/**
+ * Serialise an RCML document to a JSON string (useful for substring assertions).
+ */
+export function docToString(doc: RCMLDocument): string {
+  return JSON.stringify(doc);
+}

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -724,7 +724,9 @@ describe('RCML Elements', () => {
 // ============================================================================
 
 describe('Automation Config Utilities', () => {
-  const fakeTemplate = { tagName: 'rcml' as const, children: [] };
+  const fakeTemplate = createRCMLDocument({
+    sections: [createCenteredSection({ children: [createText('test')] })],
+  });
 
   const automations: AutomationConfigV2[] = [
     {
@@ -733,7 +735,7 @@ describe('Automation Config Utilities', () => {
       description: 'Sent on sign-up',
       triggerTag: 'user-registered',
       subject: 'Welcome!',
-      templateBuilder: () => fakeTemplate as never,
+      templateBuilder: () => fakeTemplate,
     },
     {
       id: 'abandoned-cart',
@@ -741,7 +743,7 @@ describe('Automation Config Utilities', () => {
       description: 'Sent when cart abandoned',
       triggerTag: 'cart-abandoned',
       subject: 'You left items behind',
-      templateBuilder: () => fakeTemplate as never,
+      templateBuilder: () => fakeTemplate,
     },
   ];
 

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -10,6 +10,8 @@ import {
   createRCMLDocument,
   createCenteredSection,
   createTwoColumnSection,
+  createSection,
+  createColumn,
   createHeading,
   createText,
   createButton,
@@ -24,6 +26,11 @@ import {
   createVideo,
 } from '../src/rcml';
 import { RuleConfigError } from '../src/errors';
+import {
+  getAutomationByIdV2,
+  getAutomationByTriggerV2,
+} from '../src/automation-configs-v2';
+import type { AutomationConfigV2 } from '../src/automation-configs-v2';
 
 describe('RCML Utils', () => {
   describe('escapeHtml', () => {
@@ -460,6 +467,36 @@ describe('RCML Elements', () => {
       expect(video.attributes.src).toBe('https://example.com/video.mp4');
     });
 
+    it('should apply default attributes', () => {
+      const video = createVideo('https://example.com/video.mp4');
+
+      expect(video.attributes.alt).toBe('');
+      expect(video.attributes.align).toBe('center');
+      expect(video.attributes.padding).toBe('0 0 20px 0');
+    });
+
+    it('should accept all options', () => {
+      const video = createVideo('https://example.com/video.mp4', {
+        alt: 'Demo video',
+        width: '560px',
+        height: '315px',
+        href: 'https://example.com/watch',
+        buttonUrl: 'https://example.com/play-icon.png',
+        align: 'left',
+        padding: '10px 0',
+        borderRadius: '8px',
+      });
+
+      expect(video.attributes.alt).toBe('Demo video');
+      expect(video.attributes.width).toBe('560px');
+      expect(video.attributes.height).toBe('315px');
+      expect(video.attributes.href).toBe('https://example.com/watch');
+      expect(video.attributes['button-url']).toBe('https://example.com/play-icon.png');
+      expect(video.attributes.align).toBe('left');
+      expect(video.attributes.padding).toBe('10px 0');
+      expect(video.attributes['border-radius']).toBe('8px');
+    });
+
     it('should reject javascript: URLs', () => {
       expect(() => createVideo('javascript:alert(1)')).toThrow(RuleConfigError);
     });
@@ -507,6 +544,86 @@ describe('RCML Elements', () => {
         buttonUrl: 'not a valid url',
       });
       expect(video.attributes['button-url']).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // Section / Column (low-level builders)
+  // ==========================================================================
+
+  describe('createSection', () => {
+    it('should create a section with given columns', () => {
+      const col = createColumn([createText('Cell')]);
+      const section = createSection([col]);
+
+      expect(section.tagName).toBe('rc-section');
+      expect(section.children).toHaveLength(1);
+      expect(section.children[0].tagName).toBe('rc-column');
+    });
+
+    it('should apply default padding', () => {
+      const section = createSection([createColumn([])]);
+
+      expect(section.attributes?.padding).toBe('20px 0');
+    });
+
+    it('should accept custom options', () => {
+      const section = createSection([createColumn([])], {
+        backgroundColor: '#FF0000',
+        padding: '40px 0',
+        textAlign: 'center',
+      });
+
+      expect(section.attributes?.['background-color']).toBe('#FF0000');
+      expect(section.attributes?.padding).toBe('40px 0');
+      expect(section.attributes?.['text-align']).toBe('center');
+    });
+
+    it('should accept multiple columns', () => {
+      const section = createSection([
+        createColumn([createText('Left')]),
+        createColumn([createText('Center')]),
+        createColumn([createText('Right')]),
+      ]);
+
+      expect(section.children).toHaveLength(3);
+    });
+  });
+
+  describe('createColumn', () => {
+    it('should create a column with children', () => {
+      const col = createColumn([createText('Hello'), createButton('Click', 'https://example.com')]);
+
+      expect(col.tagName).toBe('rc-column');
+      expect(col.children).toHaveLength(2);
+    });
+
+    it('should apply default padding', () => {
+      const col = createColumn([]);
+
+      expect(col.attributes?.padding).toBe('0 20px');
+    });
+
+    it('should accept custom options', () => {
+      const col = createColumn([], {
+        width: '33%',
+        backgroundColor: '#EEEEEE',
+        padding: '10px',
+        verticalAlign: 'middle',
+      });
+
+      expect(col.attributes?.width).toBe('33%');
+      expect(col.attributes?.['background-color']).toBe('#EEEEEE');
+      expect(col.attributes?.padding).toBe('10px');
+      expect(col.attributes?.['vertical-align']).toBe('middle');
+    });
+
+    it('should leave optional attributes undefined when not provided', () => {
+      const col = createColumn([]);
+
+      expect(col.attributes?.width).toBeUndefined();
+      expect(col.attributes?.['background-color']).toBeUndefined();
+      expect(col.attributes?.['vertical-align']).toBeUndefined();
     });
   });
 
@@ -598,6 +715,69 @@ describe('RCML Elements', () => {
 
       expect(node.attrs.name).toBe('variant_title');
       expect(node.attrs.original).toBe('[LoopValue:variant_title]');
+    });
+  });
+});
+
+// ============================================================================
+// Automation Config Utilities
+// ============================================================================
+
+describe('Automation Config Utilities', () => {
+  const fakeTemplate = { tagName: 'rcml' as const, children: [] };
+
+  const automations: AutomationConfigV2[] = [
+    {
+      id: 'welcome',
+      name: 'Welcome Email',
+      description: 'Sent on sign-up',
+      triggerTag: 'user-registered',
+      subject: 'Welcome!',
+      templateBuilder: () => fakeTemplate as never,
+    },
+    {
+      id: 'abandoned-cart',
+      name: 'Abandoned Cart',
+      description: 'Sent when cart abandoned',
+      triggerTag: 'cart-abandoned',
+      subject: 'You left items behind',
+      templateBuilder: () => fakeTemplate as never,
+    },
+  ];
+
+  describe('getAutomationByIdV2', () => {
+    it('should find automation by ID', () => {
+      const result = getAutomationByIdV2('welcome', automations);
+      expect(result).toBeDefined();
+      expect(result?.name).toBe('Welcome Email');
+    });
+
+    it('should return undefined for unknown ID', () => {
+      const result = getAutomationByIdV2('nonexistent', automations);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for empty list', () => {
+      const result = getAutomationByIdV2('welcome', []);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAutomationByTriggerV2', () => {
+    it('should find automation by trigger tag', () => {
+      const result = getAutomationByTriggerV2('cart-abandoned', automations);
+      expect(result).toBeDefined();
+      expect(result?.id).toBe('abandoned-cart');
+    });
+
+    it('should return undefined for unknown trigger tag', () => {
+      const result = getAutomationByTriggerV2('unknown-tag', automations);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for empty list', () => {
+      const result = getAutomationByTriggerV2('cart-abandoned', []);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -6,8 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { RCMLDocument } from '../src/types';
-import type { BrandStyleConfig, CustomFieldMap } from '../src/rcml';
+import type { CustomFieldMap } from '../src/rcml';
 import { RuleConfigError } from '../src/errors';
 import { validateCustomFields, toBrandStyleConfig } from '../src/rcml/brand-template';
 import {
@@ -36,24 +35,11 @@ import {
   createOrderCancellationEmail,
   createDefaultContentSection,
 } from '../src/rcml';
+import { TEST_BRAND_STYLE, assertValidRCMLDocument, docToString } from './helpers';
 
 // ============================================================================
 // Shared test fixtures
 // ============================================================================
-
-const TEST_BRAND_STYLE: BrandStyleConfig = {
-  brandStyleId: '99999',
-  logoUrl: 'https://example.com/logo.png',
-  buttonColor: '#0066CC',
-  bodyBackgroundColor: '#f3f3f3',
-  sectionBackgroundColor: '#ffffff',
-  brandColor: '#f6f8f9',
-  headingFont: "'Helvetica Neue', sans-serif",
-  headingFontUrl: 'https://app.rule.io/brand-style/99999/font/1/css',
-  bodyFont: "'Arial', sans-serif",
-  bodyFontUrl: 'https://app.rule.io/brand-style/99999/font/2/css',
-  textColor: '#1A1A1A',
-};
 
 const TEST_CUSTOM_FIELDS: CustomFieldMap = {
   'Booking.FirstName': 100001,
@@ -103,24 +89,6 @@ const TEST_CUSTOM_FIELDS: CustomFieldMap = {
   'Order.ShippingCost': 200033,
   'Order.ShippingCarrier': 200034,
 };
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function assertValidRCMLDocument(doc: RCMLDocument): void {
-  expect(doc.tagName).toBe('rcml');
-  expect(doc.children).toHaveLength(2);
-  expect(doc.children[0].tagName).toBe('rc-head');
-  expect(doc.children[1].tagName).toBe('rc-body');
-
-  const body = doc.children[1];
-  expect(body.children.length).toBeGreaterThan(0);
-}
-
-function docToString(doc: RCMLDocument): string {
-  return JSON.stringify(doc);
-}
 
 // ============================================================================
 // Brand Template Utilities

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { CustomFieldMap } from '../src/rcml';
+import type { BrandStyleConfig, CustomFieldMap } from '../src/rcml';
 import { RuleConfigError } from '../src/errors';
 import { validateCustomFields, toBrandStyleConfig } from '../src/rcml/brand-template';
 import {

--- a/tests/vendors/bookzen.test.ts
+++ b/tests/vendors/bookzen.test.ts
@@ -3,29 +3,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { RCMLDocument } from '../../src/types';
-import type { BrandStyleConfig, CustomFieldMap } from '../../src/rcml';
+import type { CustomFieldMap } from '../../src/rcml';
 import type { VendorConsumerConfig } from '../../src/vendors/types';
 import { RuleConfigError } from '../../src/errors';
 import { bookzenPreset, BOOKZEN_FIELDS, BOOKZEN_TAGS } from '../../src/vendors/bookzen';
+import { TEST_BRAND_STYLE, assertValidRCMLDocument } from '../helpers';
 
 // ============================================================================
 // Shared fixtures
 // ============================================================================
-
-const TEST_BRAND_STYLE: BrandStyleConfig = {
-  brandStyleId: '99999',
-  logoUrl: 'https://example.com/logo.png',
-  buttonColor: '#0066CC',
-  bodyBackgroundColor: '#f3f3f3',
-  sectionBackgroundColor: '#ffffff',
-  brandColor: '#f6f8f9',
-  headingFont: "'Helvetica Neue', sans-serif",
-  headingFontUrl: 'https://app.rule.io/brand-style/99999/font/1/css',
-  bodyFont: "'Arial', sans-serif",
-  bodyFontUrl: 'https://app.rule.io/brand-style/99999/font/2/css',
-  textColor: '#1A1A1A',
-};
 
 const TEST_CUSTOM_FIELDS: CustomFieldMap = {
   [BOOKZEN_FIELDS.guestFirstName]: 100001,
@@ -43,14 +29,6 @@ const TEST_CONFIG: VendorConsumerConfig = {
   customFields: TEST_CUSTOM_FIELDS,
   websiteUrl: 'https://myhotel.example.com',
 };
-
-function assertValidRCMLDocument(doc: RCMLDocument): void {
-  expect(doc.tagName).toBe('rcml');
-  expect(doc.children).toHaveLength(2);
-  expect(doc.children[0].tagName).toBe('rc-head');
-  expect(doc.children[1].tagName).toBe('rc-body');
-  expect(doc.children[1].children.length).toBeGreaterThan(0);
-}
 
 // ============================================================================
 // Preset metadata

--- a/tests/vendors/shopify.test.ts
+++ b/tests/vendors/shopify.test.ts
@@ -3,29 +3,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { RCMLDocument } from '../../src/types';
-import type { BrandStyleConfig, CustomFieldMap } from '../../src/rcml';
+import type { CustomFieldMap } from '../../src/rcml';
 import type { VendorConsumerConfig } from '../../src/vendors/types';
 import { RuleConfigError } from '../../src/errors';
 import { shopifyPreset, SHOPIFY_FIELDS, SHOPIFY_TAGS } from '../../src/vendors/shopify';
+import { TEST_BRAND_STYLE, assertValidRCMLDocument } from '../helpers';
 
 // ============================================================================
 // Shared fixtures
 // ============================================================================
-
-const TEST_BRAND_STYLE: BrandStyleConfig = {
-  brandStyleId: '99999',
-  logoUrl: 'https://example.com/logo.png',
-  buttonColor: '#0066CC',
-  bodyBackgroundColor: '#f3f3f3',
-  sectionBackgroundColor: '#ffffff',
-  brandColor: '#f6f8f9',
-  headingFont: "'Helvetica Neue', sans-serif",
-  headingFontUrl: 'https://app.rule.io/brand-style/99999/font/1/css',
-  bodyFont: "'Arial', sans-serif",
-  bodyFontUrl: 'https://app.rule.io/brand-style/99999/font/2/css',
-  textColor: '#1A1A1A',
-};
 
 const TEST_CUSTOM_FIELDS: CustomFieldMap = {
   // Subscriber fields
@@ -58,14 +44,6 @@ const TEST_CONFIG: VendorConsumerConfig = {
   customFields: TEST_CUSTOM_FIELDS,
   websiteUrl: 'https://myshop.example.com',
 };
-
-function assertValidRCMLDocument(doc: RCMLDocument): void {
-  expect(doc.tagName).toBe('rcml');
-  expect(doc.children).toHaveLength(2);
-  expect(doc.children[0].tagName).toBe('rc-head');
-  expect(doc.children[1].tagName).toBe('rc-body');
-  expect(doc.children[1].children.length).toBeGreaterThan(0);
-}
 
 // ============================================================================
 // Preset metadata


### PR DESCRIPTION
## Summary
- **6A**: Add unit tests for `createVideo()` (options/defaults), `createSection()`, `createColumn()`, `getAutomationByIdV2()`, and `getAutomationByTriggerV2()`
- **6B**: Add unit tests (with mocked fetch) for `getTags()`, `getTagIdByName()`, `deleteSubscriber()`, and `getSubscriberTags()` which previously only had integration test coverage
- **6C**: Add network error handling tests (fetch rejection wraps in `RuleApiError` with statusCode 0) and `createAutomationEmail` cleanup-on-failure tests (template fail + message fail scenarios)
- **6D**: Extract shared `TEST_BRAND_STYLE`, `assertValidRCMLDocument`, and `docToString` into `tests/helpers.ts`; update `templates.test.ts`, `shopify.test.ts`, and `bookzen.test.ts` to import from it

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` passes (386 passed, 50 skipped integration tests)
- [x] All existing tests unchanged in behavior
- [x] New tests cover previously untested code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)