### PR TITLE
feat: add Samfora vendor preset for Swedish donation flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for Swedish charitable-donation flows: donation confirmation (first-time,
   second-time, returning donors — gated by donor-lifecycle tags), monthly
   donation confirmation, welcome, and annual tax summary. Default copy ships
-  in Swedish.
+  in Swedish. Donor identity lives on the flat `Subscriber.*` group,
+  per-donation event data on the historical `Donation.*` group, per
+  Rule.io field-group praxis.
 - `scripts/deploy-samfora.ts` — reference deployment script that resolves
   the account's preferred brand style via `is_default: true` from
   `listBrandStyles()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Samfora vendor preset (`samforaPreset`, `SAMFORA_FIELDS`, `SAMFORA_TAGS`)
+  for Swedish charitable-donation flows: donation confirmation (first-time,
+  second-time, returning donors — gated by donor-lifecycle tags), monthly
+  donation confirmation, welcome, and annual tax summary. Default copy ships
+  in Swedish.
+- `scripts/deploy-samfora.ts` — reference deployment script that resolves
+  the account's preferred brand style via `is_default: true` from
+  `listBrandStyles()`.
+
 ## [0.3.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -313,6 +313,33 @@ const config = {
 const automations = bookzenPreset.getAutomations(config);
 ```
 
+### Samfora (Donation)
+
+Swedish charitable-giving preset. Default email copy ships in Swedish.
+Three donation-confirmation variants are gated by donor-lifecycle tags
+(`donor-first-gift`, `donor-second-gift`, `donor-returning`) so first-time,
+second-time, and loyal donors see different wording.
+
+```typescript
+import { samforaPreset, SAMFORA_FIELDS } from 'rule-io-sdk';
+
+const config = {
+  brandStyle: myBrand,
+  customFields: {
+    [SAMFORA_FIELDS.donorFirstName]: 200001,
+    [SAMFORA_FIELDS.donationAmount]: 200002,
+    [SAMFORA_FIELDS.donationDate]: 200003,
+    [SAMFORA_FIELDS.donationRef]: 200004,
+    [SAMFORA_FIELDS.causeName]: 200005,
+    // Optional: donationCurrency, totalLifetimeAmount, taxYear,
+    // taxDeductibleAmount (required only for the tax-summary automation)
+  },
+  websiteUrl: 'https://samfora.org',
+};
+
+const automations = samforaPreset.getAutomations(config);
+```
+
 Each preset provides `getAutomations()`, `getAutomation(id, config)`, `validateConfig()`, and `getRequiredFields()`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -326,13 +326,16 @@ import { samforaPreset, SAMFORA_FIELDS } from 'rule-io-sdk';
 const config = {
   brandStyle: myBrand,
   customFields: {
+    // Required for every automation the preset returns
     [SAMFORA_FIELDS.donorFirstName]: 200001,
     [SAMFORA_FIELDS.donationAmount]: 200002,
     [SAMFORA_FIELDS.donationDate]: 200003,
     [SAMFORA_FIELDS.donationRef]: 200004,
     [SAMFORA_FIELDS.causeName]: 200005,
-    // Optional: donationCurrency, totalLifetimeAmount, taxYear,
-    // taxDeductibleAmount (required only for the tax-summary automation)
+    [SAMFORA_FIELDS.totalLifetimeAmount]: 200006,
+    [SAMFORA_FIELDS.taxYear]: 200007,
+    [SAMFORA_FIELDS.taxDeductibleAmount]: 200008,
+    // Optional: donationCurrency, donationType
   },
   websiteUrl: 'https://samfora.org',
 };

--- a/README.md
+++ b/README.md
@@ -320,14 +320,20 @@ Three donation-confirmation variants are gated by donor-lifecycle tags
 (`donor-first-gift`, `donor-second-gift`, `donor-returning`) so first-time,
 second-time, and loyal donors see different wording.
 
+Samfora uses Rule.io's standard Subscriber fields (`Subscriber.FirstName`,
+`Subscriber.LastName`, `Subscriber.Address1`, etc.) rather than creating
+new custom ones — those fields already exist on every account. Per-donation
+data lives on a historical `Donation.*` group.
+
 ```typescript
 import { samforaPreset, SAMFORA_FIELDS } from 'rule-io-sdk';
 
 const config = {
   brandStyle: myBrand,
   customFields: {
-    // Required for every automation the preset returns
-    [SAMFORA_FIELDS.donorFirstName]: 200001,
+    // Required: standard Subscriber field for the greeting
+    [SAMFORA_FIELDS.donorFirstName]: 47736,
+    // Required: historical Donation.* group
     [SAMFORA_FIELDS.donationAmount]: 200002,
     [SAMFORA_FIELDS.donationDate]: 200003,
     [SAMFORA_FIELDS.donationRef]: 200004,
@@ -335,7 +341,11 @@ const config = {
     [SAMFORA_FIELDS.totalLifetimeAmount]: 200006,
     [SAMFORA_FIELDS.taxYear]: 200007,
     [SAMFORA_FIELDS.taxDeductibleAmount]: 200008,
-    // Optional: donationCurrency, donationType
+    // Optional Subscriber extensions (not referenced by built-in
+    // templates but available for consumer extensions):
+    // donorLastName, donorAddress1, donorAddress2, donorZipcode,
+    // donorCity, donorCountry, donorPhone, donorSource
+    // Optional Donation extras: donationCurrency, donationType
   },
   websiteUrl: 'https://samfora.org',
 };

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -164,9 +164,22 @@ const DONATION_SEED_VALUES: Array<{ field: string; value: unknown }> = [
  * Flat Subscriber-group fields seeded per persona. These live on the
  * subscriber itself (not historical) — Rule.io overwrites them on each
  * sync, matching the "Subscriber.* is mutable identity" praxis.
+ *
+ * Populates all nine standard Subscriber fields the preset exposes so
+ * each persona has realistic data when previewed in Rule.io's editor.
  */
 function subscriberFieldSeed(firstName: string): Array<{ key: string; value: string }> {
-  return [{ key: SAMFORA_FIELDS.donorFirstName, value: firstName }];
+  return [
+    { key: SAMFORA_FIELDS.donorFirstName, value: firstName },
+    { key: SAMFORA_FIELDS.donorLastName, value: 'Svensson' },
+    { key: SAMFORA_FIELDS.donorAddress1, value: 'Storgatan 1' },
+    { key: SAMFORA_FIELDS.donorAddress2, value: 'Lgh 1201' },
+    { key: SAMFORA_FIELDS.donorZipcode, value: '11122' },
+    { key: SAMFORA_FIELDS.donorCity, value: 'Stockholm' },
+    { key: SAMFORA_FIELDS.donorCountry, value: 'Sweden' },
+    { key: SAMFORA_FIELDS.donorPhone, value: '+46701234567' },
+    { key: SAMFORA_FIELDS.donorSource, value: 'samfora' },
+  ];
 }
 
 // ============================================================================

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -1,0 +1,416 @@
+/**
+ * Deploy the SDK's Samfora automations into the test account.
+ *
+ * Flow mirrors deploy-shopify.ts but uses the account's PREFERRED brand
+ * style (is_default: true) rather than a hardcoded ID. See issue #91 —
+ * that's how every deploy script should resolve brand styles.
+ *
+ *   1. Seed samfora-seed@rule.se with every Samfora field + every trigger
+ *      & segment tag so the field definitions and tags exist in the
+ *      account and we can resolve their numeric ids.
+ *   2. Create per-persona test subscribers, one for each automation
+ *      trigger, so you can eyeball each flow in the Rule.io UI.
+ *   3. Seed the historical Donation.* group for every subscriber that
+ *      needs donation detail (all personas except the welcome-only one).
+ *   4. Resolve numeric field ids from the seed subscriber.
+ *   5. Fetch the account's preferred brand style and build the config.
+ *   6. Deploy each automation via createAutomationEmail (auto-handles
+ *      automail → message → template → dynamic-set with cleanup on
+ *      failure). Leaves automails INACTIVE unless --activate is passed.
+ *
+ * Usage:
+ *   npx tsx scripts/deploy-samfora.ts                 # deploy, automails inactive
+ *   npx tsx scripts/deploy-samfora.ts --activate      # deploy + activate
+ *   npx tsx scripts/deploy-samfora.ts --brand=12345   # force a specific style id
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  RuleClient,
+  samforaPreset,
+  SAMFORA_FIELDS,
+  SAMFORA_TAGS,
+} from '../src';
+import { toBrandStyleConfig } from '../src/rcml/brand-template';
+import type { VendorConsumerConfig } from '../src/vendors/types';
+import type { CustomFieldMap } from '../src/rcml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = join(__dirname, '..');
+
+function loadEnv(): void {
+  const envPath = join(ROOT, '.env');
+  if (!existsSync(envPath)) return;
+  const content = readFileSync(envPath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    const k = t.slice(0, i).trim();
+    const v = t
+      .slice(i + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+    if (!process.env[k]) process.env[k] = v;
+  }
+}
+
+function getArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const hit = process.argv.find((a) => a.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : undefined;
+}
+
+const V2_BASE = 'https://app.rule.io/api/v2';
+const SEED_EMAIL = 'samfora-seed@rule.se';
+const WEBSITE_URL = 'https://samfora.org';
+
+// ============================================================================
+// Persona test subscribers
+// ============================================================================
+
+interface Persona {
+  email: string;
+  firstName: string;
+  description: string;
+  /** Tags applied via v2 /subscribers — creates the tags in Rule.io as a side effect. */
+  tags: string[];
+  /** If false, no Donation.* group data is seeded (e.g. welcome-only persona). */
+  seedDonationGroup: boolean;
+}
+
+const PERSONAS: Persona[] = [
+  {
+    email: 'samfora-first@rule.se',
+    firstName: 'Ella',
+    description: 'First-time donor',
+    tags: [SAMFORA_TAGS.donationReceived, SAMFORA_TAGS.donorFirstGift],
+    seedDonationGroup: true,
+  },
+  {
+    email: 'samfora-second@rule.se',
+    firstName: 'Oskar',
+    description: 'Second gift donor',
+    tags: [SAMFORA_TAGS.donationReceived, SAMFORA_TAGS.donorSecondGift],
+    seedDonationGroup: true,
+  },
+  {
+    email: 'samfora-returning@rule.se',
+    firstName: 'Saga',
+    description: 'Returning donor (3+ gifts)',
+    tags: [SAMFORA_TAGS.donationReceived, SAMFORA_TAGS.donorReturning],
+    seedDonationGroup: true,
+  },
+  {
+    email: 'samfora-monthly@rule.se',
+    firstName: 'Arvid',
+    description: 'Monthly giver',
+    tags: [SAMFORA_TAGS.monthlyDonation, SAMFORA_TAGS.monthlyGiver],
+    seedDonationGroup: true,
+  },
+  {
+    email: 'samfora-new@rule.se',
+    firstName: 'Linnea',
+    description: 'Newly signed-up donor (no donation yet)',
+    tags: [SAMFORA_TAGS.newDonor],
+    seedDonationGroup: false,
+  },
+  {
+    email: 'samfora-tax@rule.se',
+    firstName: 'Johan',
+    description: 'Tax-summary recipient',
+    tags: [SAMFORA_TAGS.annualTaxSummary],
+    seedDonationGroup: true,
+  },
+];
+
+/** Every tag the preset references, applied to the seed so they all exist. */
+const ALL_TAGS = Object.values(SAMFORA_TAGS);
+
+// Note: Samfora keeps the donor first name inside the historical Donation
+// group, so there are no subscriber-level flat fields to seed — the v2 sync
+// below just carries tags.
+
+/**
+ * One donation record seeded into the historical Donation.* group. Values are
+ * typed explicitly so Rule.io creates the right field type on first write.
+ */
+function donationSeed(firstName: string): Array<{ field: string; value: unknown }> {
+  return [
+    { field: 'FirstName', value: firstName },
+    { field: 'Amount', value: 250 },
+    { field: 'Currency', value: 'SEK' },
+    { field: 'Date', value: '2026-04-22' },
+    { field: 'Reference', value: 'SAM-2026-0001' },
+    { field: 'CauseName', value: 'Barnens Hav' },
+    { field: 'Type', value: 'one-time' },
+    { field: 'TotalLifetime', value: 2450 },
+    { field: 'TaxYear', value: '2026' },
+    { field: 'TaxDeductible', value: 2000 },
+  ];
+}
+
+// ============================================================================
+// Live calls
+// ============================================================================
+
+/**
+ * Attach subscriber-level flat fields + trigger/segment tags via v2
+ * /subscribers. An empty fields array is fine — v2 still applies the tags.
+ */
+async function syncSubscriberV2(
+  apiKey: string,
+  email: string,
+  fields: Array<{ key: string; value: string }>,
+  tags: string[],
+): Promise<void> {
+  const payload = {
+    update_on_duplicate: true,
+    tags,
+    subscribers: { email, fields },
+  };
+  const res = await fetch(`${V2_BASE}/subscribers`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `v2 /subscribers POST failed for ${email}: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+/**
+ * Recreate the Donation custom-field group as historical via v3 so each
+ * donation record is its own row rather than a flat overwrite. Matches how
+ * deploy-shopify.ts seeds the Order group.
+ */
+async function seedDonationGroup(
+  client: RuleClient,
+  subscriberId: number,
+  firstName: string,
+): Promise<void> {
+  await client.createCustomFieldData(subscriberId, {
+    groups: [
+      {
+        group: 'Donation',
+        create_if_not_exists: true,
+        historical: true,
+        values: donationSeed(firstName).map(({ field, value }) => ({
+          field,
+          create_if_not_exists: true,
+          value: value as Parameters<
+            typeof client.createCustomFieldData
+          >[1]['groups'][number]['values'][number]['value'],
+        })),
+      },
+    ],
+  });
+}
+
+async function resolveFieldIds(
+  client: RuleClient,
+  subscriberId: number,
+): Promise<CustomFieldMap> {
+  const data = await client.getCustomFieldData(subscriberId);
+  const map: CustomFieldMap = {};
+  for (const record of data.data ?? []) {
+    const groupName = record.group_name ?? '';
+    for (const v of record.values) {
+      const key = `${groupName}.${v.field_name}`;
+      map[key] = v.field_id;
+    }
+  }
+  return map;
+}
+
+/**
+ * Fetch the account's preferred brand style. Uses `is_default: true` from the
+ * brand-style list; falls back to the first entry only if no default is set
+ * (shouldn't happen in practice). See issue #91 for why this is mandatory.
+ */
+async function resolvePreferredBrandStyle(
+  client: RuleClient,
+  overrideId: number | undefined,
+): Promise<{ id: number; name?: string }> {
+  if (overrideId !== undefined) {
+    const resp = await client.getBrandStyle(overrideId);
+    if (!resp?.data) throw new Error(`Brand style ${overrideId} not found`);
+    return { id: overrideId, name: resp.data.name };
+  }
+
+  const listResp = await client.listBrandStyles();
+  const styles = listResp.data ?? [];
+  if (styles.length === 0) {
+    throw new Error('No brand styles available in the account');
+  }
+  const preferred = styles.find((s) => s.is_default) ?? styles[0];
+  if (!styles.some((s) => s.is_default)) {
+    console.warn(
+      '  WARN: no brand style is flagged as default — falling back to first in list',
+    );
+  }
+  return { id: preferred.id, name: preferred.name };
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main(): Promise<void> {
+  loadEnv();
+  const apiKey = process.env.RULE_API_KEY;
+  if (!apiKey) throw new Error('Missing RULE_API_KEY in .env');
+
+  const brandOverride = getArg('brand');
+  const activate = process.argv.includes('--activate');
+
+  const client = new RuleClient({ apiKey });
+
+  // --- 1. Seed subscriber (all fields + all tags so everything gets created) ---
+  console.log(`→ Seeding ${SEED_EMAIL} with every Samfora tag...`);
+  await syncSubscriberV2(apiKey, SEED_EMAIL, [], ALL_TAGS);
+
+  console.log('→ Looking up seed subscriber id...');
+  const seed = await client.getSubscriber(SEED_EMAIL);
+  const rawId = seed?.subscriber?.id;
+  if (!rawId) throw new Error('Seed subscriber not found after sync');
+  const seedId = Number(rawId);
+  console.log(`  id: ${seedId}`);
+
+  console.log('→ Seeding Donation group on seed subscriber (historical=true)...');
+  await seedDonationGroup(client, seedId, 'Seed');
+
+  // --- 2. Personas ---
+  console.log(`\n→ Creating ${PERSONAS.length} persona subscriber(s)...`);
+  const personaIds: Record<string, number> = {};
+  for (const p of PERSONAS) {
+    console.log(`  — ${p.email} (${p.description})`);
+    await syncSubscriberV2(apiKey, p.email, [], p.tags);
+    const sub = await client.getSubscriber(p.email);
+    const id = Number(sub?.subscriber?.id ?? 0);
+    if (!id) throw new Error(`Persona ${p.email} missing after sync`);
+    personaIds[p.email] = id;
+    if (p.seedDonationGroup) {
+      await seedDonationGroup(client, id, p.firstName);
+    }
+    console.log(`    id: ${id}${p.seedDonationGroup ? ' (+ donation record)' : ''}`);
+  }
+
+  // --- 3. Resolve field ids from the seed (after donation group is in place) ---
+  console.log('\n→ Resolving custom field ids from seed subscriber...');
+  const resolved = await resolveFieldIds(client, seedId);
+  console.log(`  ${Object.keys(resolved).length} raw field(s) resolved`);
+
+  // Case-insensitive alias pass — the test account may have pre-existing
+  // fields with slightly different casing (e.g. Donation.Firstname vs
+  // Donation.FirstName). Mirrors the shopify deploy's handling.
+  const customFields: CustomFieldMap = { ...resolved };
+  const lower: Record<string, number> = {};
+  for (const [k, v] of Object.entries(resolved)) lower[k.toLowerCase()] = v;
+  const expected = Object.values(SAMFORA_FIELDS).filter((n) => n.includes('.'));
+  const aliased: string[] = [];
+  const stillMissing: string[] = [];
+  for (const name of expected) {
+    if (customFields[name] !== undefined) continue;
+    const hit = lower[name.toLowerCase()];
+    if (hit !== undefined) {
+      customFields[name] = hit;
+      aliased.push(name);
+    } else {
+      stillMissing.push(name);
+    }
+  }
+  if (aliased.length) console.log(`  aliased (case-insensitive): ${aliased.join(', ')}`);
+  if (stillMissing.length) {
+    console.warn(
+      `  WARN: ${stillMissing.length} expected fields not present in account:`,
+      stillMissing,
+    );
+  }
+
+  // --- 4. Brand style (preferred / is_default) ---
+  console.log('\n→ Resolving preferred brand style (is_default)...');
+  const { id: brandStyleId, name: brandName } = await resolvePreferredBrandStyle(
+    client,
+    brandOverride ? Number(brandOverride) : undefined,
+  );
+  console.log(`  using "${brandName ?? '-'}" (id ${brandStyleId})`);
+
+  const brandResp = await client.getBrandStyle(brandStyleId);
+  if (!brandResp?.data) throw new Error(`Brand style ${brandStyleId} not found`);
+  const brandStyle = toBrandStyleConfig(brandResp.data);
+
+  const config: VendorConsumerConfig = {
+    brandStyle,
+    customFields,
+    websiteUrl: WEBSITE_URL,
+  };
+
+  console.log('→ Validating config against samfora preset...');
+  samforaPreset.validateConfig(config);
+
+  // --- 5. Deploy the 6 automations ---
+  const automations = samforaPreset.getAutomations(config);
+  console.log(`\n→ Deploying ${automations.length} automation(s)...`);
+
+  const results: Array<{
+    name: string;
+    automationId: number;
+    messageId: number;
+    templateId: number;
+  }> = [];
+  for (const a of automations) {
+    console.log(`\n  — ${a.name}`);
+    const template = a.templateBuilder(config);
+    const res = await client.createAutomationEmail({
+      name: `${a.name} (SDK standard)`,
+      description: a.description,
+      triggerType: 'tag',
+      triggerValue: a.triggerTag,
+      subject: a.subject,
+      preheader: a.preheader,
+      sendoutType: 2,
+      delayInSeconds: a.delayInSeconds,
+      template,
+    });
+    console.log(
+      `    automail: ${res.automationId}  message: ${res.messageId}  template: ${res.templateId}`,
+    );
+    console.log(
+      `    edit: https://app.rule.io/v5/#/app/automations/automail/${res.automationId}/v6/email/${res.messageId}/edit`,
+    );
+    if (activate) {
+      await client.updateAutomation(res.automationId, { active: true });
+      console.log('    activated ✓');
+    }
+    results.push({
+      name: a.name,
+      automationId: res.automationId,
+      messageId: res.messageId,
+      templateId: res.templateId,
+    });
+  }
+
+  console.log('\n✓ Deployed');
+  for (const r of results) {
+    console.log(`  ${r.automationId}  ${r.name}`);
+  }
+  console.log('\nPersona subscribers:');
+  for (const p of PERSONAS) {
+    console.log(`  ${personaIds[p.email]}  ${p.email}  — ${p.description}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.stack ?? e.message : e);
+  process.exit(1);
+});

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -5,17 +5,20 @@
  * style (is_default: true) rather than a hardcoded ID. See issue #91 —
  * that's how every deploy script should resolve brand styles.
  *
- *   1. Sync samfora-seed@rule.se with every trigger & segment tag so the
- *      tags exist in the account. (No flat subscriber fields: Samfora
- *      keeps donor data inside the historical Donation group.)
+ *   1. Sync samfora-seed@rule.se with `Subscriber.FirstName` (flat) +
+ *      every trigger & segment tag so the tags and the Subscriber-group
+ *      field definition exist in the account. Subscriber.* fields are
+ *      flat/overwriting per Rule.io praxis.
  *   2. Create per-persona test subscribers, one for each automation
- *      trigger, so you can eyeball each flow in the Rule.io UI.
+ *      trigger, so you can eyeball each flow in the Rule.io UI. Each
+ *      persona also gets a personalised `Subscriber.FirstName`.
  *   3. Seed the historical Donation.* group on every subscriber that
  *      needs donation detail (all personas except the welcome-only one).
  *      This creates the Donation.* field definitions in the account as
  *      a side effect of the first write.
- *   4. Resolve numeric field ids from the seed subscriber's Donation
- *      group (read back via v3 custom-field-data).
+ *   4. Resolve numeric field ids from the seed subscriber — both the
+ *      Subscriber and Donation groups are read back via v3
+ *      custom-field-data.
  *   5. Fetch the account's preferred brand style and build the config.
  *   6. Deploy each automation via createAutomationEmail (auto-handles
  *      automail → message → template → dynamic-set with cleanup on
@@ -141,20 +144,29 @@ const ALL_TAGS = Object.values(SAMFORA_TAGS);
 /**
  * One donation record seeded into the historical Donation.* group. Values are
  * typed explicitly so Rule.io creates the right field type on first write.
+ *
+ * Note: `FirstName` lives on the flat `Subscriber` group per Rule.io praxis,
+ * not inside this historical group — see `subscriberFieldSeed()`.
  */
-function donationSeed(firstName: string): Array<{ field: string; value: unknown }> {
-  return [
-    { field: 'FirstName', value: firstName },
-    { field: 'Amount', value: 250 },
-    { field: 'Currency', value: 'SEK' },
-    { field: 'Date', value: '2026-04-22' },
-    { field: 'Reference', value: 'SAM-2026-0001' },
-    { field: 'CauseName', value: 'Barnens Hav' },
-    { field: 'Type', value: 'one-time' },
-    { field: 'TotalLifetime', value: 2450 },
-    { field: 'TaxYear', value: '2026' },
-    { field: 'TaxDeductible', value: 2000 },
-  ];
+const DONATION_SEED_VALUES: Array<{ field: string; value: unknown }> = [
+  { field: 'Amount', value: 250 },
+  { field: 'Currency', value: 'SEK' },
+  { field: 'Date', value: '2026-04-22' },
+  { field: 'Reference', value: 'SAM-2026-0001' },
+  { field: 'CauseName', value: 'Barnens Hav' },
+  { field: 'Type', value: 'one-time' },
+  { field: 'TotalLifetime', value: 2450 },
+  { field: 'TaxYear', value: '2026' },
+  { field: 'TaxDeductible', value: 2000 },
+];
+
+/**
+ * Flat Subscriber-group fields seeded per persona. These live on the
+ * subscriber itself (not historical) — Rule.io overwrites them on each
+ * sync, matching the "Subscriber.* is mutable identity" praxis.
+ */
+function subscriberFieldSeed(firstName: string): Array<{ key: string; value: string }> {
+  return [{ key: SAMFORA_FIELDS.donorFirstName, value: firstName }];
 }
 
 // ============================================================================
@@ -195,11 +207,13 @@ async function syncSubscriberV2(
  * Recreate the Donation custom-field group as historical via v3 so each
  * donation record is its own row rather than a flat overwrite. Matches how
  * deploy-shopify.ts seeds the Order group.
+ *
+ * First-name lives on the flat Subscriber group and is seeded via
+ * `syncSubscriberV2` elsewhere, not here.
  */
 async function seedDonationGroup(
   client: RuleClient,
   subscriberId: number,
-  firstName: string,
 ): Promise<void> {
   await client.createCustomFieldData(subscriberId, {
     groups: [
@@ -207,7 +221,7 @@ async function seedDonationGroup(
         group: 'Donation',
         create_if_not_exists: true,
         historical: true,
-        values: donationSeed(firstName).map(({ field, value }) => ({
+        values: DONATION_SEED_VALUES.map(({ field, value }) => ({
           field,
           create_if_not_exists: true,
           value: value as Parameters<
@@ -309,9 +323,9 @@ async function main(): Promise<void> {
 
   const client = new RuleClient({ apiKey });
 
-  // --- 1. Seed subscriber (all fields + all tags so everything gets created) ---
-  console.log(`→ Seeding ${SEED_EMAIL} with every Samfora tag...`);
-  await syncSubscriberV2(apiKey, SEED_EMAIL, [], ALL_TAGS);
+  // --- 1. Seed subscriber (flat Subscriber fields + every tag) ---
+  console.log(`→ Seeding ${SEED_EMAIL} with Subscriber.FirstName + every Samfora tag...`);
+  await syncSubscriberV2(apiKey, SEED_EMAIL, subscriberFieldSeed('Seed'), ALL_TAGS);
 
   console.log('→ Looking up seed subscriber id...');
   const seed = await client.getSubscriber(SEED_EMAIL);
@@ -321,20 +335,20 @@ async function main(): Promise<void> {
   console.log(`  id: ${seedId}`);
 
   console.log('→ Seeding Donation group on seed subscriber (historical=true)...');
-  await seedDonationGroup(client, seedId, 'Seed');
+  await seedDonationGroup(client, seedId);
 
   // --- 2. Personas ---
   console.log(`\n→ Creating ${PERSONAS.length} persona subscriber(s)...`);
   const personaIds: Record<string, number> = {};
   for (const p of PERSONAS) {
     console.log(`  — ${p.email} (${p.description})`);
-    await syncSubscriberV2(apiKey, p.email, [], p.tags);
+    await syncSubscriberV2(apiKey, p.email, subscriberFieldSeed(p.firstName), p.tags);
     const sub = await client.getSubscriber(p.email);
     const id = Number(sub?.subscriber?.id ?? 0);
     if (!id) throw new Error(`Persona ${p.email} missing after sync`);
     personaIds[p.email] = id;
     if (p.seedDonationGroup) {
-      await seedDonationGroup(client, id, p.firstName);
+      await seedDonationGroup(client, id);
     }
     console.log(`    id: ${id}${p.seedDonationGroup ? ' (+ donation record)' : ''}`);
   }

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -35,7 +35,7 @@ import {
 } from '../src';
 import { toBrandStyleConfig } from '../src/rcml/brand-template';
 import type { VendorConsumerConfig } from '../src/vendors/types';
-import type { CustomFieldMap } from '../src/rcml';
+import type { BrandStyleConfig, CustomFieldMap } from '../src/rcml';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -233,18 +233,26 @@ async function resolveFieldIds(
 }
 
 /**
- * Fetch the account's preferred brand style. Uses `is_default: true` from the
+ * Fetch the account's preferred brand style and convert it to a
+ * `BrandStyleConfig` in one pass. Uses `is_default: true` from the
  * brand-style list; falls back to the first entry only if no default is set
  * (shouldn't happen in practice). See issue #91 for why this is mandatory.
+ *
+ * Returns the converted config so callers can use it directly without a
+ * second round trip through `getBrandStyle`.
  */
 async function resolvePreferredBrandStyle(
   client: RuleClient,
   overrideId: number | undefined,
-): Promise<{ id: number; name?: string }> {
+): Promise<{ id: number; name?: string; brandStyle: BrandStyleConfig }> {
   if (overrideId !== undefined) {
     const resp = await client.getBrandStyle(overrideId);
     if (!resp?.data) throw new Error(`Brand style ${overrideId} not found`);
-    return { id: overrideId, name: resp.data.name };
+    return {
+      id: overrideId,
+      name: resp.data.name,
+      brandStyle: toBrandStyleConfig(resp.data),
+    };
   }
 
   const listResp = await client.listBrandStyles();
@@ -258,7 +266,30 @@ async function resolvePreferredBrandStyle(
       '  WARN: no brand style is flagged as default — falling back to first in list',
     );
   }
-  return { id: preferred.id, name: preferred.name };
+  const resp = await client.getBrandStyle(preferred.id);
+  if (!resp?.data) throw new Error(`Brand style ${preferred.id} not found`);
+  return {
+    id: preferred.id,
+    name: preferred.name,
+    brandStyle: toBrandStyleConfig(resp.data),
+  };
+}
+
+/**
+ * Parse a `--brand=<id>` CLI argument into a positive integer, throwing a
+ * clear error for non-numeric, negative, or fractional values. Rejecting
+ * `NaN` up front avoids a downstream `getBrandStyle(NaN)` call that would
+ * surface as a confusing 404.
+ */
+function parseBrandOverride(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(
+      `Invalid --brand value "${raw}": expected a positive integer brand style id.`,
+    );
+  }
+  return n;
 }
 
 // ============================================================================
@@ -270,7 +301,7 @@ async function main(): Promise<void> {
   const apiKey = process.env.RULE_API_KEY;
   if (!apiKey) throw new Error('Missing RULE_API_KEY in .env');
 
-  const brandOverride = getArg('brand');
+  const brandOverride = parseBrandOverride(getArg('brand'));
   const activate = process.argv.includes('--activate');
 
   const client = new RuleClient({ apiKey });
@@ -339,15 +370,9 @@ async function main(): Promise<void> {
 
   // --- 4. Brand style (preferred / is_default) ---
   console.log('\n→ Resolving preferred brand style (is_default)...');
-  const { id: brandStyleId, name: brandName } = await resolvePreferredBrandStyle(
-    client,
-    brandOverride ? Number(brandOverride) : undefined,
-  );
+  const { id: brandStyleId, name: brandName, brandStyle } =
+    await resolvePreferredBrandStyle(client, brandOverride);
   console.log(`  using "${brandName ?? '-'}" (id ${brandStyleId})`);
-
-  const brandResp = await client.getBrandStyle(brandStyleId);
-  if (!brandResp?.data) throw new Error(`Brand style ${brandStyleId} not found`);
-  const brandStyle = toBrandStyleConfig(brandResp.data);
 
   const config: VendorConsumerConfig = {
     brandStyle,

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -137,9 +137,10 @@ const PERSONAS: Persona[] = [
 /** Every tag the preset references, applied to the seed so they all exist. */
 const ALL_TAGS = Object.values(SAMFORA_TAGS);
 
-// Note: Samfora keeps the donor first name inside the historical Donation
-// group, so there are no subscriber-level flat fields to seed — the v2 sync
-// below just carries tags.
+// Note: donor identity (first name, address, phone, etc.) is seeded on the
+// flat Subscriber group via `subscriberFieldSeed()`; per-donation event data
+// is written into the historical Donation group via `seedDonationGroup()`.
+// The v2 sync below carries both the flat Subscriber fields and the tags.
 
 /**
  * One donation record seeded into the historical Donation.* group. Values are

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -5,14 +5,17 @@
  * style (is_default: true) rather than a hardcoded ID. See issue #91 —
  * that's how every deploy script should resolve brand styles.
  *
- *   1. Seed samfora-seed@rule.se with every Samfora field + every trigger
- *      & segment tag so the field definitions and tags exist in the
- *      account and we can resolve their numeric ids.
+ *   1. Sync samfora-seed@rule.se with every trigger & segment tag so the
+ *      tags exist in the account. (No flat subscriber fields: Samfora
+ *      keeps donor data inside the historical Donation group.)
  *   2. Create per-persona test subscribers, one for each automation
  *      trigger, so you can eyeball each flow in the Rule.io UI.
- *   3. Seed the historical Donation.* group for every subscriber that
+ *   3. Seed the historical Donation.* group on every subscriber that
  *      needs donation detail (all personas except the welcome-only one).
- *   4. Resolve numeric field ids from the seed subscriber.
+ *      This creates the Donation.* field definitions in the account as
+ *      a side effect of the first write.
+ *   4. Resolve numeric field ids from the seed subscriber's Donation
+ *      group (read back via v3 custom-field-data).
  *   5. Fetch the account's preferred brand style and build the config.
  *   6. Deploy each automation via createAutomationEmail (auto-handles
  *      automail → message → template → dynamic-set with cleanup on

--- a/scripts/deploy-samfora.ts
+++ b/scripts/deploy-samfora.ts
@@ -5,13 +5,15 @@
  * style (is_default: true) rather than a hardcoded ID. See issue #91 —
  * that's how every deploy script should resolve brand styles.
  *
- *   1. Sync samfora-seed@rule.se with `Subscriber.FirstName` (flat) +
- *      every trigger & segment tag so the tags and the Subscriber-group
- *      field definition exist in the account. Subscriber.* fields are
- *      flat/overwriting per Rule.io praxis.
+ *   1. Sync samfora-seed@rule.se with every standard `Subscriber.*`
+ *      field the preset maps (FirstName, LastName, Address1/2, Zipcode,
+ *      City, Country, Number, Source) plus every trigger & segment tag,
+ *      so the tags and the Subscriber-group field definitions exist in
+ *      the account. Subscriber.* fields are flat/overwriting per
+ *      Rule.io praxis.
  *   2. Create per-persona test subscribers, one for each automation
  *      trigger, so you can eyeball each flow in the Rule.io UI. Each
- *      persona also gets a personalised `Subscriber.FirstName`.
+ *      persona gets the full `Subscriber.*` field set personalised.
  *   3. Seed the historical Donation.* group on every subscriber that
  *      needs donation detail (all personas except the welcome-only one).
  *      This creates the Donation.* field definitions in the account as
@@ -338,7 +340,7 @@ async function main(): Promise<void> {
   const client = new RuleClient({ apiKey });
 
   // --- 1. Seed subscriber (flat Subscriber fields + every tag) ---
-  console.log(`→ Seeding ${SEED_EMAIL} with Subscriber.FirstName + every Samfora tag...`);
+  console.log(`→ Seeding ${SEED_EMAIL} with Subscriber.* fields + every Samfora tag...`);
   await syncSubscriberV2(apiKey, SEED_EMAIL, subscriberFieldSeed('Seed'), ALL_TAGS);
 
   console.log('→ Looking up seed subscriber id...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,6 +335,9 @@ export {
   bookzenPreset,
   BOOKZEN_FIELDS,
   BOOKZEN_TAGS,
+  samforaPreset,
+  SAMFORA_FIELDS,
+  SAMFORA_TAGS,
 } from './vendors';
 
 export type {
@@ -352,4 +355,8 @@ export type {
   BookzenFieldNames,
   BookzenTagSchema,
   BookzenTagNames,
+  SamforaFieldSchema,
+  SamforaFieldNames,
+  SamforaTagSchema,
+  SamforaTagNames,
 } from './vendors';

--- a/src/vendors/index.ts
+++ b/src/vendors/index.ts
@@ -34,3 +34,7 @@ export type { ShopifyFieldSchema, ShopifyFieldNames, ShopifyTagSchema, ShopifyTa
 // Bookzen (hospitality)
 export { bookzenPreset, BOOKZEN_FIELDS, BOOKZEN_TAGS } from './bookzen';
 export type { BookzenFieldSchema, BookzenFieldNames, BookzenTagSchema, BookzenTagNames } from './bookzen';
+
+// Samfora (donation)
+export { samforaPreset, SAMFORA_FIELDS, SAMFORA_TAGS } from './samfora';
+export type { SamforaFieldSchema, SamforaFieldNames, SamforaTagSchema, SamforaTagNames } from './samfora';

--- a/src/vendors/samfora/automations.ts
+++ b/src/vendors/samfora/automations.ts
@@ -27,6 +27,11 @@ import {
   createFooterSection,
   validateCustomFields,
 } from '../../rcml';
+// `createLogoSection` is an internal helper (not in the barrel) shared by
+// hospitality/ecommerce templates. Imported directly to keep the Samfora
+// preset consistent with those builders — every other preset's emails lead
+// with the account logo, and earlier this preset was silently missing it.
+import { createLogoSection } from '../../rcml/brand-template';
 import { RuleConfigError } from '../../errors';
 
 // ============================================================================
@@ -252,6 +257,7 @@ function buildDonationConfirmationTemplate(
   const firstNameId = cf[SAMFORA_FIELDS.donorFirstName];
 
   const sections: RCMLBodyChild[] = [
+    ...createLogoSection(config.brandStyle.logoUrl),
     greetingSection(text.heading, firstNameId),
     paragraphSection(text.intro),
     createContentSection([
@@ -315,6 +321,7 @@ function buildMonthlyDonationTemplate(config: VendorConsumerConfig): RCMLDocumen
   const t = MONTHLY_DONATION_TEXT;
 
   const sections: RCMLBodyChild[] = [
+    ...createLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([
@@ -371,6 +378,7 @@ function buildWelcomeTemplate(config: VendorConsumerConfig): RCMLDocument {
   const t = WELCOME_TEXT;
 
   const sections: RCMLBodyChild[] = [
+    ...createLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([
@@ -412,6 +420,7 @@ function buildTaxSummaryTemplate(config: VendorConsumerConfig): RCMLDocument {
   const t = TAX_SUMMARY_TEXT;
 
   const sections: RCMLBodyChild[] = [
+    ...createLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([

--- a/src/vendors/samfora/automations.ts
+++ b/src/vendors/samfora/automations.ts
@@ -12,7 +12,7 @@
 
 import type { VendorAutomation, VendorConsumerConfig } from '../types';
 import type { RCMLDocument, RCMLBodyChild } from '../../types';
-import type { CustomFieldMap } from '../../rcml';
+import type { CustomFieldMap, FooterConfig } from '../../rcml';
 import { SAMFORA_FIELDS } from './fields';
 import { SAMFORA_TAGS } from './tags';
 import {
@@ -150,6 +150,37 @@ function fieldPlaceholder(customFields: CustomFieldMap, fieldName: string) {
 }
 
 // ============================================================================
+// Footer (Swedish defaults)
+// ============================================================================
+
+/**
+ * Swedish footer text defaults. `createFooterSection()` ships with English
+ * link text as its own default — without these, an out-of-the-box Samfora
+ * email mixes Swedish body copy with English footer links, which conflicts
+ * with the preset's stated Swedish-first intent.
+ *
+ * Consumer overrides still win per-field because `config.footer` is
+ * spread after the defaults.
+ */
+const SAMFORA_FOOTER_DEFAULTS: FooterConfig = {
+  viewInBrowserText: 'Öppna i webbläsare',
+  unsubscribeText: 'Avregistrera',
+};
+
+function samforaFooterSection(override: FooterConfig | undefined): RCMLBodyChild {
+  return createFooterSection({ ...SAMFORA_FOOTER_DEFAULTS, ...override });
+}
+
+/**
+ * Swedish plain-text fallback. `createBrandHead()` otherwise defaults to
+ * English ("View this email in your browser: ..." / "Unsubscribe: ...") —
+ * same class of leak as the footer links. Passed explicitly into every
+ * `createBrandTemplate` call below.
+ */
+const SAMFORA_PLAIN_TEXT =
+  'Öppna e-postmeddelandet i webbläsaren: %Link:WebBrowser%\n\n---\nAvregistrera: %Link:Unsubscribe%';
+
+// ============================================================================
 // Shared section builders
 // ============================================================================
 
@@ -255,12 +286,13 @@ function buildDonationConfirmationTemplate(
     ),
     ctaSection(text.ctaButton, config.websiteUrl),
     paragraphSection(text.signOff),
-    createFooterSection(config.footer),
+    samforaFooterSection(config.footer),
   ];
 
   return createBrandTemplate({
     brandStyle: config.brandStyle,
     preheader: text.preheader,
+    plainText: SAMFORA_PLAIN_TEXT,
     sections,
   });
 }
@@ -317,12 +349,13 @@ function buildMonthlyDonationTemplate(config: VendorConsumerConfig): RCMLDocumen
     ),
     ctaSection(t.ctaButton, config.websiteUrl),
     paragraphSection(t.signOff),
-    createFooterSection(config.footer),
+    samforaFooterSection(config.footer),
   ];
 
   return createBrandTemplate({
     brandStyle: config.brandStyle,
     preheader: t.preheader,
+    plainText: SAMFORA_PLAIN_TEXT,
     sections,
   });
 }
@@ -351,12 +384,13 @@ function buildWelcomeTemplate(config: VendorConsumerConfig): RCMLDocument {
     ]),
     ctaSection(t.ctaButton, config.websiteUrl),
     paragraphSection(t.signOff),
-    createFooterSection(config.footer),
+    samforaFooterSection(config.footer),
   ];
 
   return createBrandTemplate({
     brandStyle: config.brandStyle,
     preheader: t.preheader,
+    plainText: SAMFORA_PLAIN_TEXT,
     sections,
   });
 }
@@ -417,12 +451,13 @@ function buildTaxSummaryTemplate(config: VendorConsumerConfig): RCMLDocument {
     paragraphSection(t.disclaimer),
     ctaSection(t.ctaButton, config.websiteUrl),
     paragraphSection(t.signOff),
-    createFooterSection(config.footer),
+    samforaFooterSection(config.footer),
   ];
 
   return createBrandTemplate({
     brandStyle: config.brandStyle,
     preheader: t.preheader,
+    plainText: SAMFORA_PLAIN_TEXT,
     sections,
   });
 }

--- a/src/vendors/samfora/automations.ts
+++ b/src/vendors/samfora/automations.ts
@@ -1,0 +1,511 @@
+/**
+ * Samfora Automation Definitions
+ *
+ * Swedish charitable-donation automations for the Samfora platform.
+ * Each automation assembles its RCML document inline from the generic
+ * brand-template helpers — no vertical-specific template builders exist
+ * for donations, and the user chose "reuse generic templates only".
+ *
+ * Default copy ships in Swedish to match Samfora's market. Consumers can
+ * still override any field value via the merged `TemplateConfigV2`.
+ */
+
+import type { VendorAutomation, VendorConsumerConfig } from '../types';
+import type { RCMLDocument, RCMLBodyChild } from '../../types';
+import type { CustomFieldMap } from '../../rcml';
+import { SAMFORA_FIELDS } from './fields';
+import { SAMFORA_TAGS } from './tags';
+import {
+  createBrandTemplate,
+  createContentSection,
+  createBrandHeading,
+  createBrandText,
+  createBrandButton,
+  createDocWithPlaceholders,
+  createPlaceholder,
+  createTextNode,
+  createFooterSection,
+  validateCustomFields,
+} from '../../rcml';
+import { RuleConfigError } from '../../errors';
+
+// ============================================================================
+// Swedish copy fixtures
+// ============================================================================
+
+interface DonationConfirmationText {
+  readonly preheader: string;
+  readonly heading: string;
+  readonly intro: string;
+  readonly detailsHeading: string;
+  readonly amountLabel: string;
+  readonly causeLabel: string;
+  readonly dateLabel: string;
+  readonly referenceLabel: string;
+  readonly ctaButton: string;
+  readonly signOff: string;
+}
+
+const DONATION_CONFIRMATION_FIRST_TEXT: DonationConfirmationText = {
+  preheader: 'Tack för din första gåva!',
+  heading: 'Tack för din första gåva',
+  intro:
+    'Din gåva har tagits emot. 100 % av beloppet går direkt till det ändamål du har valt.',
+  detailsHeading: 'Gåvans detaljer',
+  amountLabel: 'Belopp',
+  causeLabel: 'Ändamål',
+  dateLabel: 'Datum',
+  referenceLabel: 'Referens',
+  ctaButton: 'Se mitt konto',
+  signOff: 'Varmt välkommen till Samfora — vi är glada att ha dig med oss.',
+} as const;
+
+const DONATION_CONFIRMATION_SECOND_TEXT: DonationConfirmationText = {
+  preheader: 'Tack för att du ger igen!',
+  heading: 'Tack för att du ger igen',
+  intro:
+    'Det betyder mycket att du väljer att ge en gång till. Din gåva är mottagen och går oavkortat till det ändamål du valt.',
+  detailsHeading: 'Gåvans detaljer',
+  amountLabel: 'Belopp',
+  causeLabel: 'Ändamål',
+  dateLabel: 'Datum',
+  referenceLabel: 'Referens',
+  ctaButton: 'Se mitt konto',
+  signOff: 'Tack för att du fortsätter göra skillnad.',
+} as const;
+
+const DONATION_CONFIRMATION_RETURNING_TEXT: DonationConfirmationText = {
+  preheader: 'Ännu en gåva som gör skillnad',
+  heading: 'Ännu en gåva som gör skillnad',
+  intro:
+    'Tack för ditt fortsatta stöd. Din gåva har mottagits och går direkt till det ändamål du valt.',
+  detailsHeading: 'Gåvans detaljer',
+  amountLabel: 'Belopp',
+  causeLabel: 'Ändamål',
+  dateLabel: 'Datum',
+  referenceLabel: 'Referens',
+  ctaButton: 'Se mitt konto',
+  signOff: 'Det är tack vare givare som du som vi kan fortsätta vårt arbete.',
+} as const;
+
+const MONTHLY_DONATION_TEXT = {
+  preheader: 'Din månadsgåva är mottagen',
+  heading: 'Månadsgåva mottagen',
+  intro:
+    'Din månadsgåva har dragits och skickats vidare till det ändamål du har valt. Tack för att du ger regelbundet.',
+  detailsHeading: 'Gåvans detaljer',
+  amountLabel: 'Belopp',
+  causeLabel: 'Ändamål',
+  dateLabel: 'Dragningsdatum',
+  referenceLabel: 'Referens',
+  ctaButton: 'Hantera månadsgåva',
+  signOff: 'Tack för att du är månadsgivare hos Samfora.',
+} as const;
+
+const WELCOME_TEXT = {
+  preheader: 'Välkommen till Samfora',
+  heading: 'Välkommen till Samfora',
+  intro:
+    'Kul att du är här! Samfora är ditt konto för ditt givande — samla dina gåvor, följ dina ändamål och bidra till en värld som mår bättre.',
+  listHeading: 'Så här kommer du igång',
+  stepOne: 'Välj ett ändamål som berör dig.',
+  stepTwo: 'Ge en engångsgåva eller starta ett månadsgivande.',
+  stepThree: 'Följ effekten av ditt givande från ditt konto.',
+  ctaButton: 'Utforska ändamål',
+  signOff: 'Varmt välkommen — vi ses på plattformen.',
+} as const;
+
+const TAX_SUMMARY_TEXT = {
+  preheader: 'Din gåvosammanställning för skatteavdrag',
+  heading: 'Din gåvosammanställning',
+  intro:
+    'Här är en sammanställning av dina gåvor under året. Du kan använda den för att göra skatteavdrag för gåvor i din deklaration.',
+  detailsHeading: 'Sammanställning',
+  yearLabel: 'Skatteår',
+  totalLabel: 'Totalt givet',
+  deductibleLabel: 'Avdragsgillt belopp',
+  ctaButton: 'Ladda ner kvitto',
+  disclaimer:
+    'Vi rapporterar dina gåvor till Skatteverket enligt gällande regler för gåvoskatteavdrag.',
+  signOff: 'Tack för ditt engagemang under året.',
+} as const;
+
+// ============================================================================
+// Placeholder helper
+// ============================================================================
+
+/**
+ * Look up a placeholder for a field name, throwing if it isn't mapped.
+ * Callers should pre-validate with `validateCustomFields`; this is a
+ * defensive backstop so the non-null assertion doesn't appear inline.
+ */
+function fieldPlaceholder(customFields: CustomFieldMap, fieldName: string) {
+  const id = customFields[fieldName];
+  if (id === undefined) {
+    throw new RuleConfigError(
+      `samfora: missing customFields entry for "${fieldName}"`,
+    );
+  }
+  return createPlaceholder(fieldName, id);
+}
+
+// ============================================================================
+// Shared section builders
+// ============================================================================
+
+/**
+ * Build a labelled summary row (label on one line, value placeholder below).
+ * Kept simple for readability — one row renders as two short paragraphs.
+ */
+function summaryRow(label: string, valueContent: ReturnType<typeof createDocWithPlaceholders>): RCMLBodyChild {
+  return createContentSection([
+    createBrandText(
+      createDocWithPlaceholders([createTextNode(label)]),
+      { padding: '8px 0 2px 0' },
+    ),
+    createBrandText(valueContent, { padding: '0 0 8px 0' }),
+  ]);
+}
+
+function greetingSection(
+  greeting: string,
+  firstNameId: number,
+): RCMLBodyChild {
+  return createContentSection([
+    createBrandHeading(
+      createDocWithPlaceholders([
+        createTextNode(`${greeting}, `),
+        createPlaceholder(SAMFORA_FIELDS.donorFirstName, firstNameId),
+      ]),
+      1,
+    ),
+  ]);
+}
+
+function paragraphSection(text: string): RCMLBodyChild {
+  return createContentSection([
+    createBrandText(createDocWithPlaceholders([createTextNode(text)])),
+  ]);
+}
+
+function ctaSection(label: string, href: string): RCMLBodyChild {
+  return createContentSection([
+    createBrandButton(
+      createDocWithPlaceholders([createTextNode(label)]),
+      href,
+    ),
+  ]);
+}
+
+// ============================================================================
+// Template builders
+// ============================================================================
+
+function buildDonationConfirmationTemplate(
+  config: VendorConsumerConfig,
+  text: DonationConfirmationText,
+): RCMLDocument {
+  validateCustomFields(
+    config.customFields,
+    {
+      donorFirstName: SAMFORA_FIELDS.donorFirstName,
+      donationAmount: SAMFORA_FIELDS.donationAmount,
+      donationDate: SAMFORA_FIELDS.donationDate,
+      donationRef: SAMFORA_FIELDS.donationRef,
+      causeName: SAMFORA_FIELDS.causeName,
+    },
+    'samforaDonationConfirmation',
+  );
+
+  const cf = config.customFields;
+  const firstNameId = cf[SAMFORA_FIELDS.donorFirstName];
+
+  const sections: RCMLBodyChild[] = [
+    greetingSection(text.heading, firstNameId),
+    paragraphSection(text.intro),
+    createContentSection([
+      createBrandHeading(
+        createDocWithPlaceholders([createTextNode(text.detailsHeading)]),
+        3,
+      ),
+    ]),
+    summaryRow(
+      text.amountLabel,
+      createDocWithPlaceholders([
+        fieldPlaceholder(cf, SAMFORA_FIELDS.donationAmount),
+        ...(cf[SAMFORA_FIELDS.donationCurrency] !== undefined
+          ? [
+              createTextNode(' '),
+              fieldPlaceholder(cf, SAMFORA_FIELDS.donationCurrency),
+            ]
+          : []),
+      ]),
+    ),
+    summaryRow(
+      text.causeLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.causeName)]),
+    ),
+    summaryRow(
+      text.dateLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.donationDate)]),
+    ),
+    summaryRow(
+      text.referenceLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.donationRef)]),
+    ),
+    ctaSection(text.ctaButton, config.websiteUrl),
+    paragraphSection(text.signOff),
+    createFooterSection(config.footer),
+  ];
+
+  return createBrandTemplate({
+    brandStyle: config.brandStyle,
+    preheader: text.preheader,
+    sections,
+  });
+}
+
+function buildMonthlyDonationTemplate(config: VendorConsumerConfig): RCMLDocument {
+  validateCustomFields(
+    config.customFields,
+    {
+      donorFirstName: SAMFORA_FIELDS.donorFirstName,
+      donationAmount: SAMFORA_FIELDS.donationAmount,
+      donationDate: SAMFORA_FIELDS.donationDate,
+      donationRef: SAMFORA_FIELDS.donationRef,
+      causeName: SAMFORA_FIELDS.causeName,
+    },
+    'samforaMonthlyDonation',
+  );
+
+  const cf = config.customFields;
+  const firstNameId = cf[SAMFORA_FIELDS.donorFirstName];
+  const t = MONTHLY_DONATION_TEXT;
+
+  const sections: RCMLBodyChild[] = [
+    greetingSection(t.heading, firstNameId),
+    paragraphSection(t.intro),
+    createContentSection([
+      createBrandHeading(
+        createDocWithPlaceholders([createTextNode(t.detailsHeading)]),
+        3,
+      ),
+    ]),
+    summaryRow(
+      t.amountLabel,
+      createDocWithPlaceholders([
+        fieldPlaceholder(cf, SAMFORA_FIELDS.donationAmount),
+        ...(cf[SAMFORA_FIELDS.donationCurrency] !== undefined
+          ? [
+              createTextNode(' '),
+              fieldPlaceholder(cf, SAMFORA_FIELDS.donationCurrency),
+            ]
+          : []),
+      ]),
+    ),
+    summaryRow(
+      t.causeLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.causeName)]),
+    ),
+    summaryRow(
+      t.dateLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.donationDate)]),
+    ),
+    summaryRow(
+      t.referenceLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.donationRef)]),
+    ),
+    ctaSection(t.ctaButton, config.websiteUrl),
+    paragraphSection(t.signOff),
+    createFooterSection(config.footer),
+  ];
+
+  return createBrandTemplate({
+    brandStyle: config.brandStyle,
+    preheader: t.preheader,
+    sections,
+  });
+}
+
+function buildWelcomeTemplate(config: VendorConsumerConfig): RCMLDocument {
+  validateCustomFields(
+    config.customFields,
+    { donorFirstName: SAMFORA_FIELDS.donorFirstName },
+    'samforaWelcome',
+  );
+
+  const firstNameId = config.customFields[SAMFORA_FIELDS.donorFirstName];
+  const t = WELCOME_TEXT;
+
+  const sections: RCMLBodyChild[] = [
+    greetingSection(t.heading, firstNameId),
+    paragraphSection(t.intro),
+    createContentSection([
+      createBrandHeading(
+        createDocWithPlaceholders([createTextNode(t.listHeading)]),
+        3,
+      ),
+      createBrandText(createDocWithPlaceholders([createTextNode(`1. ${t.stepOne}`)])),
+      createBrandText(createDocWithPlaceholders([createTextNode(`2. ${t.stepTwo}`)])),
+      createBrandText(createDocWithPlaceholders([createTextNode(`3. ${t.stepThree}`)])),
+    ]),
+    ctaSection(t.ctaButton, config.websiteUrl),
+    paragraphSection(t.signOff),
+    createFooterSection(config.footer),
+  ];
+
+  return createBrandTemplate({
+    brandStyle: config.brandStyle,
+    preheader: t.preheader,
+    sections,
+  });
+}
+
+function buildTaxSummaryTemplate(config: VendorConsumerConfig): RCMLDocument {
+  validateCustomFields(
+    config.customFields,
+    {
+      donorFirstName: SAMFORA_FIELDS.donorFirstName,
+      taxYear: SAMFORA_FIELDS.taxYear,
+      totalLifetimeAmount: SAMFORA_FIELDS.totalLifetimeAmount,
+      taxDeductibleAmount: SAMFORA_FIELDS.taxDeductibleAmount,
+    },
+    'samforaTaxSummary',
+  );
+
+  const cf = config.customFields;
+  const firstNameId = cf[SAMFORA_FIELDS.donorFirstName];
+  const t = TAX_SUMMARY_TEXT;
+
+  const sections: RCMLBodyChild[] = [
+    greetingSection(t.heading, firstNameId),
+    paragraphSection(t.intro),
+    createContentSection([
+      createBrandHeading(
+        createDocWithPlaceholders([createTextNode(t.detailsHeading)]),
+        3,
+      ),
+    ]),
+    summaryRow(
+      t.yearLabel,
+      createDocWithPlaceholders([fieldPlaceholder(cf, SAMFORA_FIELDS.taxYear)]),
+    ),
+    summaryRow(
+      t.totalLabel,
+      createDocWithPlaceholders([
+        fieldPlaceholder(cf, SAMFORA_FIELDS.totalLifetimeAmount),
+        ...(cf[SAMFORA_FIELDS.donationCurrency] !== undefined
+          ? [
+              createTextNode(' '),
+              fieldPlaceholder(cf, SAMFORA_FIELDS.donationCurrency),
+            ]
+          : []),
+      ]),
+    ),
+    summaryRow(
+      t.deductibleLabel,
+      createDocWithPlaceholders([
+        fieldPlaceholder(cf, SAMFORA_FIELDS.taxDeductibleAmount),
+        ...(cf[SAMFORA_FIELDS.donationCurrency] !== undefined
+          ? [
+              createTextNode(' '),
+              fieldPlaceholder(cf, SAMFORA_FIELDS.donationCurrency),
+            ]
+          : []),
+      ]),
+    ),
+    paragraphSection(t.disclaimer),
+    ctaSection(t.ctaButton, config.websiteUrl),
+    paragraphSection(t.signOff),
+    createFooterSection(config.footer),
+  ];
+
+  return createBrandTemplate({
+    brandStyle: config.brandStyle,
+    preheader: t.preheader,
+    sections,
+  });
+}
+
+// ============================================================================
+// Automation definitions
+// ============================================================================
+
+/**
+ * Create the full set of Samfora automation definitions.
+ *
+ * Three donation-confirmation variants are differentiated by
+ * `conditions.hasTag` against donor-lifecycle tags — same pattern as
+ * `shopify-abandoned-cart` uses `conditions.notHasTag`.
+ */
+export function createSamforaAutomations(): VendorAutomation[] {
+  return [
+    {
+      id: 'samfora-donation-confirmation-first',
+      name: 'Samfora Donation Confirmation (first gift)',
+      description:
+        'Sent to first-time donors after a one-time donation is received',
+      triggerTag: SAMFORA_TAGS.donationReceived,
+      conditions: { hasTag: [SAMFORA_TAGS.donorFirstGift] },
+      subject: 'Tack för din första gåva!',
+      preheader: DONATION_CONFIRMATION_FIRST_TEXT.preheader,
+      templateBuilder: (config) =>
+        buildDonationConfirmationTemplate(config, DONATION_CONFIRMATION_FIRST_TEXT),
+    },
+    {
+      id: 'samfora-donation-confirmation-second',
+      name: 'Samfora Donation Confirmation (second gift)',
+      description:
+        'Sent to returning donors making their second one-time donation',
+      triggerTag: SAMFORA_TAGS.donationReceived,
+      conditions: { hasTag: [SAMFORA_TAGS.donorSecondGift] },
+      subject: 'Tack för att du ger igen!',
+      preheader: DONATION_CONFIRMATION_SECOND_TEXT.preheader,
+      templateBuilder: (config) =>
+        buildDonationConfirmationTemplate(config, DONATION_CONFIRMATION_SECOND_TEXT),
+    },
+    {
+      id: 'samfora-donation-confirmation-returning',
+      name: 'Samfora Donation Confirmation (returning donor)',
+      description:
+        'Sent to loyal donors on their third or later one-time donation',
+      triggerTag: SAMFORA_TAGS.donationReceived,
+      conditions: { hasTag: [SAMFORA_TAGS.donorReturning] },
+      subject: 'Tack för din gåva',
+      preheader: DONATION_CONFIRMATION_RETURNING_TEXT.preheader,
+      templateBuilder: (config) =>
+        buildDonationConfirmationTemplate(
+          config,
+          DONATION_CONFIRMATION_RETURNING_TEXT,
+        ),
+    },
+    {
+      id: 'samfora-monthly-donation-confirmation',
+      name: 'Samfora Monthly Donation Confirmation',
+      description: 'Sent when a scheduled monthly donation is processed',
+      triggerTag: SAMFORA_TAGS.monthlyDonation,
+      subject: 'Månadsgåva mottagen',
+      preheader: MONTHLY_DONATION_TEXT.preheader,
+      templateBuilder: buildMonthlyDonationTemplate,
+    },
+    {
+      id: 'samfora-welcome',
+      name: 'Samfora Welcome',
+      description: 'Sent when a new donor creates a Samfora account',
+      triggerTag: SAMFORA_TAGS.newDonor,
+      subject: 'Välkommen till Samfora',
+      preheader: WELCOME_TEXT.preheader,
+      templateBuilder: buildWelcomeTemplate,
+    },
+    {
+      id: 'samfora-annual-tax-summary',
+      name: 'Samfora Annual Tax Summary',
+      description:
+        'Year-end summary of donations for Swedish gåvoskatteavdrag reporting',
+      triggerTag: SAMFORA_TAGS.annualTaxSummary,
+      subject: 'Din gåvosammanställning',
+      preheader: TAX_SUMMARY_TEXT.preheader,
+      templateBuilder: buildTaxSummaryTemplate,
+    },
+  ];
+}

--- a/src/vendors/samfora/automations.ts
+++ b/src/vendors/samfora/automations.ts
@@ -17,6 +17,7 @@ import { SAMFORA_FIELDS } from './fields';
 import { SAMFORA_TAGS } from './tags';
 import {
   createBrandTemplate,
+  createBrandLogo,
   createContentSection,
   createBrandHeading,
   createBrandText,
@@ -27,11 +28,6 @@ import {
   createFooterSection,
   validateCustomFields,
 } from '../../rcml';
-// `createLogoSection` is an internal helper (not in the barrel) shared by
-// hospitality/ecommerce templates. Imported directly to keep the Samfora
-// preset consistent with those builders — every other preset's emails lead
-// with the account logo, and earlier this preset was silently missing it.
-import { createLogoSection } from '../../rcml/brand-template';
 import { RuleConfigError } from '../../errors';
 
 // ============================================================================
@@ -177,6 +173,17 @@ function samforaFooterSection(override: FooterConfig | undefined): RCMLBodyChild
 }
 
 /**
+ * Produce a zero-or-one-element array with the brand logo as the first
+ * body section. Matches the `createLogoSection` helper in `brand-template`
+ * but stays local here so the preset doesn't reach past the public `rcml`
+ * barrel — sibling presets (shopify, bookzen) only import via the barrel
+ * and mixing paths risks duplicate module instances under ESM.
+ */
+function samforaLogoSection(logoUrl: string | undefined): RCMLBodyChild[] {
+  return logoUrl ? [createBrandLogo(logoUrl)] : [];
+}
+
+/**
  * Swedish plain-text fallback. `createBrandHead()` otherwise defaults to
  * English ("View this email in your browser: ..." / "Unsubscribe: ...") —
  * same class of leak as the footer links. Passed explicitly into every
@@ -257,7 +264,7 @@ function buildDonationConfirmationTemplate(
   const firstNameId = cf[SAMFORA_FIELDS.donorFirstName];
 
   const sections: RCMLBodyChild[] = [
-    ...createLogoSection(config.brandStyle.logoUrl),
+    ...samforaLogoSection(config.brandStyle.logoUrl),
     greetingSection(text.heading, firstNameId),
     paragraphSection(text.intro),
     createContentSection([
@@ -321,7 +328,7 @@ function buildMonthlyDonationTemplate(config: VendorConsumerConfig): RCMLDocumen
   const t = MONTHLY_DONATION_TEXT;
 
   const sections: RCMLBodyChild[] = [
-    ...createLogoSection(config.brandStyle.logoUrl),
+    ...samforaLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([
@@ -378,7 +385,7 @@ function buildWelcomeTemplate(config: VendorConsumerConfig): RCMLDocument {
   const t = WELCOME_TEXT;
 
   const sections: RCMLBodyChild[] = [
-    ...createLogoSection(config.brandStyle.logoUrl),
+    ...samforaLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([
@@ -420,7 +427,7 @@ function buildTaxSummaryTemplate(config: VendorConsumerConfig): RCMLDocument {
   const t = TAX_SUMMARY_TEXT;
 
   const sections: RCMLBodyChild[] = [
-    ...createLogoSection(config.brandStyle.logoUrl),
+    ...samforaLogoSection(config.brandStyle.logoUrl),
     greetingSection(t.heading, firstNameId),
     paragraphSection(t.intro),
     createContentSection([

--- a/src/vendors/samfora/fields.ts
+++ b/src/vendors/samfora/fields.ts
@@ -10,6 +10,13 @@ import type { VendorFieldSchema } from '../types';
 /**
  * Samfora field names for Rule.io custom fields.
  *
+ * Follows Rule.io praxis for custom-field groups:
+ * - **Subscriber group (flat)** — donor identity fields that get
+ *   overwritten on each sync (e.g. `Subscriber.FirstName`).
+ * - **Donation group (historical)** — per-donation event data that
+ *   appends a new record on each sync (`Donation.Amount`,
+ *   `Donation.Date`, `Donation.Reference`, etc.).
+ *
  * @example
  * ```typescript
  * import { SAMFORA_FIELDS } from 'rule-io-sdk';
@@ -22,7 +29,10 @@ import type { VendorFieldSchema } from '../types';
  * ```
  */
 export const SAMFORA_FIELDS = {
-  donorFirstName: 'Donation.FirstName',
+  // Subscriber group — flat, overwritten per sync
+  donorFirstName: 'Subscriber.FirstName',
+
+  // Donation group — historical, append-only
   donationAmount: 'Donation.Amount',
   donationCurrency: 'Donation.Currency',
   donationDate: 'Donation.Date',

--- a/src/vendors/samfora/fields.ts
+++ b/src/vendors/samfora/fields.ts
@@ -1,0 +1,41 @@
+/**
+ * Samfora Custom Field Definitions
+ *
+ * Field names used by the Samfora donation platform integration.
+ * Samfora is a Swedish charitable giving platform.
+ */
+
+import type { VendorFieldSchema } from '../types';
+
+/**
+ * Samfora field names for Rule.io custom fields.
+ *
+ * @example
+ * ```typescript
+ * import { SAMFORA_FIELDS } from 'rule-io-sdk';
+ *
+ * const customFields = {
+ *   [SAMFORA_FIELDS.donorFirstName]: 200001,
+ *   [SAMFORA_FIELDS.donationAmount]: 200002,
+ *   // ... map all fields to your Rule.io numeric IDs
+ * };
+ * ```
+ */
+export const SAMFORA_FIELDS = {
+  donorFirstName: 'Donation.FirstName',
+  donationAmount: 'Donation.Amount',
+  donationCurrency: 'Donation.Currency',
+  donationDate: 'Donation.Date',
+  donationRef: 'Donation.Reference',
+  causeName: 'Donation.CauseName',
+  donationType: 'Donation.Type',
+  totalLifetimeAmount: 'Donation.TotalLifetime',
+  taxYear: 'Donation.TaxYear',
+  taxDeductibleAmount: 'Donation.TaxDeductible',
+} as const satisfies VendorFieldSchema;
+
+/** Object type of the Samfora field schema. */
+export type SamforaFieldSchema = typeof SAMFORA_FIELDS;
+
+/** Union of logical Samfora field name keys. */
+export type SamforaFieldNames = keyof SamforaFieldSchema;

--- a/src/vendors/samfora/fields.ts
+++ b/src/vendors/samfora/fields.ts
@@ -12,7 +12,12 @@ import type { VendorFieldSchema } from '../types';
  *
  * Follows Rule.io praxis for custom-field groups:
  * - **Subscriber group (flat)** — donor identity fields that get
- *   overwritten on each sync (e.g. `Subscriber.FirstName`).
+ *   overwritten on each sync. Uses Rule.io's standard subscriber
+ *   field names so consumers can reuse the fields that already exist
+ *   on every Rule.io account instead of creating new custom ones.
+ *   Only `donorFirstName` is required by the preset's templates;
+ *   the rest are mapped for completeness so consumer extensions
+ *   can reference them.
  * - **Donation group (historical)** — per-donation event data that
  *   appends a new record on each sync (`Donation.Amount`,
  *   `Donation.Date`, `Donation.Reference`, etc.).
@@ -22,17 +27,28 @@ import type { VendorFieldSchema } from '../types';
  * import { SAMFORA_FIELDS } from 'rule-io-sdk';
  *
  * const customFields = {
- *   [SAMFORA_FIELDS.donorFirstName]: 200001,
- *   [SAMFORA_FIELDS.donationAmount]: 200002,
- *   // ... map all fields to your Rule.io numeric IDs
+ *   [SAMFORA_FIELDS.donorFirstName]: 47736,   // pre-existing in account
+ *   [SAMFORA_FIELDS.donationAmount]: 200002,  // created by setup
+ *   // ... map to your account's numeric IDs
  * };
  * ```
  */
 export const SAMFORA_FIELDS = {
-  // Subscriber group — flat, overwritten per sync
+  // Subscriber group — flat, uses Rule.io's standard subscriber fields.
+  // Only `donorFirstName` is required (used in greetings); the rest
+  // are exposed so consumers can reference them in custom extensions.
   donorFirstName: 'Subscriber.FirstName',
+  donorLastName: 'Subscriber.LastName',
+  donorAddress1: 'Subscriber.Address1',
+  donorAddress2: 'Subscriber.Address2',
+  donorZipcode: 'Subscriber.Zipcode',
+  donorCity: 'Subscriber.City',
+  donorCountry: 'Subscriber.Country',
+  donorPhone: 'Subscriber.Number',
+  donorSource: 'Subscriber.Source',
 
-  // Donation group — historical, append-only
+  // Donation group — historical, append-only. Created per-account
+  // by consumers or by a setup script.
   donationAmount: 'Donation.Amount',
   donationCurrency: 'Donation.Currency',
   donationDate: 'Donation.Date',

--- a/src/vendors/samfora/index.ts
+++ b/src/vendors/samfora/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Samfora Vendor Preset
+ *
+ * Donation-platform preset for Samfora (https://samfora.org) integrations
+ * with Rule.io. Default copy ships in Swedish.
+ */
+
+export { samforaPreset } from './preset';
+export { SAMFORA_FIELDS } from './fields';
+export { SAMFORA_TAGS } from './tags';
+export type { SamforaFieldSchema, SamforaFieldNames } from './fields';
+export type { SamforaTagSchema, SamforaTagNames } from './tags';

--- a/src/vendors/samfora/preset.ts
+++ b/src/vendors/samfora/preset.ts
@@ -1,0 +1,120 @@
+/**
+ * Samfora Vendor Preset
+ *
+ * Swedish charitable-donation preset for Samfora integrations with Rule.io.
+ *
+ * @example
+ * ```typescript
+ * import { samforaPreset, SAMFORA_FIELDS } from 'rule-io-sdk';
+ *
+ * const config = {
+ *   brandStyle: myBrandStyle,
+ *   customFields: {
+ *     [SAMFORA_FIELDS.donorFirstName]: 200001,
+ *     [SAMFORA_FIELDS.donationAmount]: 200002,
+ *     [SAMFORA_FIELDS.donationDate]: 200003,
+ *     [SAMFORA_FIELDS.donationRef]: 200004,
+ *     [SAMFORA_FIELDS.causeName]: 200005,
+ *   },
+ *   websiteUrl: 'https://samfora.org',
+ * };
+ *
+ * samforaPreset.validateConfig(config);
+ * const automations = samforaPreset.getAutomations(config);
+ * ```
+ */
+
+import type { VendorPreset, VendorConsumerConfig, VendorFieldInfo } from '../types';
+import { resolveVendorAutomations } from '../types';
+import type { AutomationConfigV2 } from '../../automation-configs-v2';
+import type { SamforaFieldSchema, SamforaFieldNames } from './fields';
+import type { SamforaTagSchema } from './tags';
+import { SAMFORA_FIELDS } from './fields';
+import { SAMFORA_TAGS } from './tags';
+import { createSamforaAutomations } from './automations';
+import { RuleConfigError } from '../../errors';
+
+const FIELD_DESCRIPTIONS: Record<SamforaFieldNames, string> = {
+  donorFirstName: 'Donor first name',
+  donationAmount: 'Amount of the donation',
+  donationCurrency: 'Currency code (e.g. SEK, EUR)',
+  donationDate: 'Date the donation was made',
+  donationRef: 'Receipt / transaction reference',
+  causeName: 'Charity or cause the gift supports',
+  donationType: 'Donation type (one-time / monthly)',
+  totalLifetimeAmount: "Donor's lifetime total (used in the annual tax summary)",
+  taxYear: 'Tax year for the annual summary',
+  taxDeductibleAmount: 'Deductible amount for Swedish gåvoskatteavdrag',
+};
+
+/**
+ * Fields required by the core confirmation / monthly / welcome flows.
+ *
+ * The annual-tax-summary automation additionally requires `taxYear`,
+ * `totalLifetimeAmount`, and `taxDeductibleAmount`. Those are validated
+ * inside that template builder rather than gated at config-level, so a
+ * consumer who doesn't ship the tax summary isn't forced to map them.
+ */
+const REQUIRED_FIELDS: readonly SamforaFieldNames[] = [
+  'donorFirstName',
+  'donationAmount',
+  'donationDate',
+  'donationRef',
+  'causeName',
+];
+
+function validateSamforaConfig(config: VendorConsumerConfig): void {
+  const missingFields: string[] = [];
+  for (const logicalName of REQUIRED_FIELDS) {
+    const fieldName = SAMFORA_FIELDS[logicalName];
+    if (config.customFields[fieldName] === undefined) {
+      missingFields.push(`${logicalName} ("${fieldName}")`);
+    }
+  }
+  if (missingFields.length > 0) {
+    throw new RuleConfigError(
+      `samforaPreset: missing customFields entries for: ${missingFields.join(', ')}`,
+    );
+  }
+}
+
+function resolveAutomations(config: VendorConsumerConfig): AutomationConfigV2[] {
+  return resolveVendorAutomations(createSamforaAutomations(), config);
+}
+
+/**
+ * Samfora vendor preset for Rule.io.
+ *
+ * Provides pre-configured automations for the Samfora donation platform:
+ * donation confirmation (first-time, second, and returning donors),
+ * monthly donation confirmation, welcome, and annual tax summary.
+ *
+ * All default copy is in Swedish to match Samfora's market.
+ */
+export const samforaPreset: VendorPreset<SamforaFieldSchema, SamforaTagSchema> = {
+  vendor: 'samfora',
+  displayName: 'Samfora',
+  vertical: 'donation',
+  fields: SAMFORA_FIELDS,
+  tags: SAMFORA_TAGS,
+
+  getAutomations(config: VendorConsumerConfig): AutomationConfigV2[] {
+    validateSamforaConfig(config);
+    return resolveAutomations(config);
+  },
+
+  getAutomation(id: string, config: VendorConsumerConfig): AutomationConfigV2 | undefined {
+    validateSamforaConfig(config);
+    return resolveAutomations(config).find((a) => a.id === id);
+  },
+
+  validateConfig: validateSamforaConfig,
+
+  getRequiredFields(): readonly VendorFieldInfo[] {
+    return REQUIRED_FIELDS.map((logicalName) => ({
+      logicalName,
+      fieldName: SAMFORA_FIELDS[logicalName],
+      description: FIELD_DESCRIPTIONS[logicalName],
+    }));
+  },
+};

--- a/src/vendors/samfora/preset.ts
+++ b/src/vendors/samfora/preset.ts
@@ -48,12 +48,18 @@ const FIELD_DESCRIPTIONS: Record<SamforaFieldNames, string> = {
 };
 
 /**
- * Fields required by the core confirmation / monthly / welcome flows.
+ * Fields required by every automation `getAutomations()` returns.
  *
- * The annual-tax-summary automation additionally requires `taxYear`,
- * `totalLifetimeAmount`, and `taxDeductibleAmount`. Those are validated
- * inside that template builder rather than gated at config-level, so a
- * consumer who doesn't ship the tax summary isn't forced to map them.
+ * Includes the tax-summary's extra fields (`taxYear`, `totalLifetimeAmount`,
+ * `taxDeductibleAmount`) so that `validateConfig` passing guarantees every
+ * automation in the returned array is buildable. Earlier versions left the
+ * tax fields out and validated them inside the template builder, which
+ * created a contract mismatch — a consumer could pass validation and still
+ * hit a runtime error while iterating.
+ *
+ * `donationCurrency` and `donationType` stay optional: currency is a nice-
+ * to-have display token, and `donationType` isn't referenced by any of the
+ * current template builders.
  */
 const REQUIRED_FIELDS: readonly SamforaFieldNames[] = [
   'donorFirstName',
@@ -61,6 +67,9 @@ const REQUIRED_FIELDS: readonly SamforaFieldNames[] = [
   'donationDate',
   'donationRef',
   'causeName',
+  'totalLifetimeAmount',
+  'taxYear',
+  'taxDeductibleAmount',
 ];
 
 function validateSamforaConfig(config: VendorConsumerConfig): void {

--- a/src/vendors/samfora/preset.ts
+++ b/src/vendors/samfora/preset.ts
@@ -39,7 +39,18 @@ import { createSamforaAutomations } from './automations';
 import { RuleConfigError } from '../../errors';
 
 const FIELD_DESCRIPTIONS: Record<SamforaFieldNames, string> = {
-  donorFirstName: 'Donor first name',
+  // Subscriber (standard Rule.io fields)
+  donorFirstName: 'Donor first name (standard Subscriber field)',
+  donorLastName: 'Donor last name (standard Subscriber field)',
+  donorAddress1: 'Donor street address, line 1 (standard Subscriber field)',
+  donorAddress2: 'Donor street address, line 2 (standard Subscriber field)',
+  donorZipcode: 'Donor postal / ZIP code (standard Subscriber field)',
+  donorCity: 'Donor city (standard Subscriber field)',
+  donorCountry: 'Donor country (standard Subscriber field)',
+  donorPhone: 'Donor phone number (standard Subscriber.Number field)',
+  donorSource: 'Signup source (standard Subscriber field)',
+
+  // Donation (historical)
   donationAmount: 'Amount of the donation',
   donationCurrency: 'Currency code (e.g. SEK, EUR)',
   donationDate: 'Date the donation was made',
@@ -60,6 +71,11 @@ const FIELD_DESCRIPTIONS: Record<SamforaFieldNames, string> = {
  * tax fields out and validated them inside the template builder, which
  * created a contract mismatch — a consumer could pass validation and still
  * hit a runtime error while iterating.
+ *
+ * Subscriber-group fields beyond `donorFirstName` (last name, address,
+ * city, etc.) stay optional — they're exposed in `SAMFORA_FIELDS` so
+ * consumers can reference them from custom extensions, but none of the
+ * preset's own template builders currently render them.
  *
  * `donationCurrency` and `donationType` stay optional: currency is a nice-
  * to-have display token, and `donationType` isn't referenced by any of the

--- a/src/vendors/samfora/preset.ts
+++ b/src/vendors/samfora/preset.ts
@@ -15,6 +15,10 @@
  *     [SAMFORA_FIELDS.donationDate]: 200003,
  *     [SAMFORA_FIELDS.donationRef]: 200004,
  *     [SAMFORA_FIELDS.causeName]: 200005,
+ *     [SAMFORA_FIELDS.totalLifetimeAmount]: 200006,
+ *     [SAMFORA_FIELDS.taxYear]: 200007,
+ *     [SAMFORA_FIELDS.taxDeductibleAmount]: 200008,
+ *     // Optional: donationCurrency, donationType
  *   },
  *   websiteUrl: 'https://samfora.org',
  * };

--- a/src/vendors/samfora/tags.ts
+++ b/src/vendors/samfora/tags.ts
@@ -1,0 +1,44 @@
+/**
+ * Samfora Tag Definitions
+ *
+ * Tags used by the Samfora charitable donation integration with Rule.io.
+ *
+ * Trigger tags fire an automation. Segment tags refine behaviour (e.g.
+ * branch donation-confirmation copy between first-time, second-time, and
+ * returning donors) without triggering a new flow on their own.
+ */
+
+import type { VendorTagSchema } from '../types';
+
+/**
+ * Samfora tags for Rule.io automations.
+ *
+ * @example
+ * ```typescript
+ * import { SAMFORA_TAGS } from 'rule-io-sdk';
+ *
+ * await client.syncSubscriber({
+ *   email: 'donor@example.com',
+ *   tags: [SAMFORA_TAGS.donationReceived, SAMFORA_TAGS.donorFirstGift],
+ * });
+ * ```
+ */
+export const SAMFORA_TAGS = {
+  /** Trigger tags — each starts a distinct automation */
+  donationReceived: 'donation-received',
+  monthlyDonation: 'monthly-donation',
+  newDonor: 'new-donor',
+  annualTaxSummary: 'annual-tax-summary',
+
+  /** Donor-lifecycle segment tags — used as conditions on confirmation flows */
+  donorFirstGift: 'donor-first-gift',
+  donorSecondGift: 'donor-second-gift',
+  donorReturning: 'donor-returning',
+  monthlyGiver: 'monthly-giver',
+} as const satisfies VendorTagSchema;
+
+/** Object type of the Samfora tag schema. */
+export type SamforaTagSchema = typeof SAMFORA_TAGS;
+
+/** Union of logical Samfora tag name keys. */
+export type SamforaTagNames = keyof SamforaTagSchema;

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -296,6 +296,54 @@ describe('samforaPreset', () => {
       expect(json).toContain('Ändamål');
     });
 
+    it('footer defaults to Swedish when config.footer is omitted', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      const doc = first.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://samfora.org',
+      });
+      const json = docToString(doc);
+
+      // Swedish footer link text (display strings, not merge-tag names).
+      expect(json).toContain('"text":"Öppna i webbläsare"');
+      expect(json).toContain('"text":"Avregistrera"');
+      // Guard against the generic builder's English display defaults
+      // leaking through. (`[Link:Unsubscribe]` merge-tag references are
+      // NOT user-visible — Rule.io substitutes them at send time.)
+      expect(json).not.toContain('"text":"View in browser"');
+      expect(json).not.toContain('"text":"Unsubscribe"');
+      // Plain-text fallback is localised too.
+      expect(json).toContain('Öppna e-postmeddelandet i webbläsaren');
+      expect(json).not.toContain('View this email in your browser');
+    });
+
+    it('consumer footer overrides still win over Swedish defaults', () => {
+      const automations = samforaPreset.getAutomations({
+        ...TEST_CONFIG,
+        footer: { viewInBrowserText: 'Open in browser' },
+      });
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      const doc = first.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://samfora.org',
+      });
+      const json = docToString(doc);
+
+      // Override of one field wins; untouched fields fall back to Swedish.
+      expect(json).toContain('"text":"Open in browser"');
+      expect(json).not.toContain('"text":"Öppna i webbläsare"');
+      expect(json).toContain('"text":"Avregistrera"');
+    });
+
     it('throws RuleConfigError for an incomplete config', () => {
       expect(() =>
         samforaPreset.getAutomations({ ...TEST_CONFIG, customFields: {} }),

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -144,10 +144,21 @@ describe('samforaPreset', () => {
       expect(logicalNames).toContain('taxDeductibleAmount');
     });
 
-    it('excludes the optional currency and donationType fields', () => {
+    it('excludes the optional donation and subscriber-extension fields', () => {
       const logicalNames = samforaPreset.getRequiredFields().map((f) => f.logicalName);
+      // Donation fields the preset's templates don't reference.
       expect(logicalNames).not.toContain('donationCurrency');
       expect(logicalNames).not.toContain('donationType');
+      // Standard Subscriber fields the preset exposes for consumer
+      // extensions but doesn't itself render.
+      expect(logicalNames).not.toContain('donorLastName');
+      expect(logicalNames).not.toContain('donorAddress1');
+      expect(logicalNames).not.toContain('donorAddress2');
+      expect(logicalNames).not.toContain('donorZipcode');
+      expect(logicalNames).not.toContain('donorCity');
+      expect(logicalNames).not.toContain('donorCountry');
+      expect(logicalNames).not.toContain('donorPhone');
+      expect(logicalNames).not.toContain('donorSource');
     });
   });
 
@@ -429,7 +440,20 @@ describe('SAMFORA_FIELDS', () => {
     // Rule.io praxis: donor identity on the flat Subscriber.* group
     // (overwritten per sync); per-donation event data on the historical
     // Donation.* group (appended per sync).
-    expect(SAMFORA_FIELDS.donorFirstName).toBe('Subscriber.FirstName');
+    const subscriberFields = [
+      SAMFORA_FIELDS.donorFirstName,
+      SAMFORA_FIELDS.donorLastName,
+      SAMFORA_FIELDS.donorAddress1,
+      SAMFORA_FIELDS.donorAddress2,
+      SAMFORA_FIELDS.donorZipcode,
+      SAMFORA_FIELDS.donorCity,
+      SAMFORA_FIELDS.donorCountry,
+      SAMFORA_FIELDS.donorPhone,
+      SAMFORA_FIELDS.donorSource,
+    ];
+    for (const value of subscriberFields) {
+      expect(value.startsWith('Subscriber.')).toBe(true);
+    }
 
     const donationFields = [
       SAMFORA_FIELDS.donationAmount,
@@ -445,6 +469,20 @@ describe('SAMFORA_FIELDS', () => {
     for (const value of donationFields) {
       expect(value.startsWith('Donation.')).toBe(true);
     }
+  });
+
+  it('uses Rule.io standard Subscriber field names exactly', () => {
+    // These must match Rule.io's pre-seeded standard subscriber field
+    // names so consumers don't have to create new custom fields.
+    expect(SAMFORA_FIELDS.donorFirstName).toBe('Subscriber.FirstName');
+    expect(SAMFORA_FIELDS.donorLastName).toBe('Subscriber.LastName');
+    expect(SAMFORA_FIELDS.donorAddress1).toBe('Subscriber.Address1');
+    expect(SAMFORA_FIELDS.donorAddress2).toBe('Subscriber.Address2');
+    expect(SAMFORA_FIELDS.donorZipcode).toBe('Subscriber.Zipcode');
+    expect(SAMFORA_FIELDS.donorCity).toBe('Subscriber.City');
+    expect(SAMFORA_FIELDS.donorCountry).toBe('Subscriber.Country');
+    expect(SAMFORA_FIELDS.donorPhone).toBe('Subscriber.Number');
+    expect(SAMFORA_FIELDS.donorSource).toBe('Subscriber.Source');
   });
 
   it('every field uses either a Subscriber.* or Donation.* prefix', () => {

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Samfora Vendor Preset Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CustomFieldMap } from '../../src/rcml';
+import type { VendorConsumerConfig } from '../../src/vendors/types';
+import { RuleConfigError } from '../../src/errors';
+import { samforaPreset, SAMFORA_FIELDS, SAMFORA_TAGS } from '../../src/vendors/samfora';
+import { TEST_BRAND_STYLE, assertValidRCMLDocument, docToString } from '../helpers';
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+/** Core fields required by all automations except the tax summary. */
+const TEST_CUSTOM_FIELDS: CustomFieldMap = {
+  [SAMFORA_FIELDS.donorFirstName]: 200001,
+  [SAMFORA_FIELDS.donationAmount]: 200002,
+  [SAMFORA_FIELDS.donationDate]: 200003,
+  [SAMFORA_FIELDS.donationRef]: 200004,
+  [SAMFORA_FIELDS.causeName]: 200005,
+};
+
+/** Extended map that also covers the tax-summary automation. */
+const TEST_CUSTOM_FIELDS_FULL: CustomFieldMap = {
+  ...TEST_CUSTOM_FIELDS,
+  [SAMFORA_FIELDS.donationCurrency]: 200006,
+  [SAMFORA_FIELDS.donationType]: 200007,
+  [SAMFORA_FIELDS.totalLifetimeAmount]: 200008,
+  [SAMFORA_FIELDS.taxYear]: 200009,
+  [SAMFORA_FIELDS.taxDeductibleAmount]: 200010,
+};
+
+const TEST_CONFIG: VendorConsumerConfig = {
+  brandStyle: TEST_BRAND_STYLE,
+  customFields: TEST_CUSTOM_FIELDS,
+  websiteUrl: 'https://samfora.org',
+};
+
+const TEST_CONFIG_FULL: VendorConsumerConfig = {
+  brandStyle: TEST_BRAND_STYLE,
+  customFields: TEST_CUSTOM_FIELDS_FULL,
+  websiteUrl: 'https://samfora.org',
+};
+
+// ============================================================================
+// Preset metadata
+// ============================================================================
+
+describe('samforaPreset', () => {
+  it('has correct vendor metadata', () => {
+    expect(samforaPreset.vendor).toBe('samfora');
+    expect(samforaPreset.displayName).toBe('Samfora');
+    expect(samforaPreset.vertical).toBe('donation');
+  });
+
+  it('exposes field and tag schemas', () => {
+    expect(samforaPreset.fields).toBe(SAMFORA_FIELDS);
+    expect(samforaPreset.tags).toBe(SAMFORA_TAGS);
+  });
+
+  // ==========================================================================
+  // Validation
+  // ==========================================================================
+
+  describe('validateConfig', () => {
+    it('passes with all required fields', () => {
+      expect(() => samforaPreset.validateConfig(TEST_CONFIG)).not.toThrow();
+    });
+
+    it('throws RuleConfigError when any required field is missing', () => {
+      const incomplete: VendorConsumerConfig = {
+        ...TEST_CONFIG,
+        customFields: {
+          [SAMFORA_FIELDS.donorFirstName]: 200001,
+        },
+      };
+      expect(() => samforaPreset.validateConfig(incomplete)).toThrow(RuleConfigError);
+    });
+
+    it('error message lists the missing fields', () => {
+      const empty: VendorConsumerConfig = { ...TEST_CONFIG, customFields: {} };
+      expect(() => samforaPreset.validateConfig(empty)).toThrow(
+        /samforaPreset.*donorFirstName/,
+      );
+    });
+
+    it('does not require tax-summary fields', () => {
+      // Tax fields aren't mapped in TEST_CUSTOM_FIELDS — validateConfig passes.
+      expect(() => samforaPreset.validateConfig(TEST_CONFIG)).not.toThrow();
+    });
+  });
+
+  // ==========================================================================
+  // getRequiredFields
+  // ==========================================================================
+
+  describe('getRequiredFields', () => {
+    it('returns the core required fields with descriptions', () => {
+      const fields = samforaPreset.getRequiredFields();
+      expect(fields.length).toBeGreaterThan(0);
+      for (const field of fields) {
+        expect(field.logicalName).toBeTruthy();
+        expect(field.fieldName).toBeTruthy();
+        expect(field.description).toBeTruthy();
+        expect(
+          SAMFORA_FIELDS[field.logicalName as keyof typeof SAMFORA_FIELDS],
+        ).toBe(field.fieldName);
+      }
+    });
+
+    it('includes the core donation fields', () => {
+      const logicalNames = samforaPreset.getRequiredFields().map((f) => f.logicalName);
+      expect(logicalNames).toContain('donorFirstName');
+      expect(logicalNames).toContain('donationAmount');
+      expect(logicalNames).toContain('donationDate');
+      expect(logicalNames).toContain('donationRef');
+      expect(logicalNames).toContain('causeName');
+    });
+  });
+
+  // ==========================================================================
+  // getAutomations
+  // ==========================================================================
+
+  describe('getAutomations', () => {
+    it('returns 6 automations', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      expect(automations).toHaveLength(6);
+    });
+
+    it('returns automations with unique IDs', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const ids = automations.map((a) => a.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('all automations have trigger tags from SAMFORA_TAGS', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const validTags = new Set(Object.values(SAMFORA_TAGS));
+      for (const automation of automations) {
+        expect(validTags.has(automation.triggerTag)).toBe(true);
+      }
+    });
+
+    it('the three confirmation variants share a trigger but differ by condition', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const confirmations = automations.filter(
+        (a) => a.triggerTag === SAMFORA_TAGS.donationReceived,
+      );
+      expect(confirmations).toHaveLength(3);
+
+      const conditionSignatures = confirmations.map((a) =>
+        JSON.stringify(a.conditions ?? {}),
+      );
+      expect(new Set(conditionSignatures).size).toBe(3);
+
+      const ids = confirmations.map((a) => a.id);
+      expect(ids).toContain('samfora-donation-confirmation-first');
+      expect(ids).toContain('samfora-donation-confirmation-second');
+      expect(ids).toContain('samfora-donation-confirmation-returning');
+    });
+
+    it('confirmation variants gate on donor-lifecycle tags', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+      const second = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-second',
+      )!;
+      const returning = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-returning',
+      )!;
+
+      expect(first.conditions?.hasTag).toEqual([SAMFORA_TAGS.donorFirstGift]);
+      expect(second.conditions?.hasTag).toEqual([SAMFORA_TAGS.donorSecondGift]);
+      expect(returning.conditions?.hasTag).toEqual([SAMFORA_TAGS.donorReturning]);
+    });
+
+    it('all automations produce valid RCML documents (with full fields)', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      for (const automation of automations) {
+        const doc = automation.templateBuilder({
+          brandStyle: TEST_BRAND_STYLE,
+          customFields: TEST_CUSTOM_FIELDS_FULL,
+          websiteUrl: 'https://samfora.org',
+        });
+        assertValidRCMLDocument(doc);
+      }
+    });
+
+    it('core automations produce valid RCML without the optional tax fields', () => {
+      // Skip the tax-summary automation, which legitimately requires tax fields.
+      const automations = samforaPreset
+        .getAutomations(TEST_CONFIG)
+        .filter((a) => a.id !== 'samfora-annual-tax-summary');
+
+      for (const automation of automations) {
+        const doc = automation.templateBuilder({
+          brandStyle: TEST_BRAND_STYLE,
+          customFields: TEST_CUSTOM_FIELDS,
+          websiteUrl: 'https://samfora.org',
+        });
+        assertValidRCMLDocument(doc);
+      }
+    });
+
+    it('tax-summary template throws when its extra fields are missing', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
+      const taxSummary = automations.find(
+        (a) => a.id === 'samfora-annual-tax-summary',
+      )!;
+
+      expect(() =>
+        taxSummary.templateBuilder({
+          brandStyle: TEST_BRAND_STYLE,
+          customFields: TEST_CUSTOM_FIELDS,
+          websiteUrl: 'https://samfora.org',
+        }),
+      ).toThrow(/taxYear|totalLifetimeAmount|taxDeductibleAmount/);
+    });
+
+    it('templateBuilder honors TemplateConfigV2 overrides', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      const doc = first.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: {
+          ...TEST_CUSTOM_FIELDS_FULL,
+          [SAMFORA_FIELDS.donationAmount]: 999999,
+        },
+        websiteUrl: 'https://override.example.com',
+      });
+      const json = docToString(doc);
+
+      expect(json).toContain('[CustomField:999999]');
+      expect(json).not.toContain('[CustomField:200002]');
+    });
+
+    it('RCML contains Samfora field placeholders', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      const doc = first.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS_FULL,
+        websiteUrl: 'https://samfora.org',
+      });
+      const json = docToString(doc);
+
+      expect(json).toContain('[CustomField:200001]'); // donorFirstName
+      expect(json).toContain('[CustomField:200002]'); // donationAmount
+      expect(json).toContain('[CustomField:200005]'); // causeName
+    });
+
+    it('default copy is in Swedish', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      expect(first.subject).toContain('Tack');
+      const doc = first.templateBuilder({
+        brandStyle: TEST_BRAND_STYLE,
+        customFields: TEST_CUSTOM_FIELDS_FULL,
+        websiteUrl: 'https://samfora.org',
+      });
+      const json = docToString(doc);
+      expect(json).toContain('Tack för din första gåva');
+      expect(json).toContain('Ändamål');
+    });
+
+    it('throws RuleConfigError for an incomplete config', () => {
+      expect(() =>
+        samforaPreset.getAutomations({ ...TEST_CONFIG, customFields: {} }),
+      ).toThrow(RuleConfigError);
+    });
+  });
+
+  // ==========================================================================
+  // getAutomation
+  // ==========================================================================
+
+  describe('getAutomation', () => {
+    it('returns a single automation by ID', () => {
+      const automation = samforaPreset.getAutomation(
+        'samfora-welcome',
+        TEST_CONFIG,
+      );
+      expect(automation).toBeDefined();
+      expect(automation!.id).toBe('samfora-welcome');
+    });
+
+    it('returns undefined for an unknown ID', () => {
+      const automation = samforaPreset.getAutomation('nonexistent', TEST_CONFIG);
+      expect(automation).toBeUndefined();
+    });
+  });
+});
+
+// ============================================================================
+// Field and tag constants
+// ============================================================================
+
+describe('SAMFORA_FIELDS', () => {
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(SAMFORA_FIELDS)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all values use the Donation.* prefix', () => {
+    for (const value of Object.values(SAMFORA_FIELDS)) {
+      expect(value.startsWith('Donation.')).toBe(true);
+    }
+  });
+});
+
+describe('SAMFORA_TAGS', () => {
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(SAMFORA_TAGS)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all values are unique', () => {
+    const values = Object.values(SAMFORA_TAGS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -293,7 +293,7 @@ describe('samforaPreset', () => {
     it('every automation leads with the brand logo section', () => {
       // Parity with bookzen/shopify: the logo must be the first body child
       // when the brand style has a logoUrl. Earlier versions silently
-      // omitted it, so Rule.io renders arrived without a header image.
+      // omitted it, so rendered emails had no header image.
       const automations = samforaPreset.getAutomations(TEST_CONFIG);
       for (const automation of automations) {
         const doc = automation.templateBuilder({

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -425,9 +425,31 @@ describe('SAMFORA_FIELDS', () => {
     }
   });
 
-  it('all values use the Donation.* prefix', () => {
-    for (const value of Object.values(SAMFORA_FIELDS)) {
+  it('splits fields between the flat Subscriber group and the historical Donation group', () => {
+    // Rule.io praxis: donor identity on the flat Subscriber.* group
+    // (overwritten per sync); per-donation event data on the historical
+    // Donation.* group (appended per sync).
+    expect(SAMFORA_FIELDS.donorFirstName).toBe('Subscriber.FirstName');
+
+    const donationFields = [
+      SAMFORA_FIELDS.donationAmount,
+      SAMFORA_FIELDS.donationCurrency,
+      SAMFORA_FIELDS.donationDate,
+      SAMFORA_FIELDS.donationRef,
+      SAMFORA_FIELDS.causeName,
+      SAMFORA_FIELDS.donationType,
+      SAMFORA_FIELDS.totalLifetimeAmount,
+      SAMFORA_FIELDS.taxYear,
+      SAMFORA_FIELDS.taxDeductibleAmount,
+    ];
+    for (const value of donationFields) {
       expect(value.startsWith('Donation.')).toBe(true);
+    }
+  });
+
+  it('every field uses either a Subscriber.* or Donation.* prefix', () => {
+    for (const value of Object.values(SAMFORA_FIELDS)) {
+      expect(/^(Subscriber|Donation)\./.test(value)).toBe(true);
     }
   });
 });

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -279,6 +279,47 @@ describe('samforaPreset', () => {
       expect(json).toContain('[CustomField:200005]'); // causeName
     });
 
+    it('every automation leads with the brand logo section', () => {
+      // Parity with bookzen/shopify: the logo must be the first body child
+      // when the brand style has a logoUrl. Earlier versions silently
+      // omitted it, so Rule.io renders arrived without a header image.
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
+      for (const automation of automations) {
+        const doc = automation.templateBuilder({
+          brandStyle: TEST_BRAND_STYLE,
+          customFields: TEST_CUSTOM_FIELDS,
+          websiteUrl: 'https://samfora.org',
+        });
+        // The RCML body is the second top-level child (after rc-head).
+        const body = doc.children[1];
+        expect(body.tagName).toBe('rc-body');
+        const firstBodyChild = body.children[0];
+        // rc-logo nests inside rc-section > rc-column > rc-logo.
+        expect(firstBodyChild.tagName).toBe('rc-section');
+        const firstColumn = (firstBodyChild as { children: { tagName: string; children?: { tagName: string }[] }[] }).children[0];
+        expect(firstColumn.tagName).toBe('rc-column');
+        expect(firstColumn.children?.[0].tagName).toBe('rc-logo');
+      }
+    });
+
+    it('omits the logo section when brandStyle has no logoUrl', () => {
+      const automations = samforaPreset.getAutomations({
+        ...TEST_CONFIG,
+        brandStyle: { ...TEST_BRAND_STYLE, logoUrl: undefined },
+      });
+      const first = automations.find(
+        (a) => a.id === 'samfora-donation-confirmation-first',
+      )!;
+
+      const doc = first.templateBuilder({
+        brandStyle: { ...TEST_BRAND_STYLE, logoUrl: undefined },
+        customFields: TEST_CUSTOM_FIELDS,
+        websiteUrl: 'https://samfora.org',
+      });
+      const json = docToString(doc);
+      expect(json).not.toContain('"tagName":"rc-logo"');
+    });
+
     it('default copy is in Swedish', () => {
       const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const first = automations.find(

--- a/tests/vendors/samfora.test.ts
+++ b/tests/vendors/samfora.test.ts
@@ -13,23 +13,26 @@ import { TEST_BRAND_STYLE, assertValidRCMLDocument, docToString } from '../helpe
 // Shared fixtures
 // ============================================================================
 
-/** Core fields required by all automations except the tax summary. */
+/**
+ * Every field `validateConfig` requires. This set guarantees that every
+ * automation returned by `getAutomations(TEST_CONFIG)` is buildable.
+ */
 const TEST_CUSTOM_FIELDS: CustomFieldMap = {
   [SAMFORA_FIELDS.donorFirstName]: 200001,
   [SAMFORA_FIELDS.donationAmount]: 200002,
   [SAMFORA_FIELDS.donationDate]: 200003,
   [SAMFORA_FIELDS.donationRef]: 200004,
   [SAMFORA_FIELDS.causeName]: 200005,
-};
-
-/** Extended map that also covers the tax-summary automation. */
-const TEST_CUSTOM_FIELDS_FULL: CustomFieldMap = {
-  ...TEST_CUSTOM_FIELDS,
-  [SAMFORA_FIELDS.donationCurrency]: 200006,
-  [SAMFORA_FIELDS.donationType]: 200007,
   [SAMFORA_FIELDS.totalLifetimeAmount]: 200008,
   [SAMFORA_FIELDS.taxYear]: 200009,
   [SAMFORA_FIELDS.taxDeductibleAmount]: 200010,
+};
+
+/** Optional fields (currency display + donation type). */
+const TEST_CUSTOM_FIELDS_WITH_OPTIONAL: CustomFieldMap = {
+  ...TEST_CUSTOM_FIELDS,
+  [SAMFORA_FIELDS.donationCurrency]: 200006,
+  [SAMFORA_FIELDS.donationType]: 200007,
 };
 
 const TEST_CONFIG: VendorConsumerConfig = {
@@ -38,9 +41,9 @@ const TEST_CONFIG: VendorConsumerConfig = {
   websiteUrl: 'https://samfora.org',
 };
 
-const TEST_CONFIG_FULL: VendorConsumerConfig = {
+const TEST_CONFIG_WITH_OPTIONAL: VendorConsumerConfig = {
   brandStyle: TEST_BRAND_STYLE,
-  customFields: TEST_CUSTOM_FIELDS_FULL,
+  customFields: TEST_CUSTOM_FIELDS_WITH_OPTIONAL,
   websiteUrl: 'https://samfora.org',
 };
 
@@ -86,8 +89,24 @@ describe('samforaPreset', () => {
       );
     });
 
-    it('does not require tax-summary fields', () => {
-      // Tax fields aren't mapped in TEST_CUSTOM_FIELDS — validateConfig passes.
+    it('requires tax-summary fields so every returned automation is buildable', () => {
+      const withoutTaxFields: VendorConsumerConfig = {
+        ...TEST_CONFIG,
+        customFields: {
+          [SAMFORA_FIELDS.donorFirstName]: 200001,
+          [SAMFORA_FIELDS.donationAmount]: 200002,
+          [SAMFORA_FIELDS.donationDate]: 200003,
+          [SAMFORA_FIELDS.donationRef]: 200004,
+          [SAMFORA_FIELDS.causeName]: 200005,
+        },
+      };
+      expect(() => samforaPreset.validateConfig(withoutTaxFields)).toThrow(
+        /taxYear|totalLifetimeAmount|taxDeductibleAmount/,
+      );
+    });
+
+    it('does not require the optional currency / donationType fields', () => {
+      // TEST_CONFIG omits donationCurrency and donationType — still passes.
       expect(() => samforaPreset.validateConfig(TEST_CONFIG)).not.toThrow();
     });
   });
@@ -110,13 +129,25 @@ describe('samforaPreset', () => {
       }
     });
 
-    it('includes the core donation fields', () => {
+    it('includes every field each automation needs to build', () => {
       const logicalNames = samforaPreset.getRequiredFields().map((f) => f.logicalName);
+      // Core fields referenced by the confirmation / monthly flows.
       expect(logicalNames).toContain('donorFirstName');
       expect(logicalNames).toContain('donationAmount');
       expect(logicalNames).toContain('donationDate');
       expect(logicalNames).toContain('donationRef');
       expect(logicalNames).toContain('causeName');
+      // Tax-summary fields — also required so `getAutomations()` never hands
+      // back a tax-summary automation that can't build.
+      expect(logicalNames).toContain('totalLifetimeAmount');
+      expect(logicalNames).toContain('taxYear');
+      expect(logicalNames).toContain('taxDeductibleAmount');
+    });
+
+    it('excludes the optional currency and donationType fields', () => {
+      const logicalNames = samforaPreset.getRequiredFields().map((f) => f.logicalName);
+      expect(logicalNames).not.toContain('donationCurrency');
+      expect(logicalNames).not.toContain('donationType');
     });
   });
 
@@ -126,18 +157,18 @@ describe('samforaPreset', () => {
 
   describe('getAutomations', () => {
     it('returns 6 automations', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       expect(automations).toHaveLength(6);
     });
 
     it('returns automations with unique IDs', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const ids = automations.map((a) => a.id);
       expect(new Set(ids).size).toBe(ids.length);
     });
 
     it('all automations have trigger tags from SAMFORA_TAGS', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const validTags = new Set(Object.values(SAMFORA_TAGS));
       for (const automation of automations) {
         expect(validTags.has(automation.triggerTag)).toBe(true);
@@ -145,7 +176,7 @@ describe('samforaPreset', () => {
     });
 
     it('the three confirmation variants share a trigger but differ by condition', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const confirmations = automations.filter(
         (a) => a.triggerTag === SAMFORA_TAGS.donationReceived,
       );
@@ -163,7 +194,7 @@ describe('samforaPreset', () => {
     });
 
     it('confirmation variants gate on donor-lifecycle tags', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const first = automations.find(
         (a) => a.id === 'samfora-donation-confirmation-first',
       )!;
@@ -179,51 +210,39 @@ describe('samforaPreset', () => {
       expect(returning.conditions?.hasTag).toEqual([SAMFORA_TAGS.donorReturning]);
     });
 
-    it('all automations produce valid RCML documents (with full fields)', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
-      for (const automation of automations) {
-        const doc = automation.templateBuilder({
-          brandStyle: TEST_BRAND_STYLE,
-          customFields: TEST_CUSTOM_FIELDS_FULL,
-          websiteUrl: 'https://samfora.org',
-        });
-        assertValidRCMLDocument(doc);
-      }
-    });
-
-    it('core automations produce valid RCML without the optional tax fields', () => {
-      // Skip the tax-summary automation, which legitimately requires tax fields.
-      const automations = samforaPreset
-        .getAutomations(TEST_CONFIG)
-        .filter((a) => a.id !== 'samfora-annual-tax-summary');
-
-      for (const automation of automations) {
-        const doc = automation.templateBuilder({
-          brandStyle: TEST_BRAND_STYLE,
-          customFields: TEST_CUSTOM_FIELDS,
-          websiteUrl: 'https://samfora.org',
-        });
-        assertValidRCMLDocument(doc);
-      }
-    });
-
-    it('tax-summary template throws when its extra fields are missing', () => {
+    it('all automations produce valid RCML documents with required fields only', () => {
       const automations = samforaPreset.getAutomations(TEST_CONFIG);
-      const taxSummary = automations.find(
-        (a) => a.id === 'samfora-annual-tax-summary',
-      )!;
-
-      expect(() =>
-        taxSummary.templateBuilder({
+      for (const automation of automations) {
+        const doc = automation.templateBuilder({
           brandStyle: TEST_BRAND_STYLE,
           customFields: TEST_CUSTOM_FIELDS,
           websiteUrl: 'https://samfora.org',
-        }),
-      ).toThrow(/taxYear|totalLifetimeAmount|taxDeductibleAmount/);
+        });
+        assertValidRCMLDocument(doc);
+      }
     });
+
+    it('all automations also render with the optional currency / type fields', () => {
+      const automations = samforaPreset.getAutomations(TEST_CONFIG_WITH_OPTIONAL);
+      for (const automation of automations) {
+        const doc = automation.templateBuilder({
+          brandStyle: TEST_BRAND_STYLE,
+          customFields: TEST_CUSTOM_FIELDS_WITH_OPTIONAL,
+          websiteUrl: 'https://samfora.org',
+        });
+        assertValidRCMLDocument(doc);
+      }
+    });
+
+    // Note: the tax-summary builder retains an internal `validateCustomFields`
+    // call as a defensive backstop, but it's no longer reachable through the
+    // resolved `templateBuilder` — `resolveVendorAutomations` merges the outer
+    // config's customFields with any override, so required fields always
+    // resolve. The upstream `validateConfig` gate is now the only path where
+    // missing fields surface, which is covered by the validateConfig tests.
 
     it('templateBuilder honors TemplateConfigV2 overrides', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const first = automations.find(
         (a) => a.id === 'samfora-donation-confirmation-first',
       )!;
@@ -231,7 +250,7 @@ describe('samforaPreset', () => {
       const doc = first.templateBuilder({
         brandStyle: TEST_BRAND_STYLE,
         customFields: {
-          ...TEST_CUSTOM_FIELDS_FULL,
+          ...TEST_CUSTOM_FIELDS,
           [SAMFORA_FIELDS.donationAmount]: 999999,
         },
         websiteUrl: 'https://override.example.com',
@@ -243,14 +262,14 @@ describe('samforaPreset', () => {
     });
 
     it('RCML contains Samfora field placeholders', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const first = automations.find(
         (a) => a.id === 'samfora-donation-confirmation-first',
       )!;
 
       const doc = first.templateBuilder({
         brandStyle: TEST_BRAND_STYLE,
-        customFields: TEST_CUSTOM_FIELDS_FULL,
+        customFields: TEST_CUSTOM_FIELDS,
         websiteUrl: 'https://samfora.org',
       });
       const json = docToString(doc);
@@ -261,7 +280,7 @@ describe('samforaPreset', () => {
     });
 
     it('default copy is in Swedish', () => {
-      const automations = samforaPreset.getAutomations(TEST_CONFIG_FULL);
+      const automations = samforaPreset.getAutomations(TEST_CONFIG);
       const first = automations.find(
         (a) => a.id === 'samfora-donation-confirmation-first',
       )!;
@@ -269,7 +288,7 @@ describe('samforaPreset', () => {
       expect(first.subject).toContain('Tack');
       const doc = first.templateBuilder({
         brandStyle: TEST_BRAND_STYLE,
-        customFields: TEST_CUSTOM_FIELDS_FULL,
+        customFields: TEST_CUSTOM_FIELDS,
         websiteUrl: 'https://samfora.org',
       });
       const json = docToString(doc);


### PR DESCRIPTION
Samfora (https://samfora.org) is a Swedish charitable-donation platform and now joins Shopify (e-commerce) and Bookzen (hospitality) as a supported vendor preset. It covers the six automations a donation platform actually sends: first-time / second-gift / returning donor confirmations gated by donor-lifecycle tags, monthly donation confirmation, welcome onboarding, and annual gåvoskatteavdrag summary.

Default copy ships in Swedish to match the target market. The preset reuses generic brand-template helpers rather than introducing donation-specific builders, so no new public surface area lands in `src/rcml/`.

Also adds `scripts/deploy-samfora.ts` — a reference deployment script that resolves the account's preferred brand style via `is_default: true` from `listBrandStyles()` instead of hardcoding an ID. See issue #91 for the pattern that every deploy script should adopt.