### PR TITLE
feat: add RCML builders for social, switch/case and update validation script

### DIFF
--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -546,22 +546,28 @@ function buildSectionGroups(
       label('14. rc-switch / rc-case (conditional content)'),
       {
         ...createSwitch([
-          createCase(
-            { caseType: 'tag', caseCondition: 'eq', caseValue: 1 },
-            [createContentSection([
-              createBrandText(createDocWithPlaceholders([
-                createTextNode('This shows when tag ID 1 matches'),
-              ])),
-            ])],
-          ),
-          createCase(
-            { caseType: 'default' },
-            [createContentSection([
-              createBrandText(createDocWithPlaceholders([
-                createTextNode('This is the default / fallback content'),
-              ])),
-            ])],
-          ),
+          {
+            ...createCase(
+              { caseType: 'tag', caseCondition: 'eq', caseValue: 1 },
+              [createContentSection([
+                createBrandText(createDocWithPlaceholders([
+                  createTextNode('This shows when tag ID 1 matches'),
+                ])),
+              ])],
+            ),
+            id: id(),
+          },
+          {
+            ...createCase(
+              { caseType: 'default' },
+              [createContentSection([
+                createBrandText(createDocWithPlaceholders([
+                  createTextNode('This is the default / fallback content'),
+                ])),
+              ])],
+            ),
+            id: id(),
+          },
         ]),
         id: id(),
       },
@@ -576,10 +582,10 @@ function buildSectionGroups(
       section([
         {
           ...createSocial([
-            createSocialElement({ name: 'facebook', href: 'https://facebook.com' }),
-            createSocialElement({ name: 'instagram', href: 'https://instagram.com' }),
-            createSocialElement({ name: 'x', href: 'https://x.com' }),
-            createSocialElement({ name: 'web', href: 'https://example.com' }),
+            { ...createSocialElement({ name: 'facebook', href: 'https://facebook.com' }), id: id() },
+            { ...createSocialElement({ name: 'instagram', href: 'https://instagram.com' }), id: id() },
+            { ...createSocialElement({ name: 'x', href: 'https://x.com' }), id: id() },
+            { ...createSocialElement({ name: 'web', href: 'https://example.com' }), id: id() },
           ], { align: 'center', iconSize: '24px' }),
           id: id(),
         },

--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -300,6 +300,7 @@ interface SectionGroup {
 }
 
 function buildSectionGroups(
+  brandStyle: BrandStyleConfig,
   resolvedField?: { id: number; name: string },
   repeatableField?: { id: number; name: string },
 ): SectionGroup[] {
@@ -575,21 +576,29 @@ function buildSectionGroups(
   });
 
   // == 15. Social (rc-social + rc-social-element) — last before footer
+  const socialLinks = brandStyle.socialLinks && brandStyle.socialLinks.length > 0
+    ? brandStyle.socialLinks
+    : [
+        { name: 'facebook', href: 'https://facebook.com' },
+        { name: 'instagram', href: 'https://instagram.com' },
+        { name: 'x', href: 'https://x.com' },
+        { name: 'web', href: 'https://example.com' },
+      ];
+  const socialNames = socialLinks.map(l => l.name).join(', ');
+
   groups.push({
     num: 15, name: 'Social icons (rc-social)',
     sections: [
       label('15. rc-social / rc-social-element'),
       section([
         {
-          ...createSocial([
-            { ...createSocialElement({ name: 'facebook', href: 'https://facebook.com' }), id: id() },
-            { ...createSocialElement({ name: 'instagram', href: 'https://instagram.com' }), id: id() },
-            { ...createSocialElement({ name: 'x', href: 'https://x.com' }), id: id() },
-            { ...createSocialElement({ name: 'web', href: 'https://example.com' }), id: id() },
-          ], { align: 'center', iconSize: '24px' }),
+          ...createSocial(
+            socialLinks.map(l => ({ ...createSocialElement(l), id: id() })),
+            { align: 'center', iconSize: '24px' },
+          ),
           id: id(),
         },
-        noteText('Social icons row — facebook, instagram, x, web'),
+        noteText(`Social icons row — ${socialNames}`),
       ]),
     ],
   });
@@ -602,7 +611,7 @@ function buildShowcase(
   resolvedField?: { id: number; name: string },
   repeatableField?: { id: number; name: string },
 ): RCMLBodyChild[] {
-  const allGroups = buildSectionGroups(resolvedField, repeatableField);
+  const allGroups = buildSectionGroups(brandStyle, resolvedField, repeatableField);
   const groups = onlySections
     ? allGroups.filter(g => onlySections.includes(g.num))
     : allGroups;
@@ -668,6 +677,7 @@ async function create(): Promise<void> {
   console.log(`  Body BG:    ${brandStyle.bodyBackgroundColor}`);
   console.log(`  Section BG: ${brandStyle.sectionBackgroundColor}`);
   console.log(`  Text:       ${brandStyle.textColor}`);
+  console.log(`  Social:     ${brandStyle.socialLinks?.length ?? 0} link(s)${brandStyle.socialLinks?.length ? ' — ' + brandStyle.socialLinks.map(l => l.name).join(', ') : ''}`);
 
   // -- Resolve a custom field for placeholder testing --
   // Fetch /api/v2/customizations to find an existing field ID on the account.

--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -46,15 +46,12 @@ import {
   createSocialElement,
   createSwitch,
   createCase,
-  createCenteredSection,
-  createText,
 } from '../src';
 import type {
   BrandStyleConfig,
   RCMLBodyChild,
   RCMLColumnChild,
   RCMLProseMirrorDoc,
-  RCMLSection,
 } from '../src';
 
 // ---------------------------------------------------------------------------
@@ -551,11 +548,19 @@ function buildSectionGroups(
         ...createSwitch([
           createCase(
             { caseType: 'tag', caseCondition: 'eq', caseValue: 1 },
-            [createCenteredSection({ children: [createText('This shows when tag ID 1 matches')] }) as RCMLSection],
+            [createContentSection([
+              createBrandText(createDocWithPlaceholders([
+                createTextNode('This shows when tag ID 1 matches'),
+              ])),
+            ])],
           ),
           createCase(
             { caseType: 'default' },
-            [createCenteredSection({ children: [createText('This is the default / fallback content')] }) as RCMLSection],
+            [createContentSection([
+              createBrandText(createDocWithPlaceholders([
+                createTextNode('This is the default / fallback content'),
+              ])),
+            ])],
           ),
         ]),
         id: id(),

--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -42,12 +42,19 @@ import {
   createPlaceholder,
   createBrandLoop,
   createLoopFieldPlaceholder,
+  createSocial,
+  createSocialElement,
+  createSwitch,
+  createCase,
+  createCenteredSection,
+  createText,
 } from '../src';
 import type {
   BrandStyleConfig,
   RCMLBodyChild,
   RCMLColumnChild,
   RCMLProseMirrorDoc,
+  RCMLSection,
 } from '../src';
 
 // ---------------------------------------------------------------------------
@@ -535,6 +542,47 @@ function buildSectionGroups(
     ],
   });
 
+  // == 14. Switch / Case (conditional content)
+  groups.push({
+    num: 14, name: 'Conditional (rc-switch)',
+    sections: [
+      label('14. rc-switch / rc-case (conditional content)'),
+      {
+        ...createSwitch([
+          createCase(
+            { caseType: 'tag', caseCondition: 'eq', caseValue: 1 },
+            [createCenteredSection({ children: [createText('This shows when tag ID 1 matches')] }) as RCMLSection],
+          ),
+          createCase(
+            { caseType: 'default' },
+            [createCenteredSection({ children: [createText('This is the default / fallback content')] }) as RCMLSection],
+          ),
+        ]),
+        id: id(),
+      },
+    ],
+  });
+
+  // == 15. Social (rc-social + rc-social-element) — last before footer
+  groups.push({
+    num: 15, name: 'Social icons (rc-social)',
+    sections: [
+      label('15. rc-social / rc-social-element'),
+      section([
+        {
+          ...createSocial([
+            createSocialElement({ name: 'facebook', href: 'https://facebook.com' }),
+            createSocialElement({ name: 'instagram', href: 'https://instagram.com' }),
+            createSocialElement({ name: 'x', href: 'https://x.com' }),
+            createSocialElement({ name: 'web', href: 'https://example.com' }),
+          ], { align: 'center', iconSize: '24px' }),
+          id: id(),
+        },
+        noteText('Social icons row — facebook, instagram, x, web'),
+      ]),
+    ],
+  });
+
   return groups;
 }
 
@@ -715,6 +763,8 @@ async function create(): Promise<void> {
   console.log('  [ ] 11. Two-column 33/67 — asymmetric layout');
   console.log(`  [${repeatableField ? ' ' : '-'}] 12. Loop            — rc-loop with sub-field placeholders${repeatableField ? '' : ' (skipped — no repeatable field found)'}`);
   console.log('  [ ] 13. Video            — rc-video with thumbnail');
+  console.log('  [ ] 14. Switch/Case      — rc-switch conditional (tag + default fallback)');
+  console.log('  [ ] 15. Social           — rc-social icons row (facebook, instagram, x, web)');
   console.log('  [ ] Footer               — View in browser + Unsubscribe links');
   console.log('\nCleanup: npx tsx scripts/validate-rcml.ts --cleanup');
 }

--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -576,7 +576,7 @@ function buildSectionGroups(
   });
 
   // == 15. Social (rc-social + rc-social-element) — last before footer
-  const socialLinks = brandStyle.socialLinks && brandStyle.socialLinks.length > 0
+  const rawSocialLinks = brandStyle.socialLinks && brandStyle.socialLinks.length > 0
     ? brandStyle.socialLinks
     : [
         { name: 'facebook', href: 'https://facebook.com' },
@@ -584,24 +584,33 @@ function buildSectionGroups(
         { name: 'x', href: 'https://x.com' },
         { name: 'web', href: 'https://example.com' },
       ];
-  const socialNames = socialLinks.map(l => l.name).join(', ');
 
-  groups.push({
-    num: 15, name: 'Social icons (rc-social)',
-    sections: [
-      label('15. rc-social / rc-social-element'),
-      section([
-        {
-          ...createSocial(
-            socialLinks.map(l => ({ ...createSocialElement(l), id: id() })),
-            { align: 'center', iconSize: '24px' },
-          ),
-          id: id(),
-        },
-        noteText(`Social icons row — ${socialNames}`),
-      ]),
-    ],
+  // Filter out links with invalid/unsafe URLs (createSocialElement throws on bad hrefs)
+  const socialElements = rawSocialLinks.flatMap(l => {
+    try {
+      return [{ ...createSocialElement(l), id: id() }];
+    } catch {
+      console.warn(`  Skipping social link "${l.name}" — invalid URL: ${l.href}`);
+      return [];
+    }
   });
+
+  if (socialElements.length > 0) {
+    const socialNames = socialElements.map(el => el.attributes.name).join(', ');
+    groups.push({
+      num: 15, name: 'Social icons (rc-social)',
+      sections: [
+        label('15. rc-social / rc-social-element'),
+        section([
+          {
+            ...createSocial(socialElements, { align: 'center', iconSize: '24px' }),
+            id: id(),
+          },
+          noteText(`Social icons row — ${socialNames}`),
+        ]),
+      ],
+    });
+  }
 
   return groups;
 }
@@ -820,7 +829,7 @@ async function probe(): Promise<void> {
   const brandStyle = toBrandStyleConfig(brandStyleResponse.data);
 
   // Probe doesn't auto-detect fields — test structural validity only
-  const groups = buildSectionGroups();
+  const groups = buildSectionGroups(brandStyle);
   const results: { num: number; name: string; ok: boolean; error?: string }[] = [];
 
   console.log(`\nProbing ${groups.length} section groups individually...\n`);

--- a/scripts/validate-rcml.ts
+++ b/scripts/validate-rcml.ts
@@ -40,6 +40,8 @@ import {
   createDocWithPlaceholders,
   createTextNode,
   createPlaceholder,
+  createBrandLoop,
+  createLoopFieldPlaceholder,
 } from '../src';
 import type {
   BrandStyleConfig,
@@ -295,6 +297,7 @@ interface SectionGroup {
 
 function buildSectionGroups(
   resolvedField?: { id: number; name: string },
+  repeatableField?: { id: number; name: string },
 ): SectionGroup[] {
   const groups: SectionGroup[] = [];
 
@@ -472,14 +475,75 @@ function buildSectionGroups(
     ],
   });
 
+  // == 12. Loop — requires a repeatable custom field to iterate over
+  if (repeatableField) {
+    groups.push({
+      num: 12, name: 'Loop (rc-loop)',
+      sections: [
+        label('12. rc-loop (repeatable custom field)'),
+        createBrandLoop(
+          repeatableField.id,
+          [
+            {
+              tagName: 'rc-section',
+              id: id(),
+              attributes: { padding: '10px 0' },
+              children: [{
+                tagName: 'rc-column',
+                id: id(),
+                attributes: { padding: '0 20px' },
+                children: [
+                  createBrandText(createDocWithPlaceholders([
+                    createTextNode('Loop item: '),
+                    createLoopFieldPlaceholder('title'),
+                  ])),
+                  createBrandText(createDocWithPlaceholders([
+                    createTextNode('Value: '),
+                    createLoopFieldPlaceholder('value'),
+                  ]), { align: 'left' }),
+                ],
+              }],
+            },
+          ],
+          { maxIterations: 10 },
+        ),
+        section([
+          noteText(`(Using repeatable field "${repeatableField.name}" — ID ${repeatableField.id})`),
+        ]),
+      ],
+    });
+  }
+
+  // == 13. Video (rc-video)
+  groups.push({
+    num: 13, name: 'Video (rc-video)',
+    sections: [
+      label('13. rc-video'),
+      section([
+        {
+          tagName: 'rc-video',
+          id: id(),
+          attributes: {
+            src: 'https://placehold.co/560x315/333333/FFFFFF?text=Video+Thumbnail',
+            alt: 'SDK video test',
+            align: 'center',
+            padding: '0 0 20px 0',
+          },
+        },
+        noteText('rc-video element with placeholder thumbnail'),
+      ]),
+    ],
+  });
+
   return groups;
 }
 
 function buildShowcase(
   brandStyle: BrandStyleConfig,
   resolvedField?: { id: number; name: string },
+  repeatableField?: { id: number; name: string },
 ): RCMLBodyChild[] {
-  const allGroups = buildSectionGroups(resolvedField);
+  const allGroups = buildSectionGroups(resolvedField, repeatableField);
   const groups = onlySections
     ? allGroups.filter(g => onlySections.includes(g.num))
     : allGroups;
@@ -549,6 +613,7 @@ async function create(): Promise<void> {
   // -- Resolve a custom field for placeholder testing --
   // Fetch /api/v2/customizations to find an existing field ID on the account.
   let resolvedField: { id: number; name: string } | undefined;
+  let repeatableField: { id: number; name: string } | undefined;
 
   console.log('\nLooking up custom fields...');
   try {
@@ -570,24 +635,35 @@ async function create(): Promise<void> {
         for (const field of fields) {
           const fieldName = String(field.name ?? field.key ?? '');
           const fieldId = Number(field.id);
+          const fieldType = String(field.type ?? '');
           if (fieldId && fieldName) {
             const fullName = `${groupName}.${fieldName}`;
+
+            // Pick the first field as fallback, prefer FirstName for placeholder section
             if (!resolvedField) {
               resolvedField = { id: fieldId, name: fullName };
             }
             if (/first.?name/i.test(fieldName)) {
               resolvedField = { id: fieldId, name: fullName };
-              break;
+            }
+
+            // Look for repeatable/json fields for the loop section
+            if (!repeatableField && /json|repeatable|array|items|products/i.test(fieldType + fieldName)) {
+              repeatableField = { id: fieldId, name: fullName };
             }
           }
         }
-        if (resolvedField && /first.?name/i.test(resolvedField.name)) break;
       }
 
       if (resolvedField) {
         console.log(`  Using field: ${resolvedField.name} (ID: ${resolvedField.id})`);
       } else {
         console.log('  No parseable custom fields found — placeholder section will be skipped');
+      }
+      if (repeatableField) {
+        console.log(`  Using repeatable field: ${repeatableField.name} (ID: ${repeatableField.id})`);
+      } else {
+        console.log('  No repeatable field found — loop section will be skipped');
       }
     } else {
       const body = await custResp.text();
@@ -598,7 +674,7 @@ async function create(): Promise<void> {
   }
 
   // -- Build showcase template --
-  const sections = buildShowcase(brandStyle, resolvedField);
+  const sections = buildShowcase(brandStyle, resolvedField, repeatableField);
 
   const template = createBrandTemplate({
     brandStyle,
@@ -637,6 +713,8 @@ async function create(): Promise<void> {
   console.log('  [ ] 9.  Dividers         — solid, dashed, dotted, colored, narrow');
   console.log('  [ ] 10. Two-column 50/50 — symmetric layout');
   console.log('  [ ] 11. Two-column 33/67 — asymmetric layout');
+  console.log(`  [${repeatableField ? ' ' : '-'}] 12. Loop            — rc-loop with sub-field placeholders${repeatableField ? '' : ' (skipped — no repeatable field found)'}`);
+  console.log('  [ ] 13. Video            — rc-video with thumbnail');
   console.log('  [ ] Footer               — View in browser + Unsubscribe links');
   console.log('\nCleanup: npx tsx scripts/validate-rcml.ts --cleanup');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,10 @@ export {
   createSpacer,
   createDivider,
   createLoop,
+  createSocialElement,
+  createSocial,
+  createCase,
+  createSwitch,
 } from './rcml';
 
 // RCML option types
@@ -245,6 +249,9 @@ export type {
   CreateVideoOptions,
   CreateDividerOptions,
   CreateLoopOptions,
+  CreateSocialElementOptions,
+  CreateSocialOptions,
+  CreateCaseOptions,
 } from './rcml';
 
 // Brand template utilities

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -784,12 +784,13 @@ export function createSocialElement(options: CreateSocialElementOptions): RCMLSo
   if (!sanitizedHref) {
     throw new RuleConfigError('createSocialElement: invalid or unsafe URL for `href`');
   }
+  const sanitizedSrc = options.src ? sanitizeUrl(options.src) : '';
   return {
     tagName: 'rc-social-element',
     attributes: {
       name: options.name,
       href: sanitizedHref,
-      ...(options.src ? { src: sanitizeUrl(options.src) || undefined } : {}),
+      ...(sanitizedSrc ? { src: sanitizedSrc } : {}),
       ...(options.backgroundColor ? { 'background-color': options.backgroundColor } : {}),
     },
     ...(options.label ? { content: options.label } : {}),

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -896,11 +896,11 @@ export type CreateCaseOptions =
 /**
  * Create a conditional case element within a switch.
  *
- * Each case contains one or more sections that render when the condition matches.
+ * Each case contains exactly one section that renders when the condition matches.
  * Use `caseType: 'default'` for the fallback case.
  *
  * @param options - Condition configuration
- * @param children - Sections to render when the condition matches
+ * @param children - Single-element array containing the section to render
  *
  * @example
  * ```typescript
@@ -916,7 +916,13 @@ export type CreateCaseOptions =
  * )
  * ```
  */
-export function createCase(options: CreateCaseOptions, children: RCMLSection[]): RCMLCase {
+export function createCase(options: CreateCaseOptions, children: [RCMLSection]): RCMLCase {
+  if (children.length !== 1) {
+    throw new RuleConfigError(
+      `createCase: each rc-case must contain exactly one section, got ${children.length}`,
+    );
+  }
+
   if (options.caseType !== 'default') {
     if (!options.caseCondition) {
       throw new RuleConfigError(

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -20,6 +20,9 @@ import type {
   RCMLDivider,
   RCMLLoop,
   RCMLSwitch,
+  RCMLCase,
+  RCMLSocial,
+  RCMLSocialElement,
   RCMLBrandStyle,
   RCMLPreview,
   RCMLAttributes,
@@ -740,5 +743,195 @@ export function createVideo(src: string, options?: CreateVideoOptions): RCMLVide
       padding: options?.padding || '0 0 20px 0',
       'border-radius': options?.borderRadius,
     },
+  };
+}
+
+// ============================================================================
+// Social Elements
+// ============================================================================
+
+export interface CreateSocialElementOptions {
+  /** Social network name (e.g., 'facebook', 'instagram', 'x') */
+  name: string;
+  /** Link URL for the social profile */
+  href: string;
+  /** Custom icon URL (optional — Rule.io provides default icons) */
+  src?: string;
+  /** Icon background color */
+  backgroundColor?: string;
+  /** Optional label text displayed beside the icon */
+  label?: string;
+}
+
+/**
+ * Create a single social element (icon + link).
+ *
+ * `href` is sanitized and must be a valid http/https URL.
+ * If `options.src` is provided, it is also sanitized; invalid values are silently omitted.
+ *
+ * @throws {RuleConfigError} If `href` is not a valid http/https URL
+ *
+ * @example
+ * ```typescript
+ * createSocialElement({
+ *   name: 'facebook',
+ *   href: 'https://facebook.com/mypage',
+ * })
+ * ```
+ */
+export function createSocialElement(options: CreateSocialElementOptions): RCMLSocialElement {
+  const sanitizedHref = sanitizeUrl(options.href);
+  if (!sanitizedHref) {
+    throw new RuleConfigError('createSocialElement: invalid or unsafe URL for `href`');
+  }
+  return {
+    tagName: 'rc-social-element',
+    attributes: {
+      name: options.name,
+      href: sanitizedHref,
+      ...(options.src ? { src: sanitizeUrl(options.src) || undefined } : {}),
+      ...(options.backgroundColor ? { 'background-color': options.backgroundColor } : {}),
+    },
+    ...(options.label ? { content: options.label } : {}),
+  };
+}
+
+export interface CreateSocialOptions {
+  /** Alignment of the social icons row */
+  align?: 'left' | 'center' | 'right';
+  /** Layout mode */
+  mode?: 'horizontal' | 'vertical';
+  /** Icon size (e.g., '24px') */
+  iconSize?: string;
+  /** Padding around individual icons */
+  iconPadding?: string;
+  /** Padding around the entire social block */
+  padding?: string;
+  /** Border radius for icon backgrounds */
+  borderRadius?: string;
+  /** Icon color (applied via font color) */
+  color?: string;
+  /** Font size for labels */
+  fontSize?: string;
+  /** Font family for labels */
+  fontFamily?: string;
+}
+
+/**
+ * Create a social icons container with one or more social elements.
+ *
+ * @param elements - Array of social element children
+ * @param options - Layout and style options
+ *
+ * @example
+ * ```typescript
+ * createSocial([
+ *   createSocialElement({ name: 'facebook', href: 'https://facebook.com/mypage' }),
+ *   createSocialElement({ name: 'instagram', href: 'https://instagram.com/mypage' }),
+ *   createSocialElement({ name: 'x', href: 'https://x.com/myhandle' }),
+ * ], { align: 'center', iconSize: '24px' })
+ * ```
+ */
+export function createSocial(
+  elements: RCMLSocialElement[],
+  options?: CreateSocialOptions,
+): RCMLSocial {
+  return {
+    tagName: 'rc-social',
+    attributes: {
+      align: options?.align || 'center',
+      ...(options?.mode ? { mode: options.mode } : {}),
+      ...(options?.iconSize ? { 'icon-size': options.iconSize } : {}),
+      ...(options?.iconPadding ? { 'icon-padding': options.iconPadding } : {}),
+      ...(options?.padding ? { padding: options.padding } : {}),
+      ...(options?.borderRadius ? { 'border-radius': options.borderRadius } : {}),
+      ...(options?.color ? { color: options.color } : {}),
+      ...(options?.fontSize ? { 'font-size': options.fontSize } : {}),
+      ...(options?.fontFamily ? { 'font-family': options.fontFamily } : {}),
+    },
+    children: elements,
+  };
+}
+
+// ============================================================================
+// Switch / Case Elements (Conditional Content)
+// ============================================================================
+
+export interface CreateCaseOptions {
+  /** Case type — determines what the condition checks against */
+  caseType: 'default' | 'segment' | 'tag' | 'custom-field';
+  /** Custom field ID (required when caseType is 'custom-field') */
+  caseProperty?: number;
+  /** Condition operator (required when caseType is 'segment', 'tag', or 'custom-field') */
+  caseCondition?: 'eq' | 'ne';
+  /** Value to compare against. For segment/tag: the ID. For custom-field: the field value. */
+  caseValue?: string | number;
+  /** Whether validation is active (default: true) */
+  caseActive?: boolean;
+}
+
+/**
+ * Create a conditional case element within a switch.
+ *
+ * Each case contains one or more sections that render when the condition matches.
+ * Use `caseType: 'default'` for the fallback case.
+ *
+ * @param options - Condition configuration
+ * @param children - Sections to render when the condition matches
+ *
+ * @example
+ * ```typescript
+ * // Default fallback case
+ * createCase({ caseType: 'default' }, [
+ *   createCenteredSection({ children: [createText('Default content')] })
+ * ])
+ *
+ * // Tag-based condition
+ * createCase(
+ *   { caseType: 'tag', caseCondition: 'eq', caseValue: 42 },
+ *   [createCenteredSection({ children: [createText('VIP content')] })]
+ * )
+ * ```
+ */
+export function createCase(options: CreateCaseOptions, children: RCMLSection[]): RCMLCase {
+  return {
+    tagName: 'rc-case',
+    attributes: {
+      'case-type': options.caseType,
+      ...(options.caseProperty !== undefined ? { 'case-property': options.caseProperty } : {}),
+      ...(options.caseCondition ? { 'case-condition': options.caseCondition } : {}),
+      ...(options.caseValue !== undefined ? { 'case-value': options.caseValue } : {}),
+      ...(options.caseActive !== undefined ? { 'case-active': options.caseActive } : {}),
+    },
+    children,
+  };
+}
+
+/**
+ * Create a switch element for conditional content rendering.
+ *
+ * A switch groups multiple cases, each with a condition. Only the first
+ * matching case is rendered. Use a 'default' case as fallback.
+ *
+ * @param cases - Array of case elements (use `createCase()` to build these)
+ *
+ * @example
+ * ```typescript
+ * createSwitch([
+ *   createCase(
+ *     { caseType: 'tag', caseCondition: 'eq', caseValue: 42 },
+ *     [createCenteredSection({ children: [createText('VIP members')] })]
+ *   ),
+ *   createCase(
+ *     { caseType: 'default' },
+ *     [createCenteredSection({ children: [createText('Regular content')] })]
+ *   ),
+ * ])
+ * ```
+ */
+export function createSwitch(cases: RCMLCase[]): RCMLSwitch {
+  return {
+    tagName: 'rc-switch',
+    children: cases,
   };
 }

--- a/src/rcml/elements.ts
+++ b/src/rcml/elements.ts
@@ -857,18 +857,41 @@ export function createSocial(
 // Switch / Case Elements (Conditional Content)
 // ============================================================================
 
-export interface CreateCaseOptions {
-  /** Case type — determines what the condition checks against */
-  caseType: 'default' | 'segment' | 'tag' | 'custom-field';
-  /** Custom field ID (required when caseType is 'custom-field') */
-  caseProperty?: number;
-  /** Condition operator (required when caseType is 'segment', 'tag', or 'custom-field') */
-  caseCondition?: 'eq' | 'ne';
-  /** Value to compare against. For segment/tag: the ID. For custom-field: the field value. */
-  caseValue?: string | number;
+interface CreateDefaultCaseOptions {
+  /** Default fallback case — renders when no other case matches */
+  caseType: 'default';
   /** Whether validation is active (default: true) */
   caseActive?: boolean;
 }
+
+interface CreateSegmentOrTagCaseOptions {
+  /** Case type — determines what the condition checks against */
+  caseType: 'segment' | 'tag';
+  /** Condition operator */
+  caseCondition: 'eq' | 'ne';
+  /** Value to compare against (segment or tag ID) */
+  caseValue: string | number;
+  /** Whether validation is active (default: true) */
+  caseActive?: boolean;
+}
+
+interface CreateCustomFieldCaseOptions {
+  /** Case type — checks against a custom field value */
+  caseType: 'custom-field';
+  /** Custom field ID */
+  caseProperty: number;
+  /** Condition operator */
+  caseCondition: 'eq' | 'ne';
+  /** Value to compare against */
+  caseValue: string | number;
+  /** Whether validation is active (default: true) */
+  caseActive?: boolean;
+}
+
+export type CreateCaseOptions =
+  | CreateDefaultCaseOptions
+  | CreateSegmentOrTagCaseOptions
+  | CreateCustomFieldCaseOptions;
 
 /**
  * Create a conditional case element within a switch.
@@ -894,17 +917,41 @@ export interface CreateCaseOptions {
  * ```
  */
 export function createCase(options: CreateCaseOptions, children: RCMLSection[]): RCMLCase {
-  return {
-    tagName: 'rc-case',
-    attributes: {
-      'case-type': options.caseType,
-      ...(options.caseProperty !== undefined ? { 'case-property': options.caseProperty } : {}),
-      ...(options.caseCondition ? { 'case-condition': options.caseCondition } : {}),
-      ...(options.caseValue !== undefined ? { 'case-value': options.caseValue } : {}),
-      ...(options.caseActive !== undefined ? { 'case-active': options.caseActive } : {}),
-    },
-    children,
+  if (options.caseType !== 'default') {
+    if (!options.caseCondition) {
+      throw new RuleConfigError(
+        `createCase: caseCondition is required when caseType is '${options.caseType}'`,
+      );
+    }
+    if (options.caseValue === undefined) {
+      throw new RuleConfigError(
+        `createCase: caseValue is required when caseType is '${options.caseType}'`,
+      );
+    }
+    if (options.caseType === 'custom-field' && options.caseProperty === undefined) {
+      throw new RuleConfigError(
+        "createCase: caseProperty is required when caseType is 'custom-field'",
+      );
+    }
+  }
+
+  const attrs: RCMLCase['attributes'] = {
+    'case-type': options.caseType,
   };
+
+  if (options.caseType !== 'default') {
+    attrs['case-condition'] = options.caseCondition;
+    attrs['case-value'] = options.caseValue;
+    if (options.caseType === 'custom-field') {
+      attrs['case-property'] = options.caseProperty;
+    }
+  }
+
+  if (options.caseActive !== undefined) {
+    attrs['case-active'] = options.caseActive;
+  }
+
+  return { tagName: 'rc-case', attributes: attrs, children };
 }
 
 /**

--- a/src/rcml/index.ts
+++ b/src/rcml/index.ts
@@ -24,6 +24,10 @@ export {
   createSpacer,
   createDivider,
   createLoop,
+  createSocialElement,
+  createSocial,
+  createCase,
+  createSwitch,
 } from './elements';
 
 // Element option types
@@ -40,6 +44,9 @@ export type {
   CreateVideoOptions,
   CreateDividerOptions,
   CreateLoopOptions,
+  CreateSocialElementOptions,
+  CreateSocialOptions,
+  CreateCaseOptions,
 } from './elements';
 
 // Brand template utilities

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -867,6 +867,8 @@ describe('RCML Social Elements', () => {
 });
 
 describe('RCML Switch / Case Elements', () => {
+  const makeSection = () => createCenteredSection({ children: [createText('Content')] });
+
   describe('createCase', () => {
     it('should create a default case', () => {
       const section = createCenteredSection({ children: [createText('Fallback')] });
@@ -892,7 +894,7 @@ describe('RCML Switch / Case Elements', () => {
     it('should create a segment-based case', () => {
       const c = createCase(
         { caseType: 'segment', caseCondition: 'ne', caseValue: 99 },
-        [],
+        [makeSection()],
       );
 
       expect(c.attributes['case-type']).toBe('segment');
@@ -903,7 +905,7 @@ describe('RCML Switch / Case Elements', () => {
     it('should create a custom-field case with property', () => {
       const c = createCase(
         { caseType: 'custom-field', caseProperty: 12345, caseCondition: 'eq', caseValue: 'gold' },
-        [],
+        [makeSection()],
       );
 
       expect(c.attributes['case-type']).toBe('custom-field');
@@ -913,12 +915,12 @@ describe('RCML Switch / Case Elements', () => {
     });
 
     it('should set caseActive when provided', () => {
-      const c = createCase({ caseType: 'default', caseActive: false }, []);
+      const c = createCase({ caseType: 'default', caseActive: false }, [makeSection()]);
       expect(c.attributes['case-active']).toBe(false);
     });
 
     it('should not include optional attributes when not provided', () => {
-      const c = createCase({ caseType: 'default' }, []);
+      const c = createCase({ caseType: 'default' }, [makeSection()]);
 
       expect(c.attributes).not.toHaveProperty('case-property');
       expect(c.attributes).not.toHaveProperty('case-condition');
@@ -927,25 +929,31 @@ describe('RCML Switch / Case Elements', () => {
     });
 
     it('should not have an id (low-level builder)', () => {
-      const c = createCase({ caseType: 'default' }, []);
+      const c = createCase({ caseType: 'default' }, [makeSection()]);
       expect(c).not.toHaveProperty('id');
+    });
+
+    it('should reject empty children array', () => {
+      expect(() =>
+        createCase({ caseType: 'default' }, [] as never),
+      ).toThrow('exactly one section');
     });
 
     it('should reject tag case without caseCondition', () => {
       expect(() =>
-        createCase({ caseType: 'tag', caseCondition: undefined as never, caseValue: 1 }, []),
+        createCase({ caseType: 'tag', caseCondition: undefined as never, caseValue: 1 }, [makeSection()]),
       ).toThrow('caseCondition is required');
     });
 
     it('should reject segment case without caseValue', () => {
       expect(() =>
-        createCase({ caseType: 'segment', caseCondition: 'eq', caseValue: undefined as never }, []),
+        createCase({ caseType: 'segment', caseCondition: 'eq', caseValue: undefined as never }, [makeSection()]),
       ).toThrow('caseValue is required');
     });
 
     it('should reject custom-field case without caseProperty', () => {
       expect(() =>
-        createCase({ caseType: 'custom-field', caseProperty: undefined as never, caseCondition: 'eq', caseValue: 'x' }, []),
+        createCase({ caseType: 'custom-field', caseProperty: undefined as never, caseCondition: 'eq', caseValue: 'x' }, [makeSection()]),
       ).toThrow('caseProperty is required');
     });
   });

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -24,6 +24,10 @@ import {
   createBrandLoop,
   createLoopFieldPlaceholder,
   createVideo,
+  createSocialElement,
+  createSocial,
+  createCase,
+  createSwitch,
 } from '../src/rcml';
 import { RuleConfigError } from '../src/errors';
 import {
@@ -734,6 +738,238 @@ describe('RCML Elements', () => {
 
       expect(node.attrs.name).toBe('variant_title');
       expect(node.attrs.original).toBe('[LoopValue:variant_title]');
+    });
+  });
+});
+
+describe('RCML Social Elements', () => {
+  describe('createSocialElement', () => {
+    it('should create a social element with name and href', () => {
+      const el = createSocialElement({
+        name: 'facebook',
+        href: 'https://facebook.com/mypage',
+      });
+
+      expect(el.tagName).toBe('rc-social-element');
+      expect(el.attributes.name).toBe('facebook');
+      expect(el.attributes.href).toBe('https://facebook.com/mypage');
+    });
+
+    it('should include optional label as content', () => {
+      const el = createSocialElement({
+        name: 'instagram',
+        href: 'https://instagram.com/mypage',
+        label: 'Follow us',
+      });
+
+      expect(el.content).toBe('Follow us');
+    });
+
+    it('should not include content when label is omitted', () => {
+      const el = createSocialElement({
+        name: 'x',
+        href: 'https://x.com/handle',
+      });
+
+      expect(el).not.toHaveProperty('content');
+    });
+
+    it('should include optional src and backgroundColor', () => {
+      const el = createSocialElement({
+        name: 'custom',
+        href: 'https://example.com',
+        src: 'https://example.com/icon.png',
+        backgroundColor: '#FF0000',
+      });
+
+      expect(el.attributes.src).toBe('https://example.com/icon.png');
+      expect(el.attributes['background-color']).toBe('#FF0000');
+    });
+
+    it('should reject javascript: href', () => {
+      expect(() =>
+        createSocialElement({ name: 'x', href: 'javascript:alert(1)' })
+      ).toThrow(RuleConfigError);
+    });
+
+    it('should reject data: href', () => {
+      expect(() =>
+        createSocialElement({ name: 'x', href: 'data:text/html,<h1>xss</h1>' })
+      ).toThrow(RuleConfigError);
+    });
+
+    it('should reject invalid href', () => {
+      expect(() =>
+        createSocialElement({ name: 'x', href: 'not a valid url' })
+      ).toThrow(RuleConfigError);
+    });
+
+    it('should strip unsafe src option', () => {
+      const el = createSocialElement({
+        name: 'x',
+        href: 'https://x.com/handle',
+        src: 'javascript:alert(1)',
+      });
+      expect(el.attributes.src).toBeUndefined();
+    });
+  });
+
+  describe('createSocial', () => {
+    it('should create a social container with elements', () => {
+      const fb = createSocialElement({ name: 'facebook', href: 'https://facebook.com/page' });
+      const ig = createSocialElement({ name: 'instagram', href: 'https://instagram.com/page' });
+      const social = createSocial([fb, ig]);
+
+      expect(social.tagName).toBe('rc-social');
+      expect(social.children).toHaveLength(2);
+      expect(social.attributes?.align).toBe('center');
+    });
+
+    it('should apply default alignment', () => {
+      const social = createSocial([]);
+      expect(social.attributes?.align).toBe('center');
+    });
+
+    it('should accept layout and style options', () => {
+      const social = createSocial([], {
+        align: 'left',
+        mode: 'vertical',
+        iconSize: '32px',
+        iconPadding: '5px',
+        padding: '10px 0',
+        borderRadius: '50%',
+        color: '#333333',
+        fontSize: '12px',
+        fontFamily: 'Arial, sans-serif',
+      });
+
+      expect(social.attributes?.align).toBe('left');
+      expect(social.attributes?.mode).toBe('vertical');
+      expect(social.attributes?.['icon-size']).toBe('32px');
+      expect(social.attributes?.['icon-padding']).toBe('5px');
+      expect(social.attributes?.padding).toBe('10px 0');
+      expect(social.attributes?.['border-radius']).toBe('50%');
+      expect(social.attributes?.color).toBe('#333333');
+      expect(social.attributes?.['font-size']).toBe('12px');
+      expect(social.attributes?.['font-family']).toBe('Arial, sans-serif');
+    });
+
+    it('should not include optional attributes when not provided', () => {
+      const social = createSocial([]);
+
+      expect(social.attributes).not.toHaveProperty('mode');
+      expect(social.attributes).not.toHaveProperty('icon-size');
+      expect(social.attributes).not.toHaveProperty('icon-padding');
+      expect(social.attributes).not.toHaveProperty('padding');
+    });
+  });
+
+});
+
+describe('RCML Switch / Case Elements', () => {
+  describe('createCase', () => {
+    it('should create a default case', () => {
+      const section = createCenteredSection({ children: [createText('Fallback')] });
+      const c = createCase({ caseType: 'default' }, [section]);
+
+      expect(c.tagName).toBe('rc-case');
+      expect(c.attributes['case-type']).toBe('default');
+      expect(c.children).toHaveLength(1);
+    });
+
+    it('should create a tag-based case with condition', () => {
+      const section = createCenteredSection({ children: [createText('VIP')] });
+      const c = createCase(
+        { caseType: 'tag', caseCondition: 'eq', caseValue: 42 },
+        [section],
+      );
+
+      expect(c.attributes['case-type']).toBe('tag');
+      expect(c.attributes['case-condition']).toBe('eq');
+      expect(c.attributes['case-value']).toBe(42);
+    });
+
+    it('should create a segment-based case', () => {
+      const c = createCase(
+        { caseType: 'segment', caseCondition: 'ne', caseValue: 99 },
+        [],
+      );
+
+      expect(c.attributes['case-type']).toBe('segment');
+      expect(c.attributes['case-condition']).toBe('ne');
+      expect(c.attributes['case-value']).toBe(99);
+    });
+
+    it('should create a custom-field case with property', () => {
+      const c = createCase(
+        { caseType: 'custom-field', caseProperty: 12345, caseCondition: 'eq', caseValue: 'gold' },
+        [],
+      );
+
+      expect(c.attributes['case-type']).toBe('custom-field');
+      expect(c.attributes['case-property']).toBe(12345);
+      expect(c.attributes['case-condition']).toBe('eq');
+      expect(c.attributes['case-value']).toBe('gold');
+    });
+
+    it('should set caseActive when provided', () => {
+      const c = createCase({ caseType: 'default', caseActive: false }, []);
+      expect(c.attributes['case-active']).toBe(false);
+    });
+
+    it('should not include optional attributes when not provided', () => {
+      const c = createCase({ caseType: 'default' }, []);
+
+      expect(c.attributes).not.toHaveProperty('case-property');
+      expect(c.attributes).not.toHaveProperty('case-condition');
+      expect(c.attributes).not.toHaveProperty('case-value');
+      expect(c.attributes).not.toHaveProperty('case-active');
+    });
+
+    it('should not have an id (low-level builder)', () => {
+      const c = createCase({ caseType: 'default' }, []);
+      expect(c).not.toHaveProperty('id');
+    });
+  });
+
+  describe('createSwitch', () => {
+    it('should create a switch with cases', () => {
+      const defaultCase = createCase({ caseType: 'default' }, [
+        createCenteredSection({ children: [createText('Default')] }),
+      ]);
+      const tagCase = createCase(
+        { caseType: 'tag', caseCondition: 'eq', caseValue: 42 },
+        [createCenteredSection({ children: [createText('VIP')] })],
+      );
+      const sw = createSwitch([tagCase, defaultCase]);
+
+      expect(sw.tagName).toBe('rc-switch');
+      expect(sw.children).toHaveLength(2);
+      expect(sw.children[0].attributes['case-type']).toBe('tag');
+      expect(sw.children[1].attributes['case-type']).toBe('default');
+    });
+
+    it('should create an empty switch', () => {
+      const sw = createSwitch([]);
+
+      expect(sw.tagName).toBe('rc-switch');
+      expect(sw.children).toHaveLength(0);
+    });
+
+    it('should not have an id (low-level builder)', () => {
+      const sw = createSwitch([]);
+      expect(sw).not.toHaveProperty('id');
+    });
+
+    it('can be used as a body child in a document', () => {
+      const sw = createSwitch([
+        createCase({ caseType: 'default' }, [
+          createCenteredSection({ children: [createText('Content')] }),
+        ]),
+      ]);
+      const doc = createRCMLDocument({ sections: [sw] });
+
+      expect(doc.children[1].children).toContain(sw);
     });
   });
 });

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -930,6 +930,24 @@ describe('RCML Switch / Case Elements', () => {
       const c = createCase({ caseType: 'default' }, []);
       expect(c).not.toHaveProperty('id');
     });
+
+    it('should reject tag case without caseCondition', () => {
+      expect(() =>
+        createCase({ caseType: 'tag', caseCondition: undefined as never, caseValue: 1 }, []),
+      ).toThrow('caseCondition is required');
+    });
+
+    it('should reject segment case without caseValue', () => {
+      expect(() =>
+        createCase({ caseType: 'segment', caseCondition: 'eq', caseValue: undefined as never }, []),
+      ).toThrow('caseValue is required');
+    });
+
+    it('should reject custom-field case without caseProperty', () => {
+      expect(() =>
+        createCase({ caseType: 'custom-field', caseProperty: undefined as never, caseCondition: 'eq', caseValue: 'x' }, []),
+      ).toThrow('caseProperty is required');
+    });
   });
 
   describe('createSwitch', () => {

--- a/tests/rcml.test.ts
+++ b/tests/rcml.test.ts
@@ -804,13 +804,13 @@ describe('RCML Social Elements', () => {
       ).toThrow(RuleConfigError);
     });
 
-    it('should strip unsafe src option', () => {
+    it('should strip unsafe src option (key omitted, not undefined)', () => {
       const el = createSocialElement({
         name: 'x',
         href: 'https://x.com/handle',
         src: 'javascript:alert(1)',
       });
-      expect(el.attributes.src).toBeUndefined();
+      expect(el.attributes).not.toHaveProperty('src');
     });
   });
 


### PR DESCRIPTION
## Summary

- **#79** — Add `createSocial()` / `createSocialElement()` builders with URL sanitization for `href` and `src`
- **#80** — Add `createSwitch()` / `createCase()` builders for conditional content (tag, segment, custom-field, default)
- **#83** — Add rc-loop section (12) to validation script using `createBrandLoop` + `createLoopFieldPlaceholder`
- **#82** — Add rc-video section (13) to validation script; commented on issue (waiting on API developer feedback)

Closes #79, closes #80, closes #83. Relates to #82.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run test` — 427 tests pass (23 new tests for social + switch/case)
- [x] `npm run lint` — 0 errors
- [ ] Run `npx tsx scripts/validate-rcml.ts` to verify loop + video sections render in editor
- [ ] Verify social elements work as column children in a template

🤖 Generated with [Claude Code](https://claude.com/claude-code)