### PR TITLE
fix: clean up public API surface

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -88,7 +88,7 @@ export class RuleApiError extends Error {
  * Error thrown when the client is not configured properly
  */
 export class RuleConfigError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
+  constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = 'RuleConfigError';
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -88,8 +88,8 @@ export class RuleApiError extends Error {
  * Error thrown when the client is not configured properly
  */
 export class RuleConfigError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'RuleConfigError';
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,7 @@ export {
   createLoopFieldPlaceholder,
   createTextNode,
   createDocWithPlaceholders,
+  validateCustomFields,
 } from './rcml';
 
 export type {

--- a/src/rcml/brand-template.ts
+++ b/src/rcml/brand-template.ts
@@ -41,6 +41,32 @@ function generateId(): string {
 }
 
 // ============================================================================
+// Error Context Helper
+// ============================================================================
+
+/**
+ * Re-throw a `RuleConfigError` with the template function name prepended.
+ *
+ * Builder functions like `createBrandButton` throw errors such as
+ * `"createBrandButton: invalid or unsafe URL"`. When called from a
+ * template function (e.g. `createOrderConfirmationEmail`), the outer
+ * template name is lost. This helper catches `RuleConfigError` and
+ * prepends the template name so callers see where the problem originated.
+ *
+ * @internal
+ */
+export function withTemplateContext<T>(templateName: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error: unknown) {
+    if (error instanceof RuleConfigError) {
+      throw new RuleConfigError(`${templateName} > ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+// ============================================================================
 // Custom Field Definitions
 // ============================================================================
 
@@ -451,14 +477,12 @@ export function createBrandTemplate(config: SimpleTemplateConfig): RCMLDocument 
 /**
  * Create a logo element using brand style.
  *
- * This function validates `logoUrl` for safety and creates the body `rc-logo`
- * node, but it does not set that URL as `src` on the element. The editor
- * resolves the displayed logo via `rc-class: rcml-logo-style`, using the
- * brand style defined in the document head by {@link createBrandHead}. To
- * affect the rendered logo, the same URL must also be configured in
- * `BrandStyleConfig.logoUrl`.
+ * The `logoUrl` is sanitized for safety and set as `src` on the `rc-logo`
+ * element. The element also carries `rc-class: rcml-logo-style` so that the
+ * Rule.io editor can resolve additional styling from the brand head defined
+ * by {@link createBrandHead}.
  *
- * @param logoUrl - Logo URL to validate before creating the logo body node
+ * @param logoUrl - Logo image URL (must be a safe http/https URL)
  */
 export function createBrandLogo(logoUrl: string): RCMLDocument['children'][1]['children'][0] {
   const sanitizedSrc = sanitizeUrl(logoUrl);
@@ -482,6 +506,7 @@ export function createBrandLogo(logoUrl: string): RCMLDocument['children'][1]['c
             id: generateId(),
             attributes: {
               'rc-class': 'rcml-logo-style rc-initial-logo',
+              src: sanitizedSrc,
               width: '96px',
               padding: '20px 0',
             },

--- a/src/rcml/brand-template.ts
+++ b/src/rcml/brand-template.ts
@@ -61,7 +61,11 @@ export function withTemplateContext<T>(templateName: string, fn: () => T): T {
   } catch (error: unknown) {
     if (error instanceof RuleConfigError) {
       const wrapped = new RuleConfigError(`${templateName} > ${error.message}`, { cause: error });
-      wrapped.stack = error.stack;
+      if (error.stack) {
+        const lines = error.stack.split('\n');
+        lines[0] = `${wrapped.name}: ${wrapped.message}`;
+        wrapped.stack = lines.join('\n');
+      }
       throw wrapped;
     }
     throw error;

--- a/src/rcml/brand-template.ts
+++ b/src/rcml/brand-template.ts
@@ -60,7 +60,9 @@ export function withTemplateContext<T>(templateName: string, fn: () => T): T {
     return fn();
   } catch (error: unknown) {
     if (error instanceof RuleConfigError) {
-      throw new RuleConfigError(`${templateName} > ${error.message}`);
+      const wrapped = new RuleConfigError(`${templateName} > ${error.message}`, { cause: error });
+      wrapped.stack = error.stack;
+      throw wrapped;
     }
     throw error;
   }

--- a/src/rcml/ecommerce-templates.ts
+++ b/src/rcml/ecommerce-templates.ts
@@ -30,6 +30,7 @@ import {
   type CustomFieldMap,
   type FooterConfig,
   validateCustomFields,
+  withTemplateContext,
 } from './brand-template';
 import { sanitizeUrl } from './utils';
 
@@ -102,160 +103,163 @@ export function createOrderConfirmationEmail(config: OrderConfirmationConfig): R
   // Loop sub-fields are JSON key names, not custom field paths — skip validation for them
   const { itemName, itemQuantity, itemUnitPrice, itemTotal, ...regularFields } = config.fieldNames;
   validateCustomFields(config.customFields, regularFields, 'createOrderConfirmationEmail');
-  const { customFields, fieldNames, text } = config;
 
-  const detailRows: ReturnType<typeof createBrandText>[] = [
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.orderRefLabel}: `),
-        createPlaceholder(fieldNames.orderRef, customFields[fieldNames.orderRef]),
-      ])
-    ),
-  ];
+  return withTemplateContext('createOrderConfirmationEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-  // Build line items section: use rc-loop if sub-fields provided, else single placeholder
-  const hasLineItemFields = fieldNames.items && fieldNames.itemName;
-  let lineItemsSection: RCMLSection | RCMLLoop | undefined;
-
-  if (hasLineItemFields && fieldNames.items && fieldNames.itemName) {
-    const loopChildren: ReturnType<typeof createBrandText>[] = [
+    const detailRows: ReturnType<typeof createBrandText>[] = [
       createBrandText(
         createDocWithPlaceholders([
-          createLoopFieldPlaceholder(fieldNames.itemName),
+          createTextNode(`${text.orderRefLabel}: `),
+          createPlaceholder(fieldNames.orderRef, customFields[fieldNames.orderRef]),
         ])
       ),
     ];
 
-    if (fieldNames.itemQuantity) {
-      loopChildren.push(
+    // Build line items section: use rc-loop if sub-fields provided, else single placeholder
+    const hasLineItemFields = fieldNames.items && fieldNames.itemName;
+    let lineItemsSection: RCMLSection | RCMLLoop | undefined;
+
+    if (hasLineItemFields && fieldNames.items && fieldNames.itemName) {
+      const loopChildren: ReturnType<typeof createBrandText>[] = [
         createBrandText(
           createDocWithPlaceholders([
-            createTextNode('Qty: '),
-            createLoopFieldPlaceholder(fieldNames.itemQuantity),
+            createLoopFieldPlaceholder(fieldNames.itemName),
+          ])
+        ),
+      ];
+
+      if (fieldNames.itemQuantity) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Qty: '),
+              createLoopFieldPlaceholder(fieldNames.itemQuantity),
+            ])
+          )
+        );
+      }
+
+      if (fieldNames.itemUnitPrice) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Price: '),
+              createLoopFieldPlaceholder(fieldNames.itemUnitPrice),
+            ])
+          )
+        );
+      }
+
+      if (fieldNames.itemTotal) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Subtotal: '),
+              createLoopFieldPlaceholder(fieldNames.itemTotal),
+            ])
+          )
+        );
+      }
+
+      const lineItemsLoop = createBrandLoop(
+        customFields[fieldNames.items],
+        [createContentSection(loopChildren, { padding: '10px 0' }) as RCMLSection],
+        { maxIterations: 20 }
+      );
+
+      lineItemsSection = lineItemsLoop;
+    } else if (fieldNames.items && text.itemsLabel) {
+      // Fallback: single placeholder for items field
+      detailRows.push(
+        createBrandText(
+          createDocWithPlaceholders([
+            createTextNode(`${text.itemsLabel}: `),
+            createPlaceholder(fieldNames.items, customFields[fieldNames.items]),
           ])
         )
       );
     }
 
-    if (fieldNames.itemUnitPrice) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('Price: '),
-            createLoopFieldPlaceholder(fieldNames.itemUnitPrice),
-          ])
-        )
-      );
-    }
-
-    if (fieldNames.itemTotal) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('Subtotal: '),
-            createLoopFieldPlaceholder(fieldNames.itemTotal),
-          ])
-        )
-      );
-    }
-
-    const lineItemsLoop = createBrandLoop(
-      customFields[fieldNames.items],
-      [createContentSection(loopChildren, { padding: '10px 0' }) as RCMLSection],
-      { maxIterations: 20 }
-    );
-
-    lineItemsSection = lineItemsLoop;
-  } else if (fieldNames.items && text.itemsLabel) {
-    // Fallback: single placeholder for items field
     detailRows.push(
       createBrandText(
         createDocWithPlaceholders([
-          createTextNode(`${text.itemsLabel}: `),
-          createPlaceholder(fieldNames.items, customFields[fieldNames.items]),
+          createTextNode(`${text.totalLabel}: `),
+          createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
         ])
       )
     );
-  }
 
-  detailRows.push(
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.totalLabel}: `),
-        createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
-      ])
-    )
-  );
-
-  if (fieldNames.shippingAddress && text.shippingLabel) {
-    detailRows.push(
-      createBrandText(
-        createDocWithPlaceholders([
-          createTextNode(`${text.shippingLabel}: `),
-          createPlaceholder(fieldNames.shippingAddress, customFields[fieldNames.shippingAddress]),
-        ])
-      )
-    );
-  }
-
-  const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
-    ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
-
-    createContentSection(
-      [
-        createBrandHeading(
-          createDocWithPlaceholders([
-            createTextNode(`${text.greeting} `),
-            createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-            createTextNode('!'),
-          ])
-        ),
+    if (fieldNames.shippingAddress && text.shippingLabel) {
+      detailRows.push(
         createBrandText(
-          createDocWithPlaceholders([createTextNode(text.intro)]),
-          { align: 'center' }
-        ),
-      ],
-      { padding: '20px 0' }
-    ),
-
-    createContentSection(
-      [
-        createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
-        ...detailRows,
-      ],
-      { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
-    ),
-  ];
-
-  if (lineItemsSection) {
-    if (text.lineItemsHeading) {
-      sections.push(
-        createContentSection(
-          [createBrandHeading(createDocWithPlaceholders([createTextNode(text.lineItemsHeading)]), 2)],
-          { padding: '10px 0' }
+          createDocWithPlaceholders([
+            createTextNode(`${text.shippingLabel}: `),
+            createPlaceholder(fieldNames.shippingAddress, customFields[fieldNames.shippingAddress]),
+          ])
         )
       );
     }
-    sections.push(lineItemsSection);
-  }
 
-  sections.push(
-    createContentSection(
-      [
-        createBrandButton(
-          createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-          config.websiteUrl
-        ),
-      ],
-      { padding: '20px 0' }
-    ),
-    createFooterSection(config.footer),
-  );
+    const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
+      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections,
+      createContentSection(
+        [
+          createBrandHeading(
+            createDocWithPlaceholders([
+              createTextNode(`${text.greeting} `),
+              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+              createTextNode('!'),
+            ])
+          ),
+          createBrandText(
+            createDocWithPlaceholders([createTextNode(text.intro)]),
+            { align: 'center' }
+          ),
+        ],
+        { padding: '20px 0' }
+      ),
+
+      createContentSection(
+        [
+          createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
+          ...detailRows,
+        ],
+        { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
+      ),
+    ];
+
+    if (lineItemsSection) {
+      if (text.lineItemsHeading) {
+        sections.push(
+          createContentSection(
+            [createBrandHeading(createDocWithPlaceholders([createTextNode(text.lineItemsHeading)]), 2)],
+            { padding: '10px 0' }
+          )
+        );
+      }
+      sections.push(lineItemsSection);
+    }
+
+    sections.push(
+      createContentSection(
+        [
+          createBrandButton(
+            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+            config.websiteUrl
+          ),
+        ],
+        { padding: '20px 0' }
+      ),
+      createFooterSection(config.footer),
+    );
+
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections,
+    });
   });
 }
 
@@ -381,267 +385,270 @@ export function createShippingUpdateEmail(config: ShippingUpdateConfig): RCMLDoc
   // Loop sub-fields are JSON key names, not custom field paths — skip validation for them
   const { itemName, itemQuantity, itemUnitPrice, itemTotal, itemSku, ...regularFields } = config.fieldNames;
   validateCustomFields(config.customFields, regularFields, 'createShippingUpdateEmail');
-  const { customFields, fieldNames, text } = config;
 
-  /** Helper to create a detail row from an optional field + label pair. */
-  const detailRow = (label: string | undefined, fieldName: string | undefined) => {
-    if (!label || !fieldName) return undefined;
-    return createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${label}: `),
-        createPlaceholder(fieldName, customFields[fieldName]),
-      ])
-    );
-  };
+  return withTemplateContext('createShippingUpdateEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-  const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
-    ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
-
-    // Heading + greeting
-    createContentSection(
-      [
-        createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode(`${text.greeting} `),
-            createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-            createTextNode(', '),
-            createTextNode(text.message),
-          ])
-        ),
-      ],
-      { padding: '20px 0' }
-    ),
-  ];
-
-  // Seller info section (company, VAT)
-  const sellerRows = [
-    detailRow(text.companyLabel, fieldNames.companyName),
-    detailRow(text.vatLabel, fieldNames.vatNumber),
-  ].filter(Boolean) as ReturnType<typeof createBrandText>[];
-
-  if (sellerRows.length > 0) {
-    sections.push(createContentSection(sellerRows, { padding: '10px 0' }));
-  }
-
-  // Order details section
-  const orderDetailRows = [
-    detailRow(text.orderRefLabel, fieldNames.orderRef),
-    detailRow(text.orderDateLabel, fieldNames.orderDate),
-    detailRow(text.paymentMethodLabel, fieldNames.paymentMethod),
-    detailRow(text.customerEmailLabel, fieldNames.customerEmail),
-  ].filter(Boolean) as ReturnType<typeof createBrandText>[];
-
-  if (orderDetailRows.length > 0) {
-    sections.push(
-      createContentSection(orderDetailRows, {
-        padding: '20px 0',
-        backgroundColor: config.brandStyle.brandColor,
-      })
-    );
-  }
-
-  // Shipping details section
-  const shippingRows = [
-    detailRow(text.shippingAddressLabel, fieldNames.shippingAddress),
-    detailRow(text.carrierLabel, fieldNames.shippingCarrier),
-    detailRow(text.trackingLabel, fieldNames.trackingNumber),
-    detailRow(text.estimatedDeliveryLabel, fieldNames.estimatedDelivery),
-  ].filter(Boolean) as ReturnType<typeof createBrandText>[];
-
-  if (shippingRows.length > 0) {
-    sections.push(createContentSection(shippingRows, { padding: '20px 0' }));
-  }
-
-  // Track shipment button
-  sections.push(
-    createContentSection(
-      [
-        createBrandButton(
-          createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-          config.trackingUrl
-        ),
-      ],
-      { padding: '20px 0' }
-    )
-  );
-
-  // Line items loop
-  if (fieldNames.items && fieldNames.itemName) {
-    const loopChildren: ReturnType<typeof createBrandText>[] = [
-      createBrandText(
+    /** Helper to create a detail row from an optional field + label pair. */
+    const detailRow = (label: string | undefined, fieldName: string | undefined) => {
+      if (!label || !fieldName) return undefined;
+      return createBrandText(
         createDocWithPlaceholders([
-          createLoopFieldPlaceholder(fieldNames.itemName),
+          createTextNode(`${label}: `),
+          createPlaceholder(fieldName, customFields[fieldName]),
         ])
+      );
+    };
+
+    const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
+      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+
+      // Heading + greeting
+      createContentSection(
+        [
+          createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode(`${text.greeting} `),
+              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+              createTextNode(', '),
+              createTextNode(text.message),
+            ])
+          ),
+        ],
+        { padding: '20px 0' }
       ),
     ];
 
-    if (fieldNames.itemSku) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('SKU: '),
-            createLoopFieldPlaceholder(fieldNames.itemSku),
-          ])
-        )
-      );
+    // Seller info section (company, VAT)
+    const sellerRows = [
+      detailRow(text.companyLabel, fieldNames.companyName),
+      detailRow(text.vatLabel, fieldNames.vatNumber),
+    ].filter(Boolean) as ReturnType<typeof createBrandText>[];
+
+    if (sellerRows.length > 0) {
+      sections.push(createContentSection(sellerRows, { padding: '10px 0' }));
     }
 
-    if (fieldNames.itemQuantity) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('Qty: '),
-            createLoopFieldPlaceholder(fieldNames.itemQuantity),
-          ])
-        )
-      );
-    }
+    // Order details section
+    const orderDetailRows = [
+      detailRow(text.orderRefLabel, fieldNames.orderRef),
+      detailRow(text.orderDateLabel, fieldNames.orderDate),
+      detailRow(text.paymentMethodLabel, fieldNames.paymentMethod),
+      detailRow(text.customerEmailLabel, fieldNames.customerEmail),
+    ].filter(Boolean) as ReturnType<typeof createBrandText>[];
 
-    if (fieldNames.itemUnitPrice) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('Unit price: '),
-            createLoopFieldPlaceholder(fieldNames.itemUnitPrice),
-          ])
-        )
-      );
-    }
-
-    if (fieldNames.itemTotal) {
-      loopChildren.push(
-        createBrandText(
-          createDocWithPlaceholders([
-            createTextNode('Line total: '),
-            createLoopFieldPlaceholder(fieldNames.itemTotal),
-          ])
-        )
-      );
-    }
-
-    if (text.lineItemsHeading) {
+    if (orderDetailRows.length > 0) {
       sections.push(
-        createContentSection(
-          [createBrandHeading(createDocWithPlaceholders([createTextNode(text.lineItemsHeading)]), 2)],
-          { padding: '10px 0' }
+        createContentSection(orderDetailRows, {
+          padding: '20px 0',
+          backgroundColor: config.brandStyle.brandColor,
+        })
+      );
+    }
+
+    // Shipping details section
+    const shippingRows = [
+      detailRow(text.shippingAddressLabel, fieldNames.shippingAddress),
+      detailRow(text.carrierLabel, fieldNames.shippingCarrier),
+      detailRow(text.trackingLabel, fieldNames.trackingNumber),
+      detailRow(text.estimatedDeliveryLabel, fieldNames.estimatedDelivery),
+    ].filter(Boolean) as ReturnType<typeof createBrandText>[];
+
+    if (shippingRows.length > 0) {
+      sections.push(createContentSection(shippingRows, { padding: '20px 0' }));
+    }
+
+    // Track shipment button
+    sections.push(
+      createContentSection(
+        [
+          createBrandButton(
+            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+            config.trackingUrl
+          ),
+        ],
+        { padding: '20px 0' }
+      )
+    );
+
+    // Line items loop
+    if (fieldNames.items && fieldNames.itemName) {
+      const loopChildren: ReturnType<typeof createBrandText>[] = [
+        createBrandText(
+          createDocWithPlaceholders([
+            createLoopFieldPlaceholder(fieldNames.itemName),
+          ])
+        ),
+      ];
+
+      if (fieldNames.itemSku) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('SKU: '),
+              createLoopFieldPlaceholder(fieldNames.itemSku),
+            ])
+          )
+        );
+      }
+
+      if (fieldNames.itemQuantity) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Qty: '),
+              createLoopFieldPlaceholder(fieldNames.itemQuantity),
+            ])
+          )
+        );
+      }
+
+      if (fieldNames.itemUnitPrice) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Unit price: '),
+              createLoopFieldPlaceholder(fieldNames.itemUnitPrice),
+            ])
+          )
+        );
+      }
+
+      if (fieldNames.itemTotal) {
+        loopChildren.push(
+          createBrandText(
+            createDocWithPlaceholders([
+              createTextNode('Line total: '),
+              createLoopFieldPlaceholder(fieldNames.itemTotal),
+            ])
+          )
+        );
+      }
+
+      if (text.lineItemsHeading) {
+        sections.push(
+          createContentSection(
+            [createBrandHeading(createDocWithPlaceholders([createTextNode(text.lineItemsHeading)]), 2)],
+            { padding: '10px 0' }
+          )
+        );
+      }
+
+      sections.push(
+        createBrandLoop(
+          customFields[fieldNames.items],
+          [createContentSection(loopChildren, { padding: '10px 0' }) as RCMLSection],
+          { maxIterations: 20 }
         )
       );
     }
 
-    sections.push(
-      createBrandLoop(
-        customFields[fieldNames.items],
-        [createContentSection(loopChildren, { padding: '10px 0' }) as RCMLSection],
-        { maxIterations: 20 }
-      )
-    );
-  }
+    // Financial summary section
+    const financialRows = [
+      detailRow(text.subtotalLabel, fieldNames.subtotal),
+      detailRow(text.discountLabel, fieldNames.discountAmount),
+      detailRow(text.taxLabel, fieldNames.taxAmount),
+      detailRow(text.shippingCostLabel, fieldNames.shippingCost),
+      detailRow(text.totalLabel, fieldNames.totalPrice),
+    ].filter(Boolean) as ReturnType<typeof createBrandText>[];
 
-  // Financial summary section
-  const financialRows = [
-    detailRow(text.subtotalLabel, fieldNames.subtotal),
-    detailRow(text.discountLabel, fieldNames.discountAmount),
-    detailRow(text.taxLabel, fieldNames.taxAmount),
-    detailRow(text.shippingCostLabel, fieldNames.shippingCost),
-    detailRow(text.totalLabel, fieldNames.totalPrice),
-  ].filter(Boolean) as ReturnType<typeof createBrandText>[];
-
-  if (financialRows.length > 0) {
-    sections.push(
-      createContentSection(financialRows, {
-        padding: '20px 0',
-        backgroundColor: config.brandStyle.brandColor,
-      })
-    );
-  }
-
-  // Buyer details section
-  const buyerRows = [
-    detailRow(text.billingAddressLabel, fieldNames.billingAddress),
-  ].filter(Boolean) as ReturnType<typeof createBrandText>[];
-
-  if (fieldNames.customerFullName) {
-    buyerRows.unshift(
-      createBrandText(
-        createDocWithPlaceholders([
-          createPlaceholder(fieldNames.customerFullName, customFields[fieldNames.customerFullName]),
-        ])
-      )
-    );
-  }
-
-  if (buyerRows.length > 0) {
-    sections.push(createContentSection(buyerRows, { padding: '10px 0' }));
-  }
-
-  // Legal section
-  const legalChildren: ReturnType<typeof createBrandText>[] = [];
-
-  if (text.legalText) {
-    legalChildren.push(
-      createBrandText(
-        createDocWithPlaceholders([createTextNode(text.legalText)]),
-        { align: 'center' }
-      )
-    );
-  }
-
-  if (text.returnPolicyText && text.returnPolicyUrl) {
-    const safeReturnPolicyUrl = sanitizeUrl(text.returnPolicyUrl);
-    if (safeReturnPolicyUrl) {
-      legalChildren.push(
-        createBrandText({
-          type: 'doc',
-          content: [{
-            type: 'paragraph',
-            content: [{
-              type: 'text',
-              text: text.returnPolicyText,
-              marks: [{
-                type: 'link',
-                attrs: { href: safeReturnPolicyUrl, target: '_blank' },
-              }],
-            }],
-          }],
-        }, { align: 'center' })
+    if (financialRows.length > 0) {
+      sections.push(
+        createContentSection(financialRows, {
+          padding: '20px 0',
+          backgroundColor: config.brandStyle.brandColor,
+        })
       );
     }
-  }
 
-  if (text.termsText && text.termsUrl) {
-    const safeTermsUrl = sanitizeUrl(text.termsUrl);
-    if (safeTermsUrl) {
-      legalChildren.push(
-        createBrandText({
-          type: 'doc',
-          content: [{
-            type: 'paragraph',
-            content: [{
-              type: 'text',
-              text: text.termsText,
-              marks: [{
-                type: 'link',
-                attrs: { href: safeTermsUrl, target: '_blank' },
-              }],
-            }],
-          }],
-        }, { align: 'center' })
+    // Buyer details section
+    const buyerRows = [
+      detailRow(text.billingAddressLabel, fieldNames.billingAddress),
+    ].filter(Boolean) as ReturnType<typeof createBrandText>[];
+
+    if (fieldNames.customerFullName) {
+      buyerRows.unshift(
+        createBrandText(
+          createDocWithPlaceholders([
+            createPlaceholder(fieldNames.customerFullName, customFields[fieldNames.customerFullName]),
+          ])
+        )
       );
     }
-  }
 
-  if (legalChildren.length > 0) {
-    sections.push(createContentSection(legalChildren, { padding: '10px 0' }));
-  }
+    if (buyerRows.length > 0) {
+      sections.push(createContentSection(buyerRows, { padding: '10px 0' }));
+    }
 
-  // Footer
-  sections.push(createFooterSection(config.footer));
+    // Legal section
+    const legalChildren: ReturnType<typeof createBrandText>[] = [];
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections,
+    if (text.legalText) {
+      legalChildren.push(
+        createBrandText(
+          createDocWithPlaceholders([createTextNode(text.legalText)]),
+          { align: 'center' }
+        )
+      );
+    }
+
+    if (text.returnPolicyText && text.returnPolicyUrl) {
+      const safeReturnPolicyUrl = sanitizeUrl(text.returnPolicyUrl);
+      if (safeReturnPolicyUrl) {
+        legalChildren.push(
+          createBrandText({
+            type: 'doc',
+            content: [{
+              type: 'paragraph',
+              content: [{
+                type: 'text',
+                text: text.returnPolicyText,
+                marks: [{
+                  type: 'link',
+                  attrs: { href: safeReturnPolicyUrl, target: '_blank' },
+                }],
+              }],
+            }],
+          }, { align: 'center' })
+        );
+      }
+    }
+
+    if (text.termsText && text.termsUrl) {
+      const safeTermsUrl = sanitizeUrl(text.termsUrl);
+      if (safeTermsUrl) {
+        legalChildren.push(
+          createBrandText({
+            type: 'doc',
+            content: [{
+              type: 'paragraph',
+              content: [{
+                type: 'text',
+                text: text.termsText,
+                marks: [{
+                  type: 'link',
+                  attrs: { href: safeTermsUrl, target: '_blank' },
+                }],
+              }],
+            }],
+          }, { align: 'center' })
+        );
+      }
+    }
+
+    if (legalChildren.length > 0) {
+      sections.push(createContentSection(legalChildren, { padding: '10px 0' }));
+    }
+
+    // Footer
+    sections.push(createFooterSection(config.footer));
+
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections,
+    });
   });
 }
 
@@ -671,47 +678,50 @@ export interface AbandonedCartConfig {
  */
 export function createAbandonedCartEmail(config: AbandonedCartConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createAbandonedCartEmail');
-  const { customFields, fieldNames, text } = config;
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+  return withTemplateContext('createAbandonedCartEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.message)]),
-            { align: 'center' }
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.reminder)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.cartUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+        createContentSection(
+          [
+            createBrandHeading(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode('!'),
+              ])
+            ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.message)]),
+              { align: 'center' }
+            ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.reminder)]),
+              { align: 'center' }
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      createFooterSection(config.footer),
-    ],
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.cartUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
+
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }
 
@@ -744,51 +754,54 @@ export interface OrderCancellationConfig {
  */
 export function createOrderCancellationEmail(config: OrderCancellationConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createOrderCancellationEmail');
-  const { customFields, fieldNames, text } = config;
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+  return withTemplateContext('createOrderCancellationEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-      createContentSection(
-        [
-          createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode(','),
-            ])
-          ),
+        createContentSection(
+          [
+            createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
 
-          createBrandText(createDocWithPlaceholders([createTextNode(text.message)])),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode(','),
+              ])
+            ),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.orderRefLabel}: `),
-              createPlaceholder(fieldNames.orderRef, customFields[fieldNames.orderRef]),
-            ])
-          ),
+            createBrandText(createDocWithPlaceholders([createTextNode(text.message)])),
 
-          createBrandText(createDocWithPlaceholders([createTextNode(text.followUp)])),
-        ],
-        { padding: '20px 0' }
-      ),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.orderRefLabel}: `),
+                createPlaceholder(fieldNames.orderRef, customFields[fieldNames.orderRef]),
+              ])
+            ),
 
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+            createBrandText(createDocWithPlaceholders([createTextNode(text.followUp)])),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      createFooterSection(config.footer),
-    ],
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.websiteUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
+
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }

--- a/src/rcml/ecommerce-templates.ts
+++ b/src/rcml/ecommerce-templates.ts
@@ -100,11 +100,12 @@ export interface OrderConfirmationConfig {
  * ```
  */
 export function createOrderConfirmationEmail(config: OrderConfirmationConfig): RCMLDocument {
+  const templateName = 'createOrderConfirmationEmail';
   // Loop sub-fields are JSON key names, not custom field paths — skip validation for them
   const { itemName, itemQuantity, itemUnitPrice, itemTotal, ...regularFields } = config.fieldNames;
-  validateCustomFields(config.customFields, regularFields, 'createOrderConfirmationEmail');
+  validateCustomFields(config.customFields, regularFields, templateName);
 
-  return withTemplateContext('createOrderConfirmationEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     const detailRows: ReturnType<typeof createBrandText>[] = [
@@ -382,11 +383,12 @@ export interface ShippingUpdateConfig {
  * financial summary, legal text), renders a full legally-binding receipt.
  */
 export function createShippingUpdateEmail(config: ShippingUpdateConfig): RCMLDocument {
+  const templateName = 'createShippingUpdateEmail';
   // Loop sub-fields are JSON key names, not custom field paths — skip validation for them
   const { itemName, itemQuantity, itemUnitPrice, itemTotal, itemSku, ...regularFields } = config.fieldNames;
-  validateCustomFields(config.customFields, regularFields, 'createShippingUpdateEmail');
+  validateCustomFields(config.customFields, regularFields, templateName);
 
-  return withTemplateContext('createShippingUpdateEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     /** Helper to create a detail row from an optional field + label pair. */
@@ -677,9 +679,10 @@ export interface AbandonedCartConfig {
  * Create an abandoned cart recovery email template.
  */
 export function createAbandonedCartEmail(config: AbandonedCartConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createAbandonedCartEmail');
+  const templateName = 'createAbandonedCartEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createAbandonedCartEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     return createBrandTemplate({
@@ -753,9 +756,10 @@ export interface OrderCancellationConfig {
  * Create an order cancellation email template.
  */
 export function createOrderCancellationEmail(config: OrderCancellationConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createOrderCancellationEmail');
+  const templateName = 'createOrderCancellationEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createOrderCancellationEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     return createBrandTemplate({

--- a/src/rcml/hospitality-templates.ts
+++ b/src/rcml/hospitality-templates.ts
@@ -29,6 +29,7 @@ import {
   type CustomFieldMap,
   type FooterConfig,
   validateCustomFields,
+  withTemplateContext,
 } from './brand-template';
 
 // ============================================================================
@@ -115,132 +116,135 @@ export interface ReservationTemplateConfig {
  */
 export function createReservationConfirmationEmail(config: ReservationTemplateConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createReservationConfirmationEmail');
-  const { customFields, fieldNames, text } = config;
 
-  const detailRows: ReturnType<typeof createBrandText>[] = [
-    // Reference
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.referenceLabel}: `),
-        createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
-      ])
-    ),
-    // Service type
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.serviceLabel}: `),
-        createPlaceholder(fieldNames.serviceType, customFields[fieldNames.serviceType]),
-      ])
-    ),
-  ];
+  return withTemplateContext('createReservationConfirmationEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-  // Room (optional)
-  if (fieldNames.roomName && text.roomLabel) {
+    const detailRows: ReturnType<typeof createBrandText>[] = [
+      // Reference
+      createBrandText(
+        createDocWithPlaceholders([
+          createTextNode(`${text.referenceLabel}: `),
+          createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
+        ])
+      ),
+      // Service type
+      createBrandText(
+        createDocWithPlaceholders([
+          createTextNode(`${text.serviceLabel}: `),
+          createPlaceholder(fieldNames.serviceType, customFields[fieldNames.serviceType]),
+        ])
+      ),
+    ];
+
+    // Room (optional)
+    if (fieldNames.roomName && text.roomLabel) {
+      detailRows.push(
+        createBrandText(
+          createDocWithPlaceholders([
+            createTextNode(`${text.roomLabel}: `),
+            createPlaceholder(fieldNames.roomName, customFields[fieldNames.roomName]),
+          ])
+        )
+      );
+    }
+
+    // Check-in
     detailRows.push(
       createBrandText(
         createDocWithPlaceholders([
-          createTextNode(`${text.roomLabel}: `),
-          createPlaceholder(fieldNames.roomName, customFields[fieldNames.roomName]),
+          createTextNode(`${text.checkInLabel}: `),
+          createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
         ])
       )
     );
-  }
 
-  // Check-in
-  detailRows.push(
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.checkInLabel}: `),
-        createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
-      ])
-    )
-  );
+    // Check-out (optional)
+    if (fieldNames.checkOutDate && text.checkOutLabel) {
+      detailRows.push(
+        createBrandText(
+          createDocWithPlaceholders([
+            createTextNode(`${text.checkOutLabel}: `),
+            createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
+          ])
+        )
+      );
+    }
 
-  // Check-out (optional)
-  if (fieldNames.checkOutDate && text.checkOutLabel) {
+    // Guests
     detailRows.push(
       createBrandText(
         createDocWithPlaceholders([
-          createTextNode(`${text.checkOutLabel}: `),
-          createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
+          createTextNode(`${text.guestsLabel}: `),
+          createPlaceholder(fieldNames.totalGuests, customFields[fieldNames.totalGuests]),
         ])
       )
     );
-  }
 
-  // Guests
-  detailRows.push(
-    createBrandText(
-      createDocWithPlaceholders([
-        createTextNode(`${text.guestsLabel}: `),
-        createPlaceholder(fieldNames.totalGuests, customFields[fieldNames.totalGuests]),
-      ])
-    )
-  );
+    // Total price (optional)
+    if (fieldNames.totalPrice && text.totalPriceLabel) {
+      const priceContent = text.currency
+        ? [
+            createTextNode(`${text.totalPriceLabel}: `),
+            createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
+            createTextNode(` ${text.currency}`),
+          ]
+        : [
+            createTextNode(`${text.totalPriceLabel}: `),
+            createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
+          ];
+      detailRows.push(createBrandText(createDocWithPlaceholders(priceContent)));
+    }
 
-  // Total price (optional)
-  if (fieldNames.totalPrice && text.totalPriceLabel) {
-    const priceContent = text.currency
-      ? [
-          createTextNode(`${text.totalPriceLabel}: `),
-          createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
-          createTextNode(` ${text.currency}`),
-        ]
-      : [
-          createTextNode(`${text.totalPriceLabel}: `),
-          createPlaceholder(fieldNames.totalPrice, customFields[fieldNames.totalPrice]),
-        ];
-    detailRows.push(createBrandText(createDocWithPlaceholders(priceContent)));
-  }
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        // Logo
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      // Logo
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        // Greeting
+        createContentSection(
+          [
+            createBrandHeading(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode('!'),
+              ])
+            ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.intro)]),
+              { align: 'center' }
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      // Greeting
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.intro)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+        // Details
+        createContentSection(
+          [
+            createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
+            ...detailRows,
+          ],
+          { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
+        ),
 
-      // Details
-      createContentSection(
-        [
-          createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
-          ...detailRows,
-        ],
-        { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
-      ),
+        // CTA
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.websiteUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      // CTA
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
-
-      // Footer
-      createFooterSection(config.footer),
-    ],
+        // Footer
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }
 
@@ -273,58 +277,61 @@ export interface ReservationCancellationConfig {
  */
 export function createReservationCancellationEmail(config: ReservationCancellationConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createReservationCancellationEmail');
-  const { customFields, fieldNames, text } = config;
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+  return withTemplateContext('createReservationCancellationEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-      createContentSection(
-        [
-          createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode(','),
-            ])
-          ),
+        createContentSection(
+          [
+            createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)])),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(text.message),
-            ])
-          ),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode(','),
+              ])
+            ),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.referenceLabel}: `),
-              createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
-            ])
-          ),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(text.message),
+              ])
+            ),
 
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.followUp)])
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.referenceLabel}: `),
+                createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
+              ])
+            ),
 
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.followUp)])
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      createFooterSection(config.footer),
-    ],
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.websiteUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
+
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }
 
@@ -361,112 +368,115 @@ export interface ReservationReminderConfig {
  */
 export function createReservationReminderEmail(config: ReservationReminderConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createReservationReminderEmail');
-  const { customFields, fieldNames, text } = config;
 
-  const detailRows: ReturnType<typeof createBrandText>[] = [];
+  return withTemplateContext('createReservationReminderEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-  // Dates
-  if (fieldNames.checkOutDate) {
-    detailRows.push(
-      createBrandText(
-        createDocWithPlaceholders([
-          createTextNode(`${text.dateLabel}: `),
-          createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
-          createTextNode(' - '),
-          createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
-        ])
-      )
-    );
-  } else {
-    detailRows.push(
-      createBrandText(
-        createDocWithPlaceholders([
-          createTextNode(`${text.dateLabel}: `),
-          createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
-        ])
-      )
-    );
-  }
+    const detailRows: ReturnType<typeof createBrandText>[] = [];
 
-  // Room (optional)
-  if (fieldNames.roomName && text.roomLabel) {
-    detailRows.push(
-      createBrandText(
-        createDocWithPlaceholders([
-          createTextNode(`${text.roomLabel}: `),
-          createPlaceholder(fieldNames.roomName, customFields[fieldNames.roomName]),
-        ])
-      )
-    );
-  }
-
-  const sections: RCMLDocument['children'][1]['children'] = [
-    ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
-
-    createContentSection(
-      [
-        createBrandHeading(
-          createDocWithPlaceholders([
-            createTextNode(`${text.greeting} `),
-            createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-            createTextNode('!'),
-          ])
-        ),
+    // Dates
+    if (fieldNames.checkOutDate) {
+      detailRows.push(
         createBrandText(
-          createDocWithPlaceholders([createTextNode(text.intro)]),
-          { align: 'center' }
-        ),
-      ],
-      { padding: '20px 0' }
-    ),
+          createDocWithPlaceholders([
+            createTextNode(`${text.dateLabel}: `),
+            createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
+            createTextNode(' - '),
+            createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
+          ])
+        )
+      );
+    } else {
+      detailRows.push(
+        createBrandText(
+          createDocWithPlaceholders([
+            createTextNode(`${text.dateLabel}: `),
+            createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
+          ])
+        )
+      );
+    }
 
-    createContentSection(
-      [
-        createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
-        ...detailRows,
-      ],
-      { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
-    ),
-  ];
+    // Room (optional)
+    if (fieldNames.roomName && text.roomLabel) {
+      detailRows.push(
+        createBrandText(
+          createDocWithPlaceholders([
+            createTextNode(`${text.roomLabel}: `),
+            createPlaceholder(fieldNames.roomName, customFields[fieldNames.roomName]),
+          ])
+        )
+      );
+    }
 
-  // Practical info (optional)
-  if (text.practicalInfoHeading && text.practicalInfo) {
-    sections.push(
+    const sections: RCMLDocument['children'][1]['children'] = [
+      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+
       createContentSection(
         [
           createBrandHeading(
-            createDocWithPlaceholders([createTextNode(text.practicalInfoHeading)]),
-            3
+            createDocWithPlaceholders([
+              createTextNode(`${text.greeting} `),
+              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+              createTextNode('!'),
+            ])
           ),
-          createBrandText(createDocWithPlaceholders([createTextNode(text.practicalInfo)])),
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
+          createBrandText(
+            createDocWithPlaceholders([createTextNode(text.intro)]),
+            { align: 'center' }
           ),
         ],
         { padding: '20px 0' }
-      )
-    );
-  } else {
-    sections.push(
+      ),
+
       createContentSection(
         [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
-          ),
+          createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
+          ...detailRows,
         ],
-        { padding: '20px 0' }
-      )
-    );
-  }
+        { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
+      ),
+    ];
 
-  sections.push(createFooterSection(config.footer));
+    // Practical info (optional)
+    if (text.practicalInfoHeading && text.practicalInfo) {
+      sections.push(
+        createContentSection(
+          [
+            createBrandHeading(
+              createDocWithPlaceholders([createTextNode(text.practicalInfoHeading)]),
+              3
+            ),
+            createBrandText(createDocWithPlaceholders([createTextNode(text.practicalInfo)])),
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.websiteUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        )
+      );
+    } else {
+      sections.push(
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.websiteUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        )
+      );
+    }
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections,
+    sections.push(createFooterSection(config.footer));
+
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections,
+    });
   });
 }
 
@@ -496,43 +506,46 @@ export interface FeedbackRequestConfig {
  */
 export function createFeedbackRequestEmail(config: FeedbackRequestConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createFeedbackRequestEmail');
-  const { customFields, fieldNames, text } = config;
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+  return withTemplateContext('createFeedbackRequestEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.message)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.feedbackUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+        createContentSection(
+          [
+            createBrandHeading(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode('!'),
+              ])
+            ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.message)]),
+              { align: 'center' }
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-      createFooterSection(config.footer),
-    ],
+        createContentSection(
+          [
+            createBrandButton(
+              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
+              config.feedbackUrl
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
+
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }
 
@@ -567,67 +580,70 @@ export interface ReservationRequestConfig {
  */
 export function createReservationRequestEmail(config: ReservationRequestConfig): RCMLDocument {
   validateCustomFields(config.customFields, config.fieldNames, 'createReservationRequestEmail');
-  const { customFields, fieldNames, text } = config;
 
-  const dateContent = fieldNames.checkOutDate
-    ? [
-        createTextNode(`${text.dateLabel}: `),
-        createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
-        createTextNode(' - '),
-        createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
-      ]
-    : [
-        createTextNode(`${text.dateLabel}: `),
-        createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
-      ];
+  return withTemplateContext('createReservationRequestEmail', () => {
+    const { customFields, fieldNames, text } = config;
 
-  return createBrandTemplate({
-    brandStyle: config.brandStyle,
-    preheader: text.preheader,
-    sections: [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+    const dateContent = fieldNames.checkOutDate
+      ? [
+          createTextNode(`${text.dateLabel}: `),
+          createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
+          createTextNode(' - '),
+          createPlaceholder(fieldNames.checkOutDate, customFields[fieldNames.checkOutDate]),
+        ]
+      : [
+          createTextNode(`${text.dateLabel}: `),
+          createPlaceholder(fieldNames.checkInDate, customFields[fieldNames.checkInDate]),
+        ];
 
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.message)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+    return createBrandTemplate({
+      brandStyle: config.brandStyle,
+      preheader: text.preheader,
+      sections: [
+        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
 
-      createContentSection(
-        [
-          createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
+        createContentSection(
+          [
+            createBrandHeading(
+              createDocWithPlaceholders([
+                createTextNode(`${text.greeting} `),
+                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
+                createTextNode('!'),
+              ])
+            ),
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.message)]),
+              { align: 'center' }
+            ),
+          ],
+          { padding: '20px 0' }
+        ),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.referenceLabel}: `),
-              createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
-            ])
-          ),
+        createContentSection(
+          [
+            createBrandHeading(createDocWithPlaceholders([createTextNode(text.detailsHeading)]), 2),
 
-          createBrandText(createDocWithPlaceholders(dateContent)),
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.referenceLabel}: `),
+                createPlaceholder(fieldNames.bookingRef, customFields[fieldNames.bookingRef]),
+              ])
+            ),
 
-          createBrandText(
-            createDocWithPlaceholders([
-              createTextNode(`${text.guestsLabel}: `),
-              createPlaceholder(fieldNames.totalGuests, customFields[fieldNames.totalGuests]),
-            ])
-          ),
-        ],
-        { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
-      ),
+            createBrandText(createDocWithPlaceholders(dateContent)),
 
-      createFooterSection(config.footer),
-    ],
+            createBrandText(
+              createDocWithPlaceholders([
+                createTextNode(`${text.guestsLabel}: `),
+                createPlaceholder(fieldNames.totalGuests, customFields[fieldNames.totalGuests]),
+              ])
+            ),
+          ],
+          { padding: '20px 0', backgroundColor: config.brandStyle.brandColor }
+        ),
+
+        createFooterSection(config.footer),
+      ],
+    });
   });
 }

--- a/src/rcml/hospitality-templates.ts
+++ b/src/rcml/hospitality-templates.ts
@@ -115,9 +115,10 @@ export interface ReservationTemplateConfig {
  * ```
  */
 export function createReservationConfirmationEmail(config: ReservationTemplateConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createReservationConfirmationEmail');
+  const templateName = 'createReservationConfirmationEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createReservationConfirmationEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     const detailRows: ReturnType<typeof createBrandText>[] = [
@@ -276,9 +277,10 @@ export interface ReservationCancellationConfig {
  * Create a reservation cancellation email template.
  */
 export function createReservationCancellationEmail(config: ReservationCancellationConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createReservationCancellationEmail');
+  const templateName = 'createReservationCancellationEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createReservationCancellationEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     return createBrandTemplate({
@@ -367,9 +369,10 @@ export interface ReservationReminderConfig {
  * Create a reservation reminder email template.
  */
 export function createReservationReminderEmail(config: ReservationReminderConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createReservationReminderEmail');
+  const templateName = 'createReservationReminderEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createReservationReminderEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     const detailRows: ReturnType<typeof createBrandText>[] = [];
@@ -505,9 +508,10 @@ export interface FeedbackRequestConfig {
  * Works for post-stay, post-purchase, or any review request.
  */
 export function createFeedbackRequestEmail(config: FeedbackRequestConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createFeedbackRequestEmail');
+  const templateName = 'createFeedbackRequestEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createFeedbackRequestEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     return createBrandTemplate({
@@ -579,9 +583,10 @@ export interface ReservationRequestConfig {
  * Create a reservation request confirmation email (for pending/manual approval flows).
  */
 export function createReservationRequestEmail(config: ReservationRequestConfig): RCMLDocument {
-  validateCustomFields(config.customFields, config.fieldNames, 'createReservationRequestEmail');
+  const templateName = 'createReservationRequestEmail';
+  validateCustomFields(config.customFields, config.fieldNames, templateName);
 
-  return withTemplateContext('createReservationRequestEmail', () => {
+  return withTemplateContext(templateName, () => {
     const { customFields, fieldNames, text } = config;
 
     const dateContent = fieldNames.checkOutDate

--- a/src/rcml/index.ts
+++ b/src/rcml/index.ts
@@ -64,6 +64,8 @@ export {
   createLoopFieldPlaceholder,
   createTextNode,
   createDocWithPlaceholders,
+  // Validation
+  validateCustomFields,
 } from './brand-template';
 
 // Brand template types

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -1606,7 +1606,7 @@ describe('withTemplateContext', () => {
     }
   });
 
-  it('should preserve original stack trace', () => {
+  it('should preserve original stack frames with wrapped message', () => {
     const original = new RuleConfigError('createBrandButton: invalid or unsafe URL');
     try {
       withTemplateContext('createOrderConfirmationEmail', () => {
@@ -1614,7 +1614,13 @@ describe('withTemplateContext', () => {
       });
     } catch (error) {
       expect(error).toBeInstanceOf(RuleConfigError);
-      expect((error as RuleConfigError).stack).toBe(original.stack);
+      const wrapped = error as RuleConfigError;
+      // Stack header should reflect the wrapped message
+      expect(wrapped.stack).toContain('createOrderConfirmationEmail > createBrandButton: invalid or unsafe URL');
+      // Original stack frames should be preserved
+      const originalFrames = original.stack!.split('\n').slice(1);
+      const wrappedFrames = wrapped.stack!.split('\n').slice(1);
+      expect(wrappedFrames).toEqual(originalFrames);
     }
   });
 

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -1594,6 +1594,30 @@ describe('withTemplateContext', () => {
     }
   });
 
+  it('should attach original error as cause', () => {
+    const original = new RuleConfigError('createBrandButton: invalid or unsafe URL');
+    try {
+      withTemplateContext('createOrderConfirmationEmail', () => {
+        throw original;
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuleConfigError);
+      expect((error as RuleConfigError).cause).toBe(original);
+    }
+  });
+
+  it('should preserve original stack trace', () => {
+    const original = new RuleConfigError('createBrandButton: invalid or unsafe URL');
+    try {
+      withTemplateContext('createOrderConfirmationEmail', () => {
+        throw original;
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuleConfigError);
+      expect((error as RuleConfigError).stack).toBe(original.stack);
+    }
+  });
+
   it('should not modify non-RuleConfigError errors', () => {
     expect(() =>
       withTemplateContext('myTemplate', () => {

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import type { RCMLDocument } from '../src/types';
 import type { BrandStyleConfig, CustomFieldMap } from '../src/rcml';
 import { RuleConfigError } from '../src/errors';
-import { validateCustomFields, toBrandStyleConfig } from '../src/rcml/brand-template';
+import { validateCustomFields, toBrandStyleConfig, withTemplateContext } from '../src/rcml/brand-template';
 import {
   // Brand template utilities
   createBrandTemplate,
@@ -724,8 +724,7 @@ describe('Brand Template Utilities', () => {
       expect(rcLogo.tagName).toBe('rc-logo');
       expect(rcLogo.id).toBeDefined();
       expect(rcLogo.attributes?.['rc-class']).toBe('rcml-logo-style rc-initial-logo');
-      // src comes from rc-class, not directly on rc-logo
-      expect(rcLogo.attributes?.src).toBeUndefined();
+      expect(rcLogo.attributes?.src).toBe('https://app.rule.io/brand-style/123/image/456');
     });
 
     it('should generate unique IDs across nodes', () => {
@@ -1548,5 +1547,119 @@ describe('Template Footer Localization', () => {
     expect(json).toContain('Voir dans le navigateur');
     expect(json).toContain('Se désabonner');
     expect(json).not.toContain('View in browser');
+  });
+});
+
+// ============================================================================
+// Barrel Export
+// ============================================================================
+
+describe('barrel exports', () => {
+  it('should export validateCustomFields from the barrel', async () => {
+    const barrel = await import('../src/rcml');
+    expect(barrel.validateCustomFields).toBe(validateCustomFields);
+  });
+
+  it('should export validateCustomFields from the top-level barrel', async () => {
+    const topBarrel = await import('../src/index');
+    expect(topBarrel.validateCustomFields).toBe(validateCustomFields);
+  });
+});
+
+// ============================================================================
+// withTemplateContext
+// ============================================================================
+
+describe('withTemplateContext', () => {
+  it('should return the value from the callback', () => {
+    const result = withTemplateContext('myTemplate', () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('should prepend template name to RuleConfigError messages', () => {
+    expect(() =>
+      withTemplateContext('createOrderConfirmationEmail', () => {
+        throw new RuleConfigError('createBrandButton: invalid or unsafe URL');
+      })
+    ).toThrow('createOrderConfirmationEmail > createBrandButton: invalid or unsafe URL');
+  });
+
+  it('should preserve RuleConfigError type', () => {
+    try {
+      withTemplateContext('myTemplate', () => {
+        throw new RuleConfigError('some error');
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuleConfigError);
+    }
+  });
+
+  it('should not modify non-RuleConfigError errors', () => {
+    expect(() =>
+      withTemplateContext('myTemplate', () => {
+        throw new TypeError('something else');
+      })
+    ).toThrow(TypeError);
+  });
+});
+
+// ============================================================================
+// Template Error Context
+// ============================================================================
+
+describe('template error context', () => {
+  it('should include template name when createBrandButton throws inside a template', () => {
+    expect(() =>
+      createReservationConfirmationEmail({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'javascript:alert(1)',
+        text: {
+          preheader: 'Test',
+          greeting: 'Hello',
+          intro: 'Intro',
+          detailsHeading: 'Details',
+          referenceLabel: 'Ref',
+          serviceLabel: 'Service',
+          checkInLabel: 'Check-in',
+          guestsLabel: 'Guests',
+          ctaButton: 'Click',
+        },
+        fieldNames: {
+          firstName: 'Booking.FirstName',
+          bookingRef: 'Booking.BookingRef',
+          serviceType: 'Booking.ServiceType',
+          checkInDate: 'Booking.CheckInDate',
+          totalGuests: 'Booking.TotalGuests',
+        },
+      })
+    ).toThrow('createReservationConfirmationEmail > createBrandButton: invalid or unsafe URL');
+  });
+
+  it('should include template name when createBrandLogo throws inside e-commerce template', () => {
+    expect(() =>
+      createOrderConfirmationEmail({
+        brandStyle: {
+          ...TEST_BRAND_STYLE,
+          logoUrl: 'javascript:void(0)',
+        },
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://example.com',
+        text: {
+          preheader: 'Test',
+          greeting: 'Hi',
+          intro: 'Intro',
+          detailsHeading: 'Details',
+          orderRefLabel: 'Order',
+          totalLabel: 'Total',
+          ctaButton: 'View',
+        },
+        fieldNames: {
+          firstName: 'Booking.FirstName',
+          orderRef: 'Booking.BookingRef',
+          totalPrice: 'Booking.ServiceType',
+        },
+      })
+    ).toThrow('createOrderConfirmationEmail > createBrandLogo: invalid or unsafe logoUrl');
   });
 });


### PR DESCRIPTION
## Summary
- **5A**: Export `validateCustomFields` from barrel (`src/rcml/index.ts` and `src/index.ts`) so consumers building custom templates can validate their field mappings
- **5B**: Fix `createBrandLogo` to actually pass the sanitized URL as `src` on the `rc-logo` element, instead of validating then discarding it
- **5C**: Add `withTemplateContext` helper that wraps `RuleConfigError` with the calling template name (e.g. `createOrderConfirmationEmail > createBrandButton: invalid or unsafe URL`), applied to all 9 template functions

## Test plan
- [x] `validateCustomFields` importable from `src/rcml` and `src/index` barrels (new barrel export tests)
- [x] `createBrandLogo` sets `src` attribute on `rc-logo` element (updated existing test)
- [x] `withTemplateContext` returns values, wraps `RuleConfigError`, preserves non-config errors (new unit tests)
- [x] Template functions include template name in error messages when inner builders throw (new integration-style tests)
- [x] `npm run type-check` passes
- [x] `npm run test` passes (363 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)