### PR TITLE
feat: add Shopify order cancellation automation

### DIFF
--- a/src/vendors/shopify/automations.ts
+++ b/src/vendors/shopify/automations.ts
@@ -15,6 +15,7 @@ import {
   createOrderConfirmationEmail,
   createShippingUpdateEmail,
   createAbandonedCartEmail,
+  createOrderCancellationEmail,
 } from '../../rcml';
 
 /** Default English text for Shopify order confirmation emails. */
@@ -47,6 +48,17 @@ const SHIPPING_UPDATE_TEXT = {
   taxLabel: 'Tax',
   totalLabel: 'Total',
   legalText: 'This email serves as your official receipt for this transaction.',
+} as const;
+
+/** Default English text for Shopify order cancellation emails. */
+const ORDER_CANCELLATION_TEXT = {
+  preheader: 'Your order has been cancelled',
+  heading: 'Order Cancelled',
+  greeting: 'Hi',
+  message: 'Your order has been cancelled. If you have any questions, please contact us.',
+  orderRefLabel: 'Order',
+  followUp: 'We hope to see you again soon.',
+  ctaButton: 'Visit Store',
 } as const;
 
 /** Default English text for Shopify abandoned cart emails. */
@@ -145,13 +157,33 @@ export function createShopifyAutomations(): VendorAutomation[] {
         }),
     },
     {
+      id: 'shopify-order-cancellation',
+      name: 'Shopify Order Cancellation',
+      description: 'Sent when a Shopify order is cancelled',
+      triggerTag: SHOPIFY_TAGS.orderCancelled,
+      subject: 'Your Order Has Been Cancelled',
+      preheader: ORDER_CANCELLATION_TEXT.preheader,
+      templateBuilder: (config: VendorConsumerConfig) =>
+        createOrderCancellationEmail({
+          brandStyle: config.brandStyle,
+          customFields: config.customFields,
+          websiteUrl: config.websiteUrl,
+          footer: config.footer,
+          text: ORDER_CANCELLATION_TEXT,
+          fieldNames: {
+            firstName: SHOPIFY_FIELDS.firstName,
+            orderRef: SHOPIFY_FIELDS.orderNumber,
+          },
+        }),
+    },
+    {
       id: 'shopify-abandoned-cart',
       name: 'Shopify Abandoned Cart',
       description: 'Sent when a cart is abandoned after a delay',
       triggerTag: SHOPIFY_TAGS.cartInProgress,
       delayInSeconds: '3600',
       conditions: {
-        notHasTag: [SHOPIFY_TAGS.orderCompleted],
+        notHasTag: [SHOPIFY_TAGS.orderCompleted, SHOPIFY_TAGS.orderCancelled],
       },
       subject: 'You Left Something Behind!',
       preheader: ABANDONED_CART_TEXT.preheader,

--- a/src/vendors/shopify/preset.ts
+++ b/src/vendors/shopify/preset.ts
@@ -103,7 +103,8 @@ function resolveAutomations(config: VendorConsumerConfig): AutomationConfigV2[] 
  * Shopify vendor preset for Rule.io.
  *
  * Provides pre-configured automations for the standard Shopify e-commerce
- * flows: order confirmation, shipping update, and abandoned cart.
+ * flows: order confirmation, shipping update, order cancellation, and
+ * abandoned cart.
  */
 export const shopifyPreset: VendorPreset<ShopifyFieldSchema, ShopifyTagSchema> = {
   vendor: 'shopify',

--- a/src/vendors/shopify/tags.ts
+++ b/src/vendors/shopify/tags.ts
@@ -24,6 +24,7 @@ export const SHOPIFY_TAGS = {
   cartInProgress: 'CartInProgress',
   orderCompleted: 'OrderCompleted',
   orderShipped: 'OrderShipped',
+  orderCancelled: 'OrderCancelled',
   newsletter: 'Newsletter',
 } as const satisfies VendorTagSchema;
 

--- a/tests/vendors/shopify.test.ts
+++ b/tests/vendors/shopify.test.ts
@@ -136,9 +136,9 @@ describe('shopifyPreset', () => {
   // ============================================================================
 
   describe('getAutomations', () => {
-    it('returns 3 automations', () => {
+    it('returns 4 automations', () => {
       const automations = shopifyPreset.getAutomations(TEST_CONFIG);
-      expect(automations).toHaveLength(3);
+      expect(automations).toHaveLength(4);
     });
 
     it('returns automations with unique IDs', () => {
@@ -264,12 +264,34 @@ describe('shopifyPreset', () => {
       expect(json).toContain('official receipt');
     });
 
+    it('order cancellation produces valid RCML with field placeholders', () => {
+      const automations = shopifyPreset.getAutomations(TEST_CONFIG);
+      const cancellation = automations.find(
+        (a) => a.id === 'shopify-order-cancellation'
+      )!;
+
+      expect(cancellation).toBeDefined();
+      expect(cancellation.triggerTag).toBe(SHOPIFY_TAGS.orderCancelled);
+
+      const doc = cancellation.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://myshop.example.com',
+      });
+      assertValidRCMLDocument(doc);
+
+      const json = JSON.stringify(doc);
+      expect(json).toContain('[CustomField:200001]'); // firstName
+      expect(json).toContain('[CustomField:200003]'); // orderNumber
+    });
+
     it('abandoned cart has delay and conditions', () => {
       const automations = shopifyPreset.getAutomations(TEST_CONFIG);
       const abandonedCart = automations.find((a) => a.id === 'shopify-abandoned-cart')!;
 
       expect(abandonedCart.delayInSeconds).toBe('3600');
       expect(abandonedCart.conditions?.notHasTag).toContain(SHOPIFY_TAGS.orderCompleted);
+      expect(abandonedCart.conditions?.notHasTag).toContain(SHOPIFY_TAGS.orderCancelled);
     });
   });
 
@@ -319,7 +341,7 @@ describe('SHOPIFY_TAGS', () => {
     }
   });
 
-  it('has 4 tags', () => {
-    expect(Object.keys(SHOPIFY_TAGS)).toHaveLength(4);
+  it('has 5 tags', () => {
+    expect(Object.keys(SHOPIFY_TAGS)).toHaveLength(5);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `OrderCancelled` tag to `SHOPIFY_TAGS`
- Wires up `createOrderCancellationEmail` as a new Shopify preset automation with default English text
- Adds `OrderCancelled` to abandoned cart's `notHasTag` condition so cancelled orders suppress cart reminders

## Test plan
- [x] Type-check passes
- [x] All 405 tests pass (24 Shopify-specific)
- [x] New test validates RCML structure and field placeholders for the cancellation automation
- [x] Updated count assertions for tags (4→5) and automations (3→4)
- [x] Verified abandoned cart condition test includes `orderCancelled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)