### PR TITLE
chore: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Rule.io API key (required)
+RULE_API_KEY=
+
+# Integration test opt-in (set to 1 to run live API tests)
+RUN_INTEGRATION=
+
+# Optional: verbose integration test output
+DEBUG_INTEGRATION=
+
+# Optional: sender details for automation email tests
+RULE_FROM_NAME=
+RULE_FROM_EMAIL=


### PR DESCRIPTION
## Summary
- Adds `.env.example` documenting environment variables needed for integration tests (`RULE_API_KEY`, `RUN_INTEGRATION`, `DEBUG_INTEGRATION`, `RULE_FROM_NAME`, `RULE_FROM_EMAIL`)

## Test plan
- [x] Verify file lists all env vars referenced in `tests/integration.test.ts`
- [x] Verify `.env` and `.env.local` remain in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)