### PR TITLE
feat: add standalone welcome email template

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,11 @@ export type {
   OrderCancellationConfig,
 } from './rcml';
 
+// Generic templates (vertical-agnostic)
+export { createWelcomeEmail } from './rcml';
+
+export type { WelcomeEmailConfig } from './rcml';
+
 // Automation configurations
 export {
   getAutomationByIdV2,

--- a/src/rcml/generic-templates.ts
+++ b/src/rcml/generic-templates.ts
@@ -1,0 +1,233 @@
+/**
+ * Generic Email Templates
+ *
+ * Vertical-agnostic templates that fit any business — newsletters,
+ * onboarding, transactional notifications — without e-commerce or
+ * hospitality-specific structure.
+ *
+ * All text and configuration must be provided by the consumer —
+ * no hardcoded defaults for any specific business.
+ */
+
+import type { RCMLBodyChild, RCMLColumnChild, RCMLDocument, RCMLText } from '../types';
+import {
+  createBrandTemplate,
+  createBrandHeading,
+  createBrandText,
+  createContentSection,
+  createFooterSection,
+  createTextNode,
+  createDocWithPlaceholders,
+  createLogoSection,
+  createGreetingSection,
+  createCtaSection,
+  type BrandStyleConfig,
+  type CustomFieldMap,
+  type FooterConfig,
+  validateCustomFields,
+  withTemplateContext,
+} from './brand-template';
+import { createDivider, createSocial, createSocialElement } from './elements';
+
+function dividerSection(): RCMLBodyChild {
+  return createContentSection([createDivider({ padding: '10px 0' })], { padding: '0' });
+}
+
+// ============================================================================
+// Welcome Email Template
+// ============================================================================
+
+export interface WelcomeEmailConfig {
+  brandStyle: BrandStyleConfig;
+  customFields: CustomFieldMap;
+  websiteUrl: string;
+  footer?: FooterConfig;
+  text: {
+    preheader: string;
+    /** Hero heading rendered on the brand-color banner (e.g. "Welcome!") */
+    heading: string;
+    greeting: string;
+    intro: string;
+    ctaButton: string;
+    /** Optional heading above the benefits / value-prop list */
+    benefitsHeading?: string;
+    /**
+     * Optional list of benefit bullets rendered as individual rows.
+     * Each entry is rendered verbatim as plain text.
+     */
+    benefits?: string[];
+    /** Optional heading above the welcome discount callout */
+    discountHeading?: string;
+    /** Optional explanatory text above the discount code (e.g. "Use at checkout") */
+    discountMessage?: string;
+    /**
+     * Optional static discount/promo code. Rendered verbatim — this is a
+     * fixed welcome code shared with all new subscribers, not a merge field.
+     */
+    discountCode?: string;
+    /** Optional closing / sign-off paragraph rendered after the CTA */
+    closing?: string;
+  };
+  fieldNames: {
+    firstName: string;
+  };
+}
+
+/**
+ * Create a welcome email template for new subscribers.
+ *
+ * Typical trigger: a subscriber opts into the newsletter or signs up for
+ * an account. Renders a hero banner, a personalized greeting, optional
+ * benefits list, optional welcome discount callout, a CTA button, and
+ * social icons when `brandStyle.socialLinks` is configured.
+ *
+ * Vertical-agnostic — pair with any trigger tag (newsletter signup,
+ * account creation, form submission, etc.).
+ *
+ * @example
+ * ```typescript
+ * const email = createWelcomeEmail({
+ *   brandStyle: myBrandStyle,
+ *   customFields: { 'Subscriber.FirstName': 169233 },
+ *   websiteUrl: 'https://example.com',
+ *   text: {
+ *     preheader: 'Welcome to the family!',
+ *     heading: 'Welcome!',
+ *     greeting: 'Hi',
+ *     intro: "Thanks for subscribing. We're glad to have you.",
+ *     ctaButton: 'Learn More',
+ *   },
+ *   fieldNames: { firstName: 'Subscriber.FirstName' },
+ * });
+ * ```
+ */
+export function createWelcomeEmail(config: WelcomeEmailConfig): RCMLDocument {
+  const templateName = 'createWelcomeEmail';
+
+  return withTemplateContext(templateName, () => {
+    const { brandStyle, customFields, fieldNames, text } = config;
+
+    validateCustomFields(customFields, {
+      firstName: fieldNames.firstName,
+    });
+
+    const socialLinks = brandStyle.socialLinks ?? [];
+    const socialElements = socialLinks
+      .map((link) => {
+        try {
+          return createSocialElement({ name: link.name, href: link.href });
+        } catch {
+          return undefined;
+        }
+      })
+      .filter((el): el is NonNullable<typeof el> => !!el);
+    const hasSocial = socialElements.length > 0;
+
+    const sections: RCMLBodyChild[] = [
+      ...createLogoSection(brandStyle.logoUrl),
+
+      // Hero banner — brand background
+      createContentSection(
+        [createBrandHeading(createDocWithPlaceholders([createTextNode(text.heading)]), 1)],
+        { padding: '20px 0', backgroundColor: brandStyle.brandColor }
+      ),
+
+      dividerSection(),
+
+      createGreetingSection(
+        text.greeting,
+        text.intro,
+        fieldNames.firstName,
+        customFields[fieldNames.firstName]
+      ),
+    ];
+
+    const benefits = text.benefits ?? [];
+    if (benefits.length > 0) {
+      sections.push(dividerSection());
+      const benefitRows: RCMLText[] = [];
+      if (text.benefitsHeading) {
+        benefitRows.push(
+          createBrandText(
+            createDocWithPlaceholders([createTextNode(text.benefitsHeading)]),
+            { align: 'center' }
+          )
+        );
+      }
+      for (const benefit of benefits) {
+        benefitRows.push(
+          createBrandText(
+            createDocWithPlaceholders([createTextNode(`• ${benefit}`)]),
+            { align: 'center' }
+          )
+        );
+      }
+      sections.push(createContentSection(benefitRows, { padding: '20px 0' }));
+    }
+
+    if (text.discountCode) {
+      sections.push(dividerSection());
+      const discountRows: RCMLColumnChild[] = [];
+      if (text.discountHeading) {
+        discountRows.push(
+          createBrandHeading(
+            createDocWithPlaceholders([createTextNode(text.discountHeading)]),
+            2
+          )
+        );
+      }
+      if (text.discountMessage) {
+        discountRows.push(
+          createBrandText(
+            createDocWithPlaceholders([createTextNode(text.discountMessage)]),
+            { align: 'center' }
+          )
+        );
+      }
+      discountRows.push(
+        createBrandHeading(
+          createDocWithPlaceholders([createTextNode(text.discountCode)]),
+          2
+        )
+      );
+      sections.push(
+        createContentSection(discountRows, {
+          padding: '20px 0',
+          backgroundColor: brandStyle.brandColor,
+        })
+      );
+    }
+
+    sections.push(createCtaSection(text.ctaButton, config.websiteUrl));
+
+    if (text.closing) {
+      sections.push(
+        createContentSection(
+          [
+            createBrandText(
+              createDocWithPlaceholders([createTextNode(text.closing)]),
+              { align: 'center' }
+            ),
+          ],
+          { padding: '10px 0' }
+        )
+      );
+    }
+
+    if (hasSocial) {
+      sections.push(
+        createContentSection([createSocial(socialElements, { align: 'center' })], {
+          padding: '10px 0',
+        })
+      );
+    }
+
+    sections.push(createFooterSection(config.footer));
+
+    return createBrandTemplate({
+      brandStyle: brandStyle,
+      preheader: text.preheader,
+      sections,
+    });
+  });
+}

--- a/src/rcml/generic-templates.ts
+++ b/src/rcml/generic-templates.ts
@@ -7,6 +7,10 @@
  *
  * All text and configuration must be provided by the consumer —
  * no hardcoded defaults for any specific business.
+ *
+ * Note: The footer section defaults to English link text ("View in browser",
+ * "Unsubscribe") when no `footer` config is provided. Pass a `footer` object
+ * to override with your own locale.
  */
 
 import type { RCMLBodyChild, RCMLColumnChild, RCMLDocument, RCMLText } from '../types';

--- a/src/rcml/index.ts
+++ b/src/rcml/index.ts
@@ -121,3 +121,8 @@ export type {
   AbandonedCartConfig,
   OrderCancellationConfig,
 } from './ecommerce-templates';
+
+// Generic templates (vertical-agnostic)
+export { createWelcomeEmail } from './generic-templates';
+
+export type { WelcomeEmailConfig } from './generic-templates';

--- a/src/vendors/shopify/automations.ts
+++ b/src/vendors/shopify/automations.ts
@@ -16,6 +16,7 @@ import {
   createShippingUpdateEmail,
   createAbandonedCartEmail,
   createOrderCancellationEmail,
+  createWelcomeEmail,
 } from '../../rcml';
 
 /** Default English text for Shopify order confirmation emails. */
@@ -75,6 +76,16 @@ const ORDER_CANCELLATION_TEXT = {
   orderDateLabel: 'Order date',
   followUp: 'We hope to see you again soon.',
   ctaButton: 'Visit Store',
+} as const;
+
+/** Default English text for Shopify newsletter welcome emails. */
+const WELCOME_TEXT = {
+  preheader: 'Welcome!',
+  heading: 'Welcome!',
+  greeting: 'Hi',
+  intro: "Thanks for joining our newsletter. We're glad to have you on board.",
+  ctaButton: 'Learn More',
+  closing: "We'll be in touch with news and updates.",
 } as const;
 
 /** Default English text for Shopify abandoned cart emails. */
@@ -225,6 +236,25 @@ export function createShopifyAutomations(): VendorAutomation[] {
             ...(config.customFields[SHOPIFY_FIELDS.orderDate] !== undefined && {
               orderDate: SHOPIFY_FIELDS.orderDate,
             }),
+          },
+        }),
+    },
+    {
+      id: 'shopify-welcome',
+      name: 'Shopify Welcome',
+      description: 'Sent when a subscriber joins the newsletter',
+      triggerTag: SHOPIFY_TAGS.newsletter,
+      subject: 'Welcome!',
+      preheader: WELCOME_TEXT.preheader,
+      templateBuilder: (config: VendorConsumerConfig) =>
+        createWelcomeEmail({
+          brandStyle: config.brandStyle,
+          customFields: config.customFields,
+          websiteUrl: config.websiteUrl,
+          footer: config.footer,
+          text: WELCOME_TEXT,
+          fieldNames: {
+            firstName: SHOPIFY_FIELDS.firstName,
           },
         }),
     },

--- a/src/vendors/shopify/automations.ts
+++ b/src/vendors/shopify/automations.ts
@@ -1,9 +1,11 @@
 /**
  * Shopify Automation Definitions
  *
- * Pre-configured automations for Shopify e-commerce flows.
- * Each automation wires Shopify-specific field names and default
- * English text into the generic e-commerce template builders.
+ * Pre-configured automations for Shopify order flows plus a newsletter
+ * welcome. Each automation wires Shopify-specific field names and default
+ * English text into the generic template builders — e-commerce templates
+ * for the order flows, and the vertical-agnostic welcome template for the
+ * newsletter signup.
  *
  * @see https://help.rule.io/en/articles/349484-shopify-integration
  */
@@ -106,7 +108,8 @@ const ABANDONED_CART_TEXT = {
  * Create the full set of Shopify automation definitions.
  *
  * Each automation returns a {@link VendorAutomation} that delegates to
- * the generic e-commerce template builders with Shopify field names
+ * the appropriate generic template builder (e-commerce for order flows,
+ * vertical-agnostic for the newsletter welcome) with Shopify field names
  * and default English text.
  */
 export function createShopifyAutomations(): VendorAutomation[] {

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -33,6 +33,7 @@ import {
   createShippingUpdateEmail,
   createAbandonedCartEmail,
   createOrderCancellationEmail,
+  createWelcomeEmail,
   createDefaultContentSection,
 } from '../src/rcml';
 import { TEST_BRAND_STYLE, assertValidRCMLDocument, docToString } from './helpers';
@@ -2631,6 +2632,172 @@ describe('E-commerce Templates', () => {
         })
       ).toThrow(RuleConfigError);
     });
+  });
+});
+
+// ============================================================================
+// Welcome Email
+// ============================================================================
+
+describe('createWelcomeEmail', () => {
+  it('produces valid RCML with hero + greeting + CTA', () => {
+    const doc = createWelcomeEmail({
+      brandStyle: TEST_BRAND_STYLE,
+      customFields: TEST_CUSTOM_FIELDS,
+      websiteUrl: 'https://shop.example.com',
+      text: {
+        preheader: 'Welcome aboard',
+        heading: 'Welcome!',
+        greeting: 'Hi',
+        intro: 'Thanks for subscribing to our newsletter.',
+        ctaButton: 'Start Shopping',
+      },
+      fieldNames: { firstName: 'Subscriber.FirstName' },
+    });
+
+    assertValidRCMLDocument(doc);
+    const json = docToString(doc);
+    expect(json).toContain('Welcome!');
+    expect(json).toContain('Thanks for subscribing');
+    expect(json).toContain('Start Shopping');
+    expect(json).toContain('https://shop.example.com');
+    expect(json).toContain('[CustomField:200001]'); // Subscriber.FirstName
+  });
+
+  it('renders benefits list when benefits array is provided', () => {
+    const doc = createWelcomeEmail({
+      brandStyle: TEST_BRAND_STYLE,
+      customFields: TEST_CUSTOM_FIELDS,
+      websiteUrl: 'https://shop.example.com',
+      text: {
+        preheader: 'Welcome',
+        heading: 'Welcome!',
+        greeting: 'Hi',
+        intro: 'Glad you are here.',
+        ctaButton: 'Shop',
+        benefitsHeading: 'What you get',
+        benefits: ['Free shipping over $50', 'Early access to sales', 'Members-only perks'],
+      },
+      fieldNames: { firstName: 'Subscriber.FirstName' },
+    });
+
+    const json = docToString(doc);
+    expect(json).toContain('What you get');
+    expect(json).toContain('Free shipping over $50');
+    expect(json).toContain('Early access to sales');
+    expect(json).toContain('Members-only perks');
+  });
+
+  it('renders discount callout when discountCode is supplied', () => {
+    const doc = createWelcomeEmail({
+      brandStyle: TEST_BRAND_STYLE,
+      customFields: TEST_CUSTOM_FIELDS,
+      websiteUrl: 'https://shop.example.com',
+      text: {
+        preheader: 'Welcome',
+        heading: 'Welcome!',
+        greeting: 'Hi',
+        intro: 'Here is a gift.',
+        ctaButton: 'Shop',
+        discountHeading: 'Your welcome gift',
+        discountMessage: 'Use code at checkout',
+        discountCode: 'WELCOME10',
+      },
+      fieldNames: { firstName: 'Subscriber.FirstName' },
+    });
+
+    const json = docToString(doc);
+    expect(json).toContain('Your welcome gift');
+    expect(json).toContain('Use code at checkout');
+    expect(json).toContain('WELCOME10');
+  });
+
+  it('renders social icons when brandStyle.socialLinks is provided', () => {
+    const doc = createWelcomeEmail({
+      brandStyle: {
+        ...TEST_BRAND_STYLE,
+        socialLinks: [
+          { name: 'facebook', href: 'https://facebook.com/shop' },
+          { name: 'instagram', href: 'https://instagram.com/shop' },
+        ],
+      },
+      customFields: TEST_CUSTOM_FIELDS,
+      websiteUrl: 'https://shop.example.com',
+      text: {
+        preheader: 'Welcome',
+        heading: 'Welcome!',
+        greeting: 'Hi',
+        intro: 'Glad you are here.',
+        ctaButton: 'Shop',
+      },
+      fieldNames: { firstName: 'Subscriber.FirstName' },
+    });
+
+    const json = docToString(doc);
+    expect(json).toContain('rc-social');
+    expect(json).toContain('facebook');
+    expect(json).toContain('instagram');
+  });
+
+  it('omits optional sections when not configured', () => {
+    const doc = createWelcomeEmail({
+      brandStyle: TEST_BRAND_STYLE,
+      customFields: TEST_CUSTOM_FIELDS,
+      websiteUrl: 'https://shop.example.com',
+      text: {
+        preheader: 'Welcome',
+        heading: 'Welcome!',
+        greeting: 'Hi',
+        intro: 'Glad you are here.',
+        ctaButton: 'Shop',
+      },
+      fieldNames: { firstName: 'Subscriber.FirstName' },
+    });
+
+    const json = docToString(doc);
+    expect(json).not.toContain('rc-social');
+    expect(json).not.toContain('WELCOME10');
+    expect(json).not.toContain('•');
+  });
+
+  it('throws RuleConfigError when firstName field is not in customFields', () => {
+    expect(() =>
+      createWelcomeEmail({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://shop.example.com',
+        text: {
+          preheader: 'Welcome',
+          heading: 'Welcome!',
+          greeting: 'Hi',
+          intro: 'Glad you are here.',
+          ctaButton: 'Shop',
+        },
+        fieldNames: { firstName: 'Subscriber.UnmappedFirstName' },
+      })
+    ).toThrow(RuleConfigError);
+  });
+
+  it('wraps config errors with template context', () => {
+    try {
+      createWelcomeEmail({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://shop.example.com',
+        text: {
+          preheader: 'Welcome',
+          heading: 'Welcome!',
+          greeting: 'Hi',
+          intro: 'Glad you are here.',
+          ctaButton: 'Shop',
+        },
+        fieldNames: { firstName: 'Subscriber.UnmappedFirstName' },
+      });
+      throw new Error('expected createWelcomeEmail to throw');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(RuleConfigError);
+      expect((error as Error).message).toMatch(/createWelcomeEmail/);
+    }
   });
 });
 

--- a/tests/vendors/shopify.test.ts
+++ b/tests/vendors/shopify.test.ts
@@ -306,7 +306,10 @@ describe('shopifyPreset', () => {
       expect(json).toContain('https://myshop.example.com');
     });
 
-    it('welcome automation builds with minimal config (only firstName mapped)', () => {
+    it('welcome automation builds with the preset-required fields only', () => {
+      // shopifyPreset.validateConfig requires firstName + orderNumber +
+      // totalPrice — orderNumber and totalPrice are for the order-flow
+      // automations; the welcome template itself only uses firstName.
       const minimal: VendorConsumerConfig = {
         brandStyle: TEST_BRAND_STYLE,
         customFields: {

--- a/tests/vendors/shopify.test.ts
+++ b/tests/vendors/shopify.test.ts
@@ -136,9 +136,9 @@ describe('shopifyPreset', () => {
   // ============================================================================
 
   describe('getAutomations', () => {
-    it('returns 4 automations', () => {
+    it('returns 5 automations', () => {
       const automations = shopifyPreset.getAutomations(TEST_CONFIG);
-      expect(automations).toHaveLength(4);
+      expect(automations).toHaveLength(5);
     });
 
     it('returns automations with unique IDs', () => {
@@ -283,6 +283,43 @@ describe('shopifyPreset', () => {
       const json = JSON.stringify(doc);
       expect(json).toContain('[CustomField:200001]'); // firstName
       expect(json).toContain('[CustomField:200003]'); // orderNumber
+    });
+
+    it('welcome automation uses newsletter trigger tag', () => {
+      const automations = shopifyPreset.getAutomations(TEST_CONFIG);
+      const welcome = automations.find((a) => a.id === 'shopify-welcome');
+
+      expect(welcome).toBeDefined();
+      expect(welcome!.triggerTag).toBe(SHOPIFY_TAGS.newsletter);
+      expect(welcome!.delayInSeconds).toBeUndefined();
+
+      const doc = welcome!.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://myshop.example.com',
+      });
+      assertValidRCMLDocument(doc);
+
+      const json = JSON.stringify(doc);
+      expect(json).toContain('Welcome!');
+      expect(json).toContain('[CustomField:200001]'); // Subscriber.FirstName
+      expect(json).toContain('https://myshop.example.com');
+    });
+
+    it('welcome automation builds with minimal config (only firstName mapped)', () => {
+      const minimal: VendorConsumerConfig = {
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: {
+          [SHOPIFY_FIELDS.firstName]: 1,
+          [SHOPIFY_FIELDS.orderNumber]: 2,
+          [SHOPIFY_FIELDS.totalPrice]: 3,
+        },
+        websiteUrl: 'https://myshop.example.com',
+      };
+      const welcome = shopifyPreset.getAutomations(minimal).find(
+        (a) => a.id === 'shopify-welcome'
+      )!;
+      expect(() => welcome.templateBuilder(minimal)).not.toThrow();
     });
 
     it('abandoned cart has delay and conditions', () => {


### PR DESCRIPTION
## Summary

- Adds `createWelcomeEmail` as a vertical-agnostic template in a new `src/rcml/generic-templates.ts` module, separate from e-commerce so non-Shopify consumers can wire it to any newsletter or onboarding trigger without pulling in order-flow machinery.
- Shopify preset keeps `shopify-welcome` (triggered on the `Newsletter` tag) with generic default text — `Learn More` CTA rather than store-specific copy — so Shopify customers still get a welcome flow out of the box via `scripts/deploy-shopify.ts`.
- Optional sections: benefits bullet list, welcome discount callout, closing paragraph, social icons (rendered only when `brandStyle.socialLinks` is configured).

## Test plan

- [x] `npm run type-check` passes
- [x] `npm test` — 478 passed, 50 skipped (integration tests gated behind `RULE_API_KEY`)
- [x] 7 new template tests in `tests/templates.test.ts`: valid RCML, benefits rendering, discount callout, social icons, optional-section omission, missing-field rejection, error-wrapping
- [x] 2 new Shopify preset tests: newsletter trigger tag wiring + minimal-config build
- [x] Manually deployed to test account and rendered in Rule.io editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)