### PR TITLE
fix(types): surface utm_campaign/utm_term on RuleMessage (dropped at type boundary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `RuleMessage` now surfaces `utm_campaign` and `utm_term` (both
-  `string | null`). The Rule.io API returns these on Message objects in
-  automation/campaign responses, but the type dropped them, so typed
-  consumers couldn't read UTM values from the wire. `RuleDynamicSet`
-  similarly gains `name`, `subject`, `pre_header`, `utm_campaign`, and
-  `utm_term` to match fields returned by `getDynamicSet` and by the
-  `default_dynamic_set` nested inside Message responses (the list
-  endpoint only returns a subset — fields remain optional). Additive,
-  optional, no runtime change. Closes #110.
+  optional `string | null`). The Rule.io API returns these on Message
+  objects in automation/campaign responses, but the type dropped them,
+  so typed consumers couldn't read UTM values from the wire.
+  `RuleDynamicSet` similarly gains optional `name`, `subject`,
+  `pre_header`, `utm_campaign`, and `utm_term` to match fields returned
+  by `getDynamicSet` and by the `default_dynamic_set` nested inside
+  Message responses; `message_id` is also now optional since the
+  `listDynamicSets` endpoint omits it (items return only
+  `{ id, name, template_id }`). Additive, no runtime change.
+  Closes #110.
 
 ## [0.4.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by `getDynamicSet` and by the `default_dynamic_set` nested inside
   Message responses; `message_id` is also now optional since the
   `listDynamicSets` endpoint omits it (items return only
-  `{ id, name, template_id }`). Additive, no runtime change.
-  Closes #110.
+  `{ id, name, template_id }`). This is a type correction to match
+  the API and may require strict TypeScript consumers to handle
+  `message_id` as possibly `undefined`; there is no runtime behavior
+  change. Closes #110.
 
 ## [0.4.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inline. Caller drives pagination via the returned `next_page` cursor.
   Closes #99.
 
+### Fixed
+- `RuleMessage` now surfaces `utm_campaign` and `utm_term` (both
+  `string | null`). The Rule.io API returns these on Message objects in
+  automation/campaign responses, but the type dropped them, so typed
+  consumers couldn't read UTM values from the wire. `RuleDynamicSet`
+  similarly gains `name`, `subject`, `pre_header`, `utm_campaign`, and
+  `utm_term` to match fields returned by `getDynamicSet` and by the
+  `default_dynamic_set` nested inside Message responses (the list
+  endpoint only returns a subset — fields remain optional). Additive,
+  optional, no runtime change. Closes #110.
+
 ## [0.4.0] - 2026-04-23
 
 ### Added

--- a/scripts/clone-email.ts
+++ b/scripts/clone-email.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { RuleClient } from '../src';
 import type {
   RuleAutomationResponse,
+  RuleMessage,
   RuleMessageResponse,
   RuleTemplateResponse,
   RuleDynamicSetResponse,
@@ -184,7 +185,7 @@ async function runSend(): Promise<void> {
     | Record<string, unknown>
     | undefined;
   const srcMessage = snapshot.message.data as unknown as
-    | Record<string, unknown>
+    | (RuleMessage & Record<string, unknown>)
     | undefined;
   const srcTemplate = snapshot.templates[0]?.data as unknown as
     | { template?: RCMLDocument; name?: string }
@@ -281,8 +282,8 @@ async function runSend(): Promise<void> {
 
     // 6. Mirror dynamic-set metadata (UTM fields) from the source.
     // These fields belong on the dynamic set, not the message.
-    const utmCampaign = (srcMessage.utm_campaign as string | null) ?? undefined;
-    const utmTerm = (srcMessage.utm_term as string | null) ?? undefined;
+    const utmCampaign = srcMessage.utm_campaign ?? undefined;
+    const utmTerm = srcMessage.utm_term ?? undefined;
     if (utmCampaign !== undefined || utmTerm !== undefined) {
       console.log('Applying dynamic-set metadata (utm_campaign/utm_term)...');
       await client.updateDynamicSet(dynamicSetId, {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -230,6 +230,8 @@ export interface RuleMessage {
   from_name?: string;
   from_email?: string;
   reply_to?: string;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
 }
 
 export interface RuleMessageCreateRequest {
@@ -290,6 +292,11 @@ export interface RuleDynamicSet {
   id?: number;
   message_id: number;
   template_id: number;
+  name?: string | null;
+  subject?: string | null;
+  pre_header?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
 }
 
 export interface RuleDynamicSetCreateRequest {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -290,7 +290,12 @@ export interface RuleTemplateResponse extends RuleApiResponse {
  */
 export interface RuleDynamicSet {
   id?: number;
-  message_id: number;
+  /**
+   * Present on getDynamicSet responses and on the nested default_dynamic_set
+   * inside Message responses. Omitted from listDynamicSets list items, so
+   * marked optional on the read type.
+   */
+  message_id?: number;
   template_id: number;
   name?: string | null;
   subject?: string | null;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -666,6 +666,115 @@ describe('RuleClient', () => {
     });
   });
 
+  describe('v3 read-side types preserve utm and dynamic-set fields', () => {
+    it('getMessage surfaces populated utm_campaign and utm_term', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 99,
+            name: 'Promo Email',
+            subject: 'Special Offer',
+            utm_campaign: 'summer-sale',
+            utm_term: 'organic-search',
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getMessage(99);
+
+      expect(result?.data?.utm_campaign).toBe('summer-sale');
+      expect(result?.data?.utm_term).toBe('organic-search');
+    });
+
+    it('getMessage preserves null utm fields without dropping them', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 99,
+            name: 'Plain Email',
+            subject: 'No UTM',
+            utm_campaign: null,
+            utm_term: null,
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getMessage(99);
+
+      expect(result?.data?.utm_campaign).toBeNull();
+      expect(result?.data?.utm_term).toBeNull();
+    });
+
+    it('listMessages preserves utm fields on list items', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [
+            {
+              id: 10,
+              name: 'Msg 1',
+              subject: 'Test',
+              utm_campaign: 'q1-promo',
+              utm_term: null,
+            },
+          ],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listMessages({ id: 123, dispatcher_type: 'automail' });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data?.[0].utm_campaign).toBe('q1-promo');
+      expect(result.data?.[0].utm_term).toBeNull();
+    });
+
+    it('getDynamicSet surfaces name, pre_header, and utm fields', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 200,
+            message_id: 456,
+            template_id: 789,
+            name: 'Standard',
+            subject: 'Fallback Subject',
+            pre_header: 'Fallback preheader',
+            utm_campaign: 'order-return',
+            utm_term: null,
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getDynamicSet(200);
+
+      expect(result?.data?.name).toBe('Standard');
+      expect(result?.data?.subject).toBe('Fallback Subject');
+      expect(result?.data?.pre_header).toBe('Fallback preheader');
+      expect(result?.data?.utm_campaign).toBe('order-return');
+      expect(result?.data?.utm_term).toBeNull();
+    });
+
+    it('listDynamicSets preserves name on list items', async () => {
+      // Real API shape (verified against email-snapshots/*): list endpoint
+      // returns only { id, name, template_id, __resource }. utm/subject/
+      // pre_header are only populated on getDynamicSet and on the nested
+      // default_dynamic_set inside Message responses.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [{ id: 200, name: 'Standard', template_id: 789 }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listDynamicSets({ message_id: 456 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data?.[0].name).toBe('Standard');
+    });
+  });
+
   describe('v3 List, Update & Render API', () => {
     it('should list automations with query params', async () => {
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- `RuleMessage` now models `utm_campaign` and `utm_term` (`string | null`) — the Rule.io API returns these on Message objects in automation/campaign responses, but the type dropped them, so typed consumers couldn't read UTM values off the wire.
- `RuleDynamicSet` gains `name`, `subject`, `pre_header`, `utm_campaign`, `utm_term` to match what `getDynamicSet` and the nested `default_dynamic_set` (inside Message responses) return. The `listDynamicSets` endpoint returns a subset — the optional modifier covers both shapes.
- `RuleDynamicSet.message_id` is now optional on the read type: `listDynamicSets` items omit it (return only `{ id, name, template_id }`). This is a type-correction that may require strict TypeScript consumers to handle `message_id` as possibly `undefined`; no runtime behavior change. Write-side types (`RuleDynamicSetCreateRequest` / `RuleDynamicSetUpdateRequest`) still require `message_id`.
- `scripts/clone-email.ts` drops its `(x as string | null)` casts by narrowing `srcMessage` to `RuleMessage & Record<string, unknown>`, giving proper types on the newly-modeled fields while leaving the `Record` fallback for fields still not on `RuleMessage` (`sender`, `automail_setting`, `pre_header`).

Closes #110.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run test` — 546 tests pass (5 new)
- [x] `npm run build` — CJS + ESM + `.d.ts` output, `dist/index.d.ts` verified to carry the new fields
- [x] New tests cover: `getMessage` with populated utm, `getMessage` with `null` utm preserved, `listMessages` passthrough, `getDynamicSet` with full shape, `listDynamicSets` with real subset shape (verified against `email-snapshots/*`)
- [ ] Spot-check `scripts/clone-email.ts` against a real automail snapshot after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
