### PR TITLE
fix(export): decode base64 object.name in exportStatistics for message records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `exportStatistics` now transparently decodes the base64-encoded
+  `object.name` that Rule.io returns for records where
+  `object.type === 'message'` (every other object type returns plain text).
+  A round-trip guard keeps the transform safe if Rule.io fixes the
+  inconsistency upstream. Opt out with `decodeNames: false` to inspect the
+  raw API response. (#95)
+
 ## [0.3.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `exportStatistics` now transparently decodes the base64-encoded
   `object.name` that Rule.io returns for records where
   `object.type === 'message'` (every other object type returns plain text).
-  A round-trip guard keeps the transform safe if Rule.io fixes the
-  inconsistency upstream. Opt out with `decodeNames: false` to inspect the
-  raw API response. (#95)
+  A round-trip guard limits decoding to values that look like canonical
+  base64. If you need to inspect the raw API response or disable this
+  behavior, opt out with `decodeNames: false`. (#95)
 
 ## [0.3.0] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ const subscribers = await client.exportSubscribers({ date_from: '2024-01-01', da
 ```
 
 Export statistics supports token-based pagination via `next_page_token`.
+For records where `object.type === 'message'`, `object.name` is returned
+base64-encoded by Rule.io and automatically decoded by the SDK. Pass
+`decodeNames: false` to inspect the raw API response.
 
 ### Recipients
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -75,6 +75,7 @@ import type {
   RuleSubscriberTagsV3Request,
   RuleExportDispatcherParams,
   RuleExportDispatcherResponse,
+  RuleExportStatisticRecord,
   RuleExportStatisticsParams,
   RuleExportStatisticsResponse,
   RuleExportSubscriberParams,
@@ -107,6 +108,58 @@ type QueryParamValue = string | number | boolean | null | undefined;
 
 /** Query-param bag accepted by `buildQueryString`. Array values emit one entry per element. */
 type QueryParamValues = Record<string, QueryParamValue | QueryParamValue[]>;
+
+/**
+ * Decode a base64 string to UTF-8, or return null if the input is not valid
+ * base64 or the decoded bytes are not valid UTF-8.
+ *
+ * Uses platform-native `atob` + `TextDecoder` (available in Node.js 18+ and
+ * all modern browser/edge runtimes) to avoid depending on Node's `Buffer`.
+ */
+function tryDecodeBase64Utf8(input: string): string | null {
+  if (!input) return null;
+  try {
+    const binary = atob(input);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/** Encode a UTF-8 string to canonical (padded) base64. */
+function encodeBase64Utf8(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Rule.io returns `object.name` base64-encoded on statistics export records
+ * where `object.type === 'message'`. Every other object type returns plain
+ * text. See GitHub issue #95.
+ *
+ * This helper decodes the name transparently, with a round-trip guard so that
+ * values which don't re-encode to the exact original are left untouched. That
+ * keeps the transform idempotent if Rule.io eventually fixes the API to
+ * return plain text.
+ */
+function decodeStatisticMessageName(
+  record: RuleExportStatisticRecord
+): RuleExportStatisticRecord {
+  if (record.object.type !== 'message') return record;
+  const original = record.object.name;
+  const decoded = tryDecodeBase64Utf8(original);
+  if (decoded === null) return record;
+  if (encodeBase64Utf8(decoded) !== original) return record;
+  return { ...record, object: { ...record.object, name: decoded } };
+}
 
 /**
  * Rule.io API Client
@@ -2024,7 +2077,16 @@ export class RuleClient {
    * Uses token-based pagination: if the response includes a `next_page_token`,
    * pass it in the next call to retrieve the following page.
    *
-   * @param params - Date range (required), optional statistic_types filter, optional next_page_token
+   * ## `object.name` decoding
+   *
+   * Rule.io returns `object.name` base64-encoded for records where
+   * `object.type === 'message'` (every other object type is plain text).
+   * By default this method decodes those names transparently so consumers
+   * always see plain text. A round-trip guard keeps the transform safe if
+   * Rule.io fixes the inconsistency upstream. Pass `decodeNames: false` to
+   * disable decoding and inspect the raw API response.
+   *
+   * @param params - Date range (required), optional statistic_types filter, optional next_page_token, optional decodeNames
    * @returns List of statistic records and optional next_page_token
    *
    * @example
@@ -2055,10 +2117,14 @@ export class RuleClient {
       'statistic_types[]': params.statistic_types,
       next_page_token: params.next_page_token || undefined,
     });
-    return this.requestV3<RuleExportStatisticsResponse>(
+    const response = await this.requestV3<RuleExportStatisticsResponse>(
       `/export/statistics${qs}`,
       { method: 'GET' }
     );
+    if (params.decodeNames === false || !response.data) {
+      return response;
+    }
+    return { ...response, data: response.data.map(decodeStatisticMessageName) };
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,6 +109,16 @@ type QueryParamValue = string | number | boolean | null | undefined;
 /** Query-param bag accepted by `buildQueryString`. Array values emit one entry per element. */
 type QueryParamValues = Record<string, QueryParamValue | QueryParamValue[]>;
 
+// Hoisted to module scope so repeated calls don't allocate a new instance per
+// record; statistics exports can contain thousands of records per page.
+const UTF8_ENCODER = new TextEncoder();
+const UTF8_DECODER_FATAL = new TextDecoder('utf-8', { fatal: true });
+
+// `String.fromCharCode(...bytes)` can blow the JS call stack for very long
+// inputs. Process in chunks for bounded stack usage and amortized linear
+// concatenation cost.
+const BYTE_TO_CHAR_CHUNK = 0x8000;
+
 /**
  * Decode a base64 string to UTF-8, or return null if the input is not valid
  * base64 or the decoded bytes are not valid UTF-8.
@@ -124,7 +134,7 @@ function tryDecodeBase64Utf8(input: string): string | null {
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    return UTF8_DECODER_FATAL.decode(bytes);
   } catch {
     return null;
   }
@@ -132,10 +142,12 @@ function tryDecodeBase64Utf8(input: string): string | null {
 
 /** Encode a UTF-8 string to canonical (padded) base64. */
 function encodeBase64Utf8(input: string): string {
-  const bytes = new TextEncoder().encode(input);
+  const bytes = UTF8_ENCODER.encode(input);
   let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i += BYTE_TO_CHAR_CHUNK) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(i, i + BYTE_TO_CHAR_CHUNK)
+    );
   }
   return btoa(binary);
 }
@@ -145,10 +157,14 @@ function encodeBase64Utf8(input: string): string {
  * where `object.type === 'message'`. Every other object type returns plain
  * text. See GitHub issue #95.
  *
- * This helper decodes the name transparently, with a round-trip guard so that
- * values which don't re-encode to the exact original are left untouched. That
- * keeps the transform idempotent if Rule.io eventually fixes the API to
- * return plain text.
+ * This helper decodes the name and then re-encodes the decoded value to check
+ * that it matches the original exactly. Inputs that don't cleanly round-trip
+ * are left untouched, so any value that's not canonical base64 passes through
+ * as-is. The guard does NOT distinguish an intentionally base64-encoded name
+ * from a plain-text name that also happens to be valid base64 (e.g.
+ * `"aGVsbG8="`) — such values will still be decoded. Consumers who need to
+ * preserve raw API output should use the `decodeNames: false` opt-out on
+ * `exportStatistics`.
  */
 function decodeStatisticMessageName(
   record: RuleExportStatisticRecord
@@ -2082,9 +2098,11 @@ export class RuleClient {
    * Rule.io returns `object.name` base64-encoded for records where
    * `object.type === 'message'` (every other object type is plain text).
    * By default this method decodes those names transparently so consumers
-   * always see plain text. A round-trip guard keeps the transform safe if
-   * Rule.io fixes the inconsistency upstream. Pass `decodeNames: false` to
-   * disable decoding and inspect the raw API response.
+   * always see plain text. A round-trip guard limits decoding to inputs that
+   * look like canonical base64, but it cannot distinguish an intentionally
+   * base64-encoded name from a plain-text name that happens to be valid
+   * base64 — pass `decodeNames: false` to preserve raw API values exactly
+   * (for debugging or if upstream behavior changes).
    *
    * @param params - Date range (required), optional statistic_types filter, optional next_page_token, optional decodeNames
    * @returns List of statistic records and optional next_page_token

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -785,6 +785,18 @@ export interface RuleExportStatisticsParams extends RuleExportDateParams {
   statistic_types?: RuleExportStatisticFilterType[];
   /** Pagination token from the previous response */
   next_page_token?: string;
+  /**
+   * Automatically decode base64-encoded `object.name` for records where
+   * `object.type === 'message'`. Rule.io currently returns these names
+   * base64-encoded while every other object type returns plain text.
+   *
+   * Default: `true`. A round-trip guard ensures values that don't cleanly
+   * re-encode are passed through unchanged, so this remains safe if Rule.io
+   * fixes the inconsistency upstream.
+   *
+   * Set to `false` to inspect raw API values (e.g. for debugging).
+   */
+  decodeNames?: boolean;
 }
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -790,11 +790,14 @@ export interface RuleExportStatisticsParams extends RuleExportDateParams {
    * `object.type === 'message'`. Rule.io currently returns these names
    * base64-encoded while every other object type returns plain text.
    *
-   * Default: `true`. A round-trip guard ensures values that don't cleanly
-   * re-encode are passed through unchanged, so this remains safe if Rule.io
-   * fixes the inconsistency upstream.
+   * Default: `true`. A round-trip guard passes through values that do not
+   * cleanly re-encode as canonical base64, but it cannot distinguish between
+   * intentionally base64-encoded names and plain-text names that also happen
+   * to be valid base64.
    *
-   * Set to `false` to inspect raw API values (e.g. for debugging).
+   * Set to `false` to preserve raw API values exactly, including message
+   * names that look like base64 (for example when debugging or if upstream
+   * behavior changes).
    */
   decodeNames?: boolean;
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -2612,6 +2612,201 @@ describe('RuleClient', () => {
       expect(url).toContain('next_page_token=token-abc');
     });
 
+    it('should decode base64 object.name for message-type records', async () => {
+      // "VG9kYXkncyBNb3JuaW5nIEJyZWFr" -> "Today's Morning Break"
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-msg',
+            statistic_type: 'sent',
+            event_id: 'evt-msg',
+            subscriber_id: 'sub-msg',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'msg-1',
+              name: 'VG9kYXkncyBNb3JuaW5nIEJyZWFr',
+              type: 'message',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+      });
+
+      expect(result.data![0].object.name).toBe("Today's Morning Break");
+    });
+
+    it('should decode base64 names that contain multi-byte UTF-8 characters', async () => {
+      // "w6Vrw6Ugw6RsZ2VuIPCfjIg=" -> "åkå älgen 🌈" (includes an emoji surrogate pair)
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-utf8',
+            statistic_type: 'open',
+            event_id: 'evt-utf8',
+            subscriber_id: 'sub-utf8',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'msg-utf8',
+              name: 'w6Vrw6Ugw6RsZ2VuIPCfjIg=',
+              type: 'message',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+      });
+
+      expect(result.data![0].object.name).toBe('åkå älgen 🌈');
+    });
+
+    it('should not decode names for non-message object types', async () => {
+      // Same base64 string; because type !== 'message' it must pass through.
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-camp',
+            statistic_type: 'open',
+            event_id: 'evt-camp',
+            subscriber_id: 'sub-camp',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'camp-1',
+              name: 'VG9kYXkncyBNb3JuaW5nIEJyZWFr',
+              type: 'campaign',
+            },
+          },
+          {
+            statistic_id: 'stat-jour',
+            statistic_type: 'open',
+            event_id: 'evt-jour',
+            subscriber_id: 'sub-jour',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'jour-1',
+              name: 'VG9kYXkncyBNb3JuaW5nIEJyZWFr',
+              type: 'journey',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+      });
+
+      expect(result.data![0].object.name).toBe('VG9kYXkncyBNb3JuaW5nIEJyZWFr');
+      expect(result.data![1].object.name).toBe('VG9kYXkncyBNb3JuaW5nIEJyZWFr');
+    });
+
+    it('should pass through message-type names that are not valid base64', async () => {
+      // Contains characters (space, apostrophe) that are invalid in base64.
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-raw',
+            statistic_type: 'open',
+            event_id: 'evt-raw',
+            subscriber_id: 'sub-raw',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'msg-raw',
+              name: "Today's Morning Break",
+              type: 'message',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+      });
+
+      expect(result.data![0].object.name).toBe("Today's Morning Break");
+    });
+
+    it('should pass through base64 input that does not round-trip cleanly', async () => {
+      // Valid base64 whose canonical re-encoding differs from the input
+      // (no padding). Guard must leave the value untouched.
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-noroundtrip',
+            statistic_type: 'open',
+            event_id: 'evt-noroundtrip',
+            subscriber_id: 'sub-noroundtrip',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'msg-noroundtrip',
+              name: 'aGVsbG8', // canonical form is "aGVsbG8="
+              type: 'message',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+      });
+
+      expect(result.data![0].object.name).toBe('aGVsbG8');
+    });
+
+    it('should skip decoding when decodeNames is false', async () => {
+      const mockData = {
+        data: [
+          {
+            statistic_id: 'stat-optout',
+            statistic_type: 'sent',
+            event_id: 'evt-optout',
+            subscriber_id: 'sub-optout',
+            message_type: 'email',
+            created_at: '2024-01-15T10:00:00Z',
+            object: {
+              id: 'msg-optout',
+              name: 'VG9kYXkncyBNb3JuaW5nIEJyZWFr',
+              type: 'message',
+            },
+          },
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.exportStatistics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+        decodeNames: false,
+      });
+
+      expect(result.data![0].object.name).toBe('VG9kYXkncyBNb3JuaW5nIEJyZWFr');
+    });
+
     it('should export subscribers with date range', async () => {
       const mockData = {
         data: [


### PR DESCRIPTION
## Summary

- `exportStatistics` now transparently decodes Rule.io's base64-encoded `object.name` for records where `object.type === 'message'` (every other object type is returned as plain text).
- A round-trip guard (`encode(decode(x)) === x`) ensures non-base64 or non-round-tripping values pass through unchanged, so the transform stays idempotent if Rule.io fixes the inconsistency upstream.
- Consumers can opt out with `decodeNames: false` to inspect the raw API response.

## Why

The `RuleExportStatisticObject.name` type promises a plain `string`. In practice Rule.io returns it base64-encoded for message rows only — a silent data-type inconsistency that tripped up the `rule-io-mcp-server` integration and presumably every other consumer. See #95.

## Implementation notes

- Uses platform globals (`atob`/`btoa`/`TextDecoder`/`TextEncoder`) instead of Node's `Buffer`, preserving the SDK's browser/edge-runtime compatibility and the "zero runtime dependencies" rule.
- `TextDecoder` is constructed with `{ fatal: true }` so invalid UTF-8 byte sequences falling out of `atob` are rejected rather than silently rendered as replacement characters.
- Helpers are module-private — no new public surface to maintain.

## Test plan

- [x] `npm run type-check`
- [x] `npm run test` — 484 passed (6 new cases covering all acceptance criteria)
- [x] `npm run build`
- [x] Message-type record: base64 → plain text decoded
- [x] Multi-byte UTF-8 (Swedish chars + emoji) decoded correctly
- [x] Non-message object types: name passed through unchanged
- [x] Non-base64 input (e.g. `"Today's Morning Break"`): passed through
- [x] Valid base64 that doesn't round-trip (unpadded `"aGVsbG8"`): passed through
- [x] `decodeNames: false` opt-out: raw base64 returned

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)