### PR TITLE
chore: sync package-lock.json with workspace changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,6 +3505,10 @@
       "resolved": "packages/sdk",
       "link": true
     },
+    "node_modules/@rule-io/templates": {
+      "resolved": "packages/templates",
+      "link": true
+    },
     "node_modules/@rule-io/vendor-bookzen": {
       "resolved": "packages/vendor-bookzen",
       "link": true
@@ -12442,6 +12446,7 @@
       "license": "MIT",
       "dependencies": {
         "@rule-io/client": "0.3.0",
+        "@rule-io/core": "0.3.0",
         "@rule-io/rcml": "0.3.0",
         "@rule-io/vendor-bookzen": "0.3.0",
         "@rule-io/vendor-samfora": "0.3.0",
@@ -12481,6 +12486,8 @@
       "license": "MIT",
       "dependencies": {
         "@rule-io/core": "0.3.0",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3",
         "ajv": "^8.17.1",
         "fast-xml-parser": "^4.5.0",
         "mdast-util-directive": "^3.0.0",
@@ -12490,10 +12497,6 @@
         "unified": "^11.0.5",
         "vfile": "^6.0.3",
         "zod": "^3.23.8"
-      },
-      "devDependencies": {
-        "@types/mdast": "^4.0.4",
-        "@types/unist": "^3.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -12554,6 +12557,17 @@
         "node": ">=20"
       }
     },
+    "packages/templates": {
+      "name": "@rule-io/templates",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "packages/vendor-bookzen": {
       "name": "@rule-io/vendor-bookzen",
       "version": "0.3.0",
@@ -12584,7 +12598,8 @@
       "license": "MIT",
       "dependencies": {
         "@rule-io/core": "0.3.0",
-        "@rule-io/rcml": "0.3.0"
+        "@rule-io/rcml": "0.3.0",
+        "@rule-io/templates": "0.3.0"
       },
       "engines": {
         "node": ">=20"


### PR DESCRIPTION
## Summary
- Picks up the new `@rule-io/templates` workspace introduced in b7169ed
- Reflects the type-deps move (`@types/mdast`, `@types/unist`) from `devDependencies` to `dependencies` in `@rule-io/rcml`
- Adds the linked `node_modules/@rule-io/templates` symlink and the `@rule-io/templates` runtime dep on vendor-shopify

Lockfile only — no source changes.

## Test plan
- [x] `npm run build` (cached, all 9 projects pass)
- [x] `npm test` (83 unit tests pass; 50 integration tests skipped as expected without `RUN_INTEGRATION=1`)
- [x] `npm run lint` (no errors; 2 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)