### PR TITLE
refactor(bookzen): move guestFirstName to flat Subscriber group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `BOOKZEN_FIELDS.guestFirstName` moved from `'Booking.FirstName'` to
+  `'Subscriber.FirstName'`. Guest identity belongs on the flat
+  `Subscriber.*` group (overwritten per sync), not the historical
+  `Booking.*` group (appended per sync). Brings Bookzen in line with
+  Shopify and Samfora per Rule.io field-group praxis.
+
 ## [0.3.0] - 2026-04-07
 
 ### Added

--- a/src/vendors/bookzen/fields.ts
+++ b/src/vendors/bookzen/fields.ts
@@ -10,6 +10,13 @@ import type { VendorFieldSchema } from '../types';
 /**
  * Bookzen field names for Rule.io custom fields.
  *
+ * Follows Rule.io praxis for custom-field groups:
+ * - **Subscriber group (flat)** — guest identity fields that get
+ *   overwritten on each sync (e.g. `Subscriber.FirstName`).
+ * - **Booking group (historical)** — per-booking event data that
+ *   appends a new record on each sync (`Booking.BookingRef`,
+ *   `Booking.CheckInDate`, `Booking.RoomName`, etc.).
+ *
  * @example
  * ```typescript
  * import { BOOKZEN_FIELDS } from 'rule-io-sdk';
@@ -22,7 +29,10 @@ import type { VendorFieldSchema } from '../types';
  * ```
  */
 export const BOOKZEN_FIELDS = {
-  guestFirstName: 'Booking.FirstName',
+  // Subscriber group — flat, overwritten per sync
+  guestFirstName: 'Subscriber.FirstName',
+
+  // Booking group — historical, append-only
   bookingRef: 'Booking.BookingRef',
   serviceType: 'Booking.ServiceType',
   checkInDate: 'Booking.CheckInDate',

--- a/tests/vendors/bookzen.test.ts
+++ b/tests/vendors/bookzen.test.ts
@@ -239,6 +239,32 @@ describe('BOOKZEN_FIELDS', () => {
       expect(value.length).toBeGreaterThan(0);
     }
   });
+
+  it('splits fields between the flat Subscriber group and the historical Booking group', () => {
+    // Rule.io praxis: guest identity on the flat Subscriber.* group
+    // (overwritten per sync); per-booking event data on the historical
+    // Booking.* group (appended per sync).
+    expect(BOOKZEN_FIELDS.guestFirstName).toBe('Subscriber.FirstName');
+
+    const bookingFields = [
+      BOOKZEN_FIELDS.bookingRef,
+      BOOKZEN_FIELDS.serviceType,
+      BOOKZEN_FIELDS.checkInDate,
+      BOOKZEN_FIELDS.checkOutDate,
+      BOOKZEN_FIELDS.totalGuests,
+      BOOKZEN_FIELDS.totalPrice,
+      BOOKZEN_FIELDS.roomName,
+    ];
+    for (const value of bookingFields) {
+      expect(value.startsWith('Booking.')).toBe(true);
+    }
+  });
+
+  it('every field uses either a Subscriber.* or Booking.* prefix', () => {
+    for (const value of Object.values(BOOKZEN_FIELDS)) {
+      expect(/^(Subscriber|Booking)\./.test(value)).toBe(true);
+    }
+  });
 });
 
 describe('BOOKZEN_TAGS', () => {


### PR DESCRIPTION
## Summary

Fixes #93. Moves `BOOKZEN_FIELDS.guestFirstName` from the historical `Booking.*` group to the flat `Subscriber.*` group, matching Rule.io field-group praxis.

Rule.io splits custom-fields across two group shapes:
- **Flat `Subscriber.*`** — identity/contact data, overwritten per sync.
- **Historical `<Domain>.*`** — event records, appended per sync.

Guest first name is stable identity data — it should not spawn a new historical record on every booking. Shopify and Samfora already follow this convention; this PR brings Bookzen in line.

## Changes

- `BOOKZEN_FIELDS.guestFirstName` → `'Subscriber.FirstName'`.
- `fields.ts` docstring explains the group split.
- Two new tests: one asserts the split (`guestFirstName` on `Subscriber.*`, rest on `Booking.*`); one asserts every value uses one of the two prefixes.
- `CHANGELOG.md` notes the praxis alignment under `[Unreleased]`.

The SDK is pre-release, so no backward-compatibility shim. Consumers updating will simply map `BOOKZEN_FIELDS.guestFirstName` to a Subscriber-group field id instead of a Booking-group one.

## Out of scope (follow-ups)

- No `deploy-bookzen.ts` reference script exists yet — when one is added, it should seed `Subscriber.FirstName` via the flat v2 `/subscribers` endpoint, mirroring `deploy-samfora.ts`.
- The generic `createReservationConfirmationEmail` docstring at `src/rcml/hospitality-templates.ts:107` still shows `firstName: 'Booking.FirstName'` as an illustrative example. That's low-level SDK code shared across all hospitality consumers; worth its own pass.

## Test plan

- [x] `npm run type-check`
- [x] `npm test` — 480 passed (2 new Bookzen tests green)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)