### PR TITLE
refactor: extract shared template section helpers

### DIFF
--- a/src/rcml/brand-template.ts
+++ b/src/rcml/brand-template.ts
@@ -897,3 +897,69 @@ export function createFooterSection(
     ],
   } as RCMLBodyChild;
 }
+
+// ============================================================================
+// Internal Template Section Helpers
+// ============================================================================
+
+/**
+ * Create the optional logo section spread element.
+ *
+ * Returns an array with zero or one elements, designed to be spread
+ * into a sections array: `...createLogoSection(config.brandStyle.logoUrl)`
+ *
+ * @internal Not exported from barrel — used by template builders only.
+ */
+export function createLogoSection(logoUrl?: string): RCMLBodyChild[] {
+  return logoUrl ? [createBrandLogo(logoUrl)] : [];
+}
+
+/**
+ * Create a greeting section with "Hello {firstName}!" heading and centered intro text.
+ *
+ * This is the standard greeting pattern used by most template builders:
+ * a heading with the greeting, a placeholder for the first name, an
+ * exclamation mark, and a centered intro paragraph below.
+ *
+ * @internal Not exported from barrel — used by template builders only.
+ */
+export function createGreetingSection(
+  greeting: string,
+  intro: string,
+  firstName: string,
+  fieldId: number
+): RCMLBodyChild {
+  return createContentSection(
+    [
+      createBrandHeading(
+        createDocWithPlaceholders([
+          createTextNode(`${greeting} `),
+          createPlaceholder(firstName, fieldId),
+          createTextNode('!'),
+        ])
+      ),
+      createBrandText(
+        createDocWithPlaceholders([createTextNode(intro)]),
+        { align: 'center' }
+      ),
+    ],
+    { padding: '20px 0' }
+  );
+}
+
+/**
+ * Create a CTA button wrapped in a content section.
+ *
+ * @internal Not exported from barrel — used by template builders only.
+ */
+export function createCtaSection(buttonText: string, url: string): RCMLBodyChild {
+  return createContentSection(
+    [
+      createBrandButton(
+        createDocWithPlaceholders([createTextNode(buttonText)]),
+        url
+      ),
+    ],
+    { padding: '20px 0' }
+  );
+}

--- a/src/rcml/brand-template.ts
+++ b/src/rcml/brand-template.ts
@@ -915,26 +915,27 @@ export function createLogoSection(logoUrl?: string): RCMLBodyChild[] {
 }
 
 /**
- * Create a greeting section with "Hello {firstName}!" heading and centered intro text.
+ * Create a greeting section with caller-provided greeting text, a first-name
+ * placeholder, and centered intro text.
  *
  * This is the standard greeting pattern used by most template builders:
- * a heading with the greeting, a placeholder for the first name, an
- * exclamation mark, and a centered intro paragraph below.
+ * a heading with the provided greeting, a placeholder for the first-name
+ * custom field, an exclamation mark, and a centered intro paragraph below.
  *
  * @internal Not exported from barrel — used by template builders only.
  */
 export function createGreetingSection(
   greeting: string,
   intro: string,
-  firstName: string,
-  fieldId: number
+  firstNameFieldName: string,
+  firstNameFieldId: number
 ): RCMLBodyChild {
   return createContentSection(
     [
       createBrandHeading(
         createDocWithPlaceholders([
           createTextNode(`${greeting} `),
-          createPlaceholder(firstName, fieldId),
+          createPlaceholder(firstNameFieldName, firstNameFieldId),
           createTextNode('!'),
         ])
       ),

--- a/src/rcml/ecommerce-templates.ts
+++ b/src/rcml/ecommerce-templates.ts
@@ -17,10 +17,8 @@
 import type { RCMLDocument, RCMLSection, RCMLLoop, RCMLSwitch } from '../types';
 import {
   createBrandTemplate,
-  createBrandLogo,
   createBrandHeading,
   createBrandText,
-  createBrandButton,
   createBrandLoop,
   createContentSection,
   createFooterSection,
@@ -28,6 +26,9 @@ import {
   createLoopFieldPlaceholder,
   createTextNode,
   createDocWithPlaceholders,
+  createLogoSection,
+  createGreetingSection,
+  createCtaSection,
   type BrandStyleConfig,
   type CustomFieldMap,
   type FooterConfig,
@@ -211,24 +212,9 @@ export function createOrderConfirmationEmail(config: OrderConfirmationConfig): R
     }
 
     const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+      ...createLogoSection(config.brandStyle.logoUrl),
 
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.intro)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+      createGreetingSection(text.greeting, text.intro, fieldNames.firstName, customFields[fieldNames.firstName]),
 
       createContentSection(
         [
@@ -252,15 +238,7 @@ export function createOrderConfirmationEmail(config: OrderConfirmationConfig): R
     }
 
     sections.push(
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.websiteUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+      createCtaSection(text.ctaButton, config.websiteUrl),
       createFooterSection(config.footer),
     );
 
@@ -419,7 +397,7 @@ export function createShippingUpdateEmail(config: ShippingUpdateConfig): RCMLDoc
     };
 
     const sections: (RCMLSection | RCMLLoop | RCMLSwitch)[] = [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+      ...createLogoSection(config.brandStyle.logoUrl),
 
       // Heading + greeting
       createContentSection(
@@ -478,17 +456,7 @@ export function createShippingUpdateEmail(config: ShippingUpdateConfig): RCMLDoc
     }
 
     // Track shipment button
-    sections.push(
-      createContentSection(
-        [
-          createBrandButton(
-            createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-            config.trackingUrl
-          ),
-        ],
-        { padding: '20px 0' }
-      )
-    );
+    sections.push(createCtaSection(text.ctaButton, config.trackingUrl));
 
     // Line items loop
     if (fieldNames.items && fieldNames.itemName) {
@@ -705,7 +673,7 @@ export function createAbandonedCartEmail(config: AbandonedCartConfig): RCMLDocum
       brandStyle: config.brandStyle,
       preheader: text.preheader,
       sections: [
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
         createContentSection(
           [
@@ -728,15 +696,7 @@ export function createAbandonedCartEmail(config: AbandonedCartConfig): RCMLDocum
           { padding: '20px 0' }
         ),
 
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.cartUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createCtaSection(text.ctaButton, config.cartUrl),
 
         createFooterSection(config.footer),
       ],
@@ -782,7 +742,7 @@ export function createOrderCancellationEmail(config: OrderCancellationConfig): R
       brandStyle: config.brandStyle,
       preheader: text.preheader,
       sections: [
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
         createContentSection(
           [
@@ -810,15 +770,7 @@ export function createOrderCancellationEmail(config: OrderCancellationConfig): R
           { padding: '20px 0' }
         ),
 
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.websiteUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createCtaSection(text.ctaButton, config.websiteUrl),
 
         createFooterSection(config.footer),
       ],

--- a/src/rcml/hospitality-templates.ts
+++ b/src/rcml/hospitality-templates.ts
@@ -16,7 +16,6 @@
 import type { RCMLDocument } from '../types';
 import {
   createBrandTemplate,
-  createBrandLogo,
   createBrandHeading,
   createBrandText,
   createBrandButton,
@@ -25,6 +24,9 @@ import {
   createPlaceholder,
   createTextNode,
   createDocWithPlaceholders,
+  createLogoSection,
+  createGreetingSection,
+  createCtaSection,
   type BrandStyleConfig,
   type CustomFieldMap,
   type FooterConfig,
@@ -202,25 +204,10 @@ export function createReservationConfirmationEmail(config: ReservationTemplateCo
       preheader: text.preheader,
       sections: [
         // Logo
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
         // Greeting
-        createContentSection(
-          [
-            createBrandHeading(
-              createDocWithPlaceholders([
-                createTextNode(`${text.greeting} `),
-                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-                createTextNode('!'),
-              ])
-            ),
-            createBrandText(
-              createDocWithPlaceholders([createTextNode(text.intro)]),
-              { align: 'center' }
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createGreetingSection(text.greeting, text.intro, fieldNames.firstName, customFields[fieldNames.firstName]),
 
         // Details
         createContentSection(
@@ -232,15 +219,7 @@ export function createReservationConfirmationEmail(config: ReservationTemplateCo
         ),
 
         // CTA
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.websiteUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createCtaSection(text.ctaButton, config.websiteUrl),
 
         // Footer
         createFooterSection(config.footer),
@@ -287,7 +266,7 @@ export function createReservationCancellationEmail(config: ReservationCancellati
       brandStyle: config.brandStyle,
       preheader: text.preheader,
       sections: [
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
         createContentSection(
           [
@@ -321,15 +300,7 @@ export function createReservationCancellationEmail(config: ReservationCancellati
           { padding: '20px 0' }
         ),
 
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.websiteUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createCtaSection(text.ctaButton, config.websiteUrl),
 
         createFooterSection(config.footer),
       ],
@@ -413,24 +384,9 @@ export function createReservationReminderEmail(config: ReservationReminderConfig
     }
 
     const sections: RCMLDocument['children'][1]['children'] = [
-      ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+      ...createLogoSection(config.brandStyle.logoUrl),
 
-      createContentSection(
-        [
-          createBrandHeading(
-            createDocWithPlaceholders([
-              createTextNode(`${text.greeting} `),
-              createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-              createTextNode('!'),
-            ])
-          ),
-          createBrandText(
-            createDocWithPlaceholders([createTextNode(text.intro)]),
-            { align: 'center' }
-          ),
-        ],
-        { padding: '20px 0' }
-      ),
+      createGreetingSection(text.greeting, text.intro, fieldNames.firstName, customFields[fieldNames.firstName]),
 
       createContentSection(
         [
@@ -460,17 +416,7 @@ export function createReservationReminderEmail(config: ReservationReminderConfig
         )
       );
     } else {
-      sections.push(
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.websiteUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        )
-      );
+      sections.push(createCtaSection(text.ctaButton, config.websiteUrl));
     }
 
     sections.push(createFooterSection(config.footer));
@@ -518,34 +464,11 @@ export function createFeedbackRequestEmail(config: FeedbackRequestConfig): RCMLD
       brandStyle: config.brandStyle,
       preheader: text.preheader,
       sections: [
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
-        createContentSection(
-          [
-            createBrandHeading(
-              createDocWithPlaceholders([
-                createTextNode(`${text.greeting} `),
-                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-                createTextNode('!'),
-              ])
-            ),
-            createBrandText(
-              createDocWithPlaceholders([createTextNode(text.message)]),
-              { align: 'center' }
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createGreetingSection(text.greeting, text.message, fieldNames.firstName, customFields[fieldNames.firstName]),
 
-        createContentSection(
-          [
-            createBrandButton(
-              createDocWithPlaceholders([createTextNode(text.ctaButton)]),
-              config.feedbackUrl
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createCtaSection(text.ctaButton, config.feedbackUrl),
 
         createFooterSection(config.footer),
       ],
@@ -605,24 +528,9 @@ export function createReservationRequestEmail(config: ReservationRequestConfig):
       brandStyle: config.brandStyle,
       preheader: text.preheader,
       sections: [
-        ...(config.brandStyle.logoUrl ? [createBrandLogo(config.brandStyle.logoUrl)] : []),
+        ...createLogoSection(config.brandStyle.logoUrl),
 
-        createContentSection(
-          [
-            createBrandHeading(
-              createDocWithPlaceholders([
-                createTextNode(`${text.greeting} `),
-                createPlaceholder(fieldNames.firstName, customFields[fieldNames.firstName]),
-                createTextNode('!'),
-              ])
-            ),
-            createBrandText(
-              createDocWithPlaceholders([createTextNode(text.message)]),
-              { align: 'center' }
-            ),
-          ],
-          { padding: '20px 0' }
-        ),
+        createGreetingSection(text.greeting, text.message, fieldNames.firstName, customFields[fieldNames.firstName]),
 
         createContentSection(
           [


### PR DESCRIPTION
## Summary
- Extract repeated logo, greeting, and CTA section patterns into shared helper functions (`createLogoSection`, `createGreetingSection`, `createCtaSection`)
- Applied across all 9 template builders in hospitality and ecommerce files
- Internal helpers only — no public API changes, not exported from barrel files
- Net reduction of 74 lines (94 added, 168 removed)

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run test` passes (all 402 tests)
- [x] All existing template tests unchanged in behavior
- [x] New helpers are not exported from barrel files (internal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)