### PR TITLE
refactor: remove dead isConfigured() method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -168,17 +168,6 @@ export class RuleClient {
   }
 
   /**
-   * Check if this client is configured with a valid API key.
-   *
-   * @deprecated This method always returns `true` because the constructor
-   * throws a `RuleConfigError` when an API key is missing. It will be
-   * removed in the next major version.
-   */
-  isConfigured(): boolean {
-    return !!this.config.apiKey;
-  }
-
-  /**
    * Get the API key (useful for passing to other functions)
    */
   getApiKey(): string {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -57,7 +57,6 @@ describe('RuleClient', () => {
   describe('constructor', () => {
     it('should accept string API key for backwards compatibility', () => {
       const client = new RuleClient('test-api-key');
-      expect(client.isConfigured()).toBe(true);
       expect(client.getApiKey()).toBe('test-api-key');
     });
 
@@ -66,7 +65,7 @@ describe('RuleClient', () => {
         apiKey: 'test-api-key',
         debug: true,
       });
-      expect(client.isConfigured()).toBe(true);
+      expect(client.getApiKey()).toBe('test-api-key');
     });
 
     it('should throw RuleConfigError if API key is missing', () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -68,7 +68,6 @@ describe.skipIf(!runIntegration)('Integration: Live Rule.io API', { timeout: 30_
 
   describe('Auth & Config', () => {
     it('should confirm client is configured', () => {
-      expect(client.isConfigured()).toBe(true);
       expect(client.getApiKey()).toBe(API_KEY);
     });
 


### PR DESCRIPTION
## Summary
- Remove `isConfigured()` from `RuleClient` — constructor throws on missing apiKey, so it always returned `true`
- Safe to remove at v0.3.0 (pre-1.0, no stability contract)

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)