### PR TITLE
docs: sync READMEs with current monorepo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,36 @@
 # rule-io-sdk
 
-Nx monorepo for the Rule.io TypeScript SDK. Publishes eight packages under the `@rule-io/*` npm scope:
+Nx monorepo for the Rule.io TypeScript SDK. Consumer-facing SDK docs live in [`packages/sdk`](packages/sdk/README.md); this README is for contributors and release maintainers.
+
+Publishes the following packages under the `@rule-io/*` npm scope:
 
 | Package | Purpose |
 |---|---|
-| [`@rule-io/core`](packages/core) | Shared error classes (zero deps) |
+| [`@rule-io/core`](packages/core) | Shared error classes |
+| [`@rule-io/templates`](packages/templates) | Angular-like XML template engine; consumed by `@rule-io/vendor-shopify` |
 | [`@rule-io/rcml`](packages/rcml) | RCML email-template builders, RCML types, automation-config schema |
 | [`@rule-io/client`](packages/client) | HTTP wrapper around the Rule.io v2/v3 API |
 | [`@rule-io/vendor-shopify`](packages/vendor-shopify) | Shopify preset — e-commerce automation flows |
 | [`@rule-io/vendor-bookzen`](packages/vendor-bookzen) | Bookzen preset — hospitality automation flows |
 | [`@rule-io/vendor-samfora`](packages/vendor-samfora) | Samfora preset — Swedish donation flows |
-| [`@rule-io/sdk`](packages/sdk) | Meta-package re-exporting the six library packages above |
+| [`@rule-io/sdk`](packages/sdk) | Meta-package re-exporting the library packages above |
 | [`@rule-io/cli`](packages/cli) | `rule-io` command-line tool — deploy presets, validate RCML, inspect accounts |
 
-Dependency graph (clean DAG, no cycles):
+Dependency graph (clean DAG, no cycles — `←` reads as "depends on"):
 
 ```
-core ← rcml ← client
-  ↑     ↑       ↑
-  └── vendor-{shopify,bookzen,samfora}
-                                    ↑
-sdk (meta) ─── depends on all six   │
-cli        ─── depends on client, rcml, core, all three vendor-*
+core            (leaf, no deps)
+templates       (leaf, external: fast-xml-parser)
+
+rcml            ← core
+
+client          ← core, rcml
+vendor-bookzen  ← core, rcml
+vendor-samfora  ← core, rcml
+vendor-shopify  ← core, rcml, templates
+
+sdk (meta)      ← core, rcml, client, vendor-{shopify,bookzen,samfora}
+cli             ← core, rcml, client, vendor-{shopify,bookzen,samfora}  (+ commander)
 ```
 
 ---
@@ -32,7 +41,7 @@ Node `>=20` required (the Nx plugins used by this workspace rely on `node:util.s
 
 ```bash
 npm install                         # install + link workspace packages
-npx nx show projects                # sanity-check: 8 publishable projects
+npx nx show projects                # sanity-check: 9 publishable projects
 npm run build                       # build all publishable packages → dist/packages/<pkg>/
 npm run test                        # run every package's tests
 npm run lint                        # lint every package
@@ -130,11 +139,9 @@ For each bumped package, Nx runs `npm publish` from `dist/packages/<pkg>/`. Cont
 - the package-specific `README.md` and `CHANGELOG.md`
 - a `package.json` with the bumped version, rewritten paths, and no `devDependencies`
 
-Runtime dependencies across all seven packages are only `@rule-io/*` workspace siblings — CI enforces zero external deps.
-
 ### CI / automated release
 
-CI (`.github/workflows/ci.yml`) currently runs quality gates (lint / test / build / zero-deps check) on every PR. Automated publish from CI is **not** wired up yet. When adding it, the usual pattern is a `release.yml` workflow triggered by a push to `main` or a manual `workflow_dispatch` that runs `npx nx release` with `NPM_CONFIG_TOKEN` from repo secrets.
+CI (`.github/workflows/ci.yml`) currently runs quality gates (lint / test / build / per-package runtime-dependency allowlist) on every PR. Automated publish from CI is **not** wired up yet. When adding it, the usual pattern is a `release.yml` workflow triggered by a push to `main` or a manual `workflow_dispatch` that runs `npx nx release` with `NPM_CONFIG_TOKEN` from repo secrets.
 
 ### Rolling back a bad release
 
@@ -161,19 +168,18 @@ If a broken version is live on npm, **unpublish within 72 hours** (`npm unpublis
 ```
 packages/
 ├── core/
+├── templates/
 ├── rcml/
 ├── client/
 ├── vendor-shopify/
 ├── vendor-bookzen/
 ├── vendor-samfora/
-└── sdk/                    # meta-package
-scripts/                    # dev utilities (deploy, clone, validate); not published
+├── sdk/                    # meta-package
+└── cli/                    # rule-io command-line tool
 .github/workflows/          # CI
 nx.json                     # Nx config incl. `release`
 tsconfig.json               # path mappings for IDE autocompletion
 ```
-
-Dev utility scripts in `scripts/` consume `@rule-io/sdk` (the meta) via the workspace symlink. Run any of them with `npx tsx scripts/<name>.ts`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Publishes the following packages under the `@rule-io/*` npm scope:
 
 | Package | Purpose |
 |---|---|
-| [`@rule-io/core`](packages/core) | Shared error classes |
+| [`@rule-io/core`](packages/core) | Shared types and utilities — error classes, brand/theme types, automation-config contract, vendor-preset interface, HTML/URL helpers |
 | [`@rule-io/templates`](packages/templates) | Angular-like XML template engine; consumed by `@rule-io/vendor-shopify` |
-| [`@rule-io/rcml`](packages/rcml) | RCML email-template builders, RCML types, automation-config schema |
+| [`@rule-io/rcml`](packages/rcml) | RCML email-template builders, types, and validators |
 | [`@rule-io/client`](packages/client) | HTTP wrapper around the Rule.io v2/v3 API |
 | [`@rule-io/vendor-shopify`](packages/vendor-shopify) | Shopify preset — e-commerce automation flows |
 | [`@rule-io/vendor-bookzen`](packages/vendor-bookzen) | Bookzen preset — hospitality automation flows |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ git push --follow-tags
 For each bumped package, Nx runs `npm publish` from `dist/packages/<pkg>/`. Contents of each tarball:
 
 - the `.js` + `.d.ts` output under `dist/packages/<pkg>/src/`
-- the package-specific `README.md` and `CHANGELOG.md`
+- the package-specific `README.md` (every package's `project.json` declares `*.md` as a build asset, so any markdown alongside the source is copied into the tarball)
+- the package-specific `CHANGELOG.md` once it exists — `nx release` auto-generates one in `packages/<pkg>/CHANGELOG.md` on each version bump (config: `release.changelog.projectChangelogs` in `nx.json`); packages that haven't been released yet don't have one
 - a `package.json` with the bumped version, rewritten paths, and no `devDependencies`
 
 ### CI / automated release

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Publishes the following packages under the `@rule-io/*` npm scope:
 | [`@rule-io/sdk`](packages/sdk) | Meta-package re-exporting the library packages above |
 | [`@rule-io/cli`](packages/cli) | `rule-io` command-line tool — deploy presets, validate RCML, inspect accounts |
 
-Dependency graph (clean DAG, no cycles — `←` reads as "depends on"):
+Dependency graph (clean DAG, no cycles — `←` reads as "depends on"; workspace edges only, external runtime deps live in each package's `package.json`):
 
 ```
-core            (leaf, no deps)
-templates       (leaf, external: fast-xml-parser)
+core
+templates
 
 rcml            ← core
 
@@ -30,7 +30,7 @@ vendor-samfora  ← core, rcml
 vendor-shopify  ← core, rcml, templates
 
 sdk (meta)      ← core, rcml, client, vendor-{shopify,bookzen,samfora}
-cli             ← core, rcml, client, vendor-{shopify,bookzen,samfora}  (+ commander)
+cli             ← core, rcml, client, vendor-{shopify,bookzen,samfora}
 ```
 
 ---
@@ -41,7 +41,7 @@ Node `>=20` required (the Nx plugins used by this workspace rely on `node:util.s
 
 ```bash
 npm install                         # install + link workspace packages
-npx nx show projects                # sanity-check: 9 publishable projects
+npx nx show projects                # sanity-check: 9 publishable packages + the workspace root
 npm run build                       # build all publishable packages → dist/packages/<pkg>/
 npm run test                        # run every package's tests
 npm run lint                        # lint every package
@@ -141,7 +141,7 @@ For each bumped package, Nx runs `npm publish` from `dist/packages/<pkg>/`. Cont
 
 ### CI / automated release
 
-CI (`.github/workflows/ci.yml`) currently runs quality gates (lint / test / build / per-package runtime-dependency allowlist) on every PR. Automated publish from CI is **not** wired up yet. When adding it, the usual pattern is a `release.yml` workflow triggered by a push to `main` or a manual `workflow_dispatch` that runs `npx nx release` with `NPM_CONFIG_TOKEN` from repo secrets.
+CI (`.github/workflows/ci.yml`) currently runs quality gates (lint / test / build / per-package runtime-dependency allowlist) on PRs to `main`, excluding docs-only changes. Automated publish from CI is **not** wired up yet. When adding it, the usual pattern is a `release.yml` workflow triggered by a push to `main` or a manual `workflow_dispatch` that runs `npx nx release` with `NPM_CONFIG_TOKEN` from repo secrets.
 
 ### Rolling back a bad release
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,14 @@
 # @rule-io/core
 
-Shared error classes and primitives used across the `@rule-io/*` package family.
+Shared types and utilities used across the `@rule-io/*` package family:
 
-Most consumers don't depend on this package directly — it's pulled in transitively by `@rule-io/client`, `@rule-io/rcml`, and the vendor presets. Import from it explicitly when you need to catch SDK errors:
+- **Error classes** — `RuleApiError`, `RuleConfigError`.
+- **Brand & theme types** — `EmailTheme` and friends (`EmailThemeColor`, `EmailThemeFont`, `EmailThemeImage`, …), `CustomFieldMap`, `FooterConfig`.
+- **Automation-config contract** — `AutomationConfigV2`, `TemplateConfigV2`, plus `getAutomationByIdV2` / `getAutomationByTriggerV2`. Vendor presets implement this.
+- **Vendor-preset interface** — `VendorPreset`, `VendorConsumerConfig`, `VendorAutomation`, plus `resolveVendorAutomations`.
+- **Sanitisation helpers** — `escapeHtml`, `sanitizeUrl`, `formatDateForRule`.
+
+Most consumers don't depend on this package directly — it's pulled in transitively by `@rule-io/client`, `@rule-io/rcml`, and every `@rule-io/vendor-*` preset. Import from it explicitly when you need any of the above:
 
 ```ts
 import { RuleApiError, RuleConfigError } from '@rule-io/core';

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 A TypeScript SDK for the [Rule.io](https://rule.io) email marketing API. Build and send email campaigns, set up tag-triggered automations, manage subscribers, and create RCML templates — all from code.
 
-**Zero external runtime dependencies** | **Full TypeScript types** | **Node.js >= 20**
+**Full TypeScript types** | **Node.js >= 20**
 
 ## Table of Contents
 
@@ -652,23 +652,20 @@ npm run dev          # Build in watch mode
 npm run test:watch   # Tests in watch mode
 ```
 
-### RCML Validation Script
+### RCML Validation
 
-Verify that the SDK produces valid templates by creating a campaign with all RCML elements:
+Verify that the SDK produces valid templates by creating a campaign with all RCML elements via [`@rule-io/cli`](../cli/README.md):
 
 ```bash
 echo "RULE_API_KEY=your-key" > .env
-npx tsx scripts/validate-rcml.ts                    # All elements
-npx tsx scripts/validate-rcml.ts --sections=1,4,7   # Specific sections
-npx tsx scripts/validate-rcml.ts --cleanup           # Clean up
+npx @rule-io/cli validate-rcml                  # All elements
+npx @rule-io/cli validate-rcml --sections 1,4,7 # Specific sections
+npx @rule-io/cli validate-rcml --cleanup        # Clean up
 ```
 
 ### Releasing
 
-1. Update `CHANGELOG.md` with the new version's changes
-2. Run `npm version <patch|minor|major>` (runs type-check + tests automatically)
-3. Push with tags: `git push && git push --tags`
-4. Publish: `npm publish`
+Releases are managed at the workspace level via `nx release`. See the [root README](../../README.md#release-process) for the full process.
 
 ### API Documentation
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -643,13 +643,14 @@ const safeUrl = sanitizeUrl(userProvidedUrl); // Blocks javascript:/data: URLs
 
 ## Development
 
+This package is part of the [`rule-io-sdk` Nx monorepo](../../README.md). Build, test, and lint commands are run at the workspace level — see the root README's [Dev workflow](../../README.md#dev-workflow) section.
+
+For commands scoped to this package only:
+
 ```bash
-npm install
-npm run build        # Build with tsup (CJS + ESM)
-npm run test         # Run tests with Vitest
-npm run type-check   # TypeScript strict mode
-npm run dev          # Build in watch mode
-npm run test:watch   # Tests in watch mode
+npx nx build sdk          # build @rule-io/sdk and its workspace deps
+npx nx vitest:test sdk    # run this package's tests
+npx nx eslint:lint sdk    # lint this package
 ```
 
 ### RCML Validation

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,0 +1,12 @@
+# @rule-io/templates
+
+Angular-like XML template engine used by `@rule-io/*` vendor email-template packages. Supports `{{ expression }}` interpolation, `*ngIf` / `*ngFor` structural directives, and `[attr]` property binding on XML elements.
+
+Most consumers don't depend on this package directly — it's pulled in transitively through `@rule-io/vendor-shopify`. Import from it explicitly when you need the renderer or its error type:
+
+```ts
+import { renderTemplate, TemplateRenderError } from '@rule-io/templates';
+import type { TemplateContext } from '@rule-io/templates';
+```
+
+See the [main `@rule-io/sdk` README](../sdk/README.md) for full SDK documentation.

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,6 +1,6 @@
 # @rule-io/templates
 
-Angular-like XML template engine used by `@rule-io/*` vendor email-template packages. Supports `{{ expression }}` interpolation, `*ngIf` / `*ngFor` structural directives, and `[attr]` property binding on XML elements.
+Angular-like XML template engine. Currently used by `@rule-io/vendor-shopify` to render its email content; intended as the shared rendering layer for any future `@rule-io/vendor-*` package that wants the same templating model. Supports `{{ expression }}` interpolation, `*ngIf` / `*ngFor` structural directives, and `[attr]` property binding on XML elements.
 
 Most consumers don't depend on this package directly — it's pulled in transitively through `@rule-io/vendor-shopify`. Import from it explicitly when you need the renderer or its error type:
 


### PR DESCRIPTION
## Summary

Root README, `packages/sdk/README.md`, and a new `packages/templates/README.md` drifted from the post-Nx-refactor reality on \`dev\`. This PR brings them in sync.

- `@rule-io/templates` was unlisted in the root package table and dep graph despite being published, non-private, and a runtime dep of `@rule-io/vendor-shopify`. Added a row, a new `packages/templates/README.md`, and a repo-layout entry.
- Dep graph implied `vendor-*` depended on `@rule-io/client`; they don't. Redrawn as an unambiguous per-package text list including the CLI's external `commander`.
- Repo layout still showed the deleted `scripts/` directory; replaced with the `cli/` entry it became in `e658c54`.
- Dropped two false zero-deps claims (root README's "CI enforces zero external deps", SDK README's "Zero external runtime dependencies" tagline) — installing `@rule-io/sdk` transitively pulls in ajv, zod, prosemirror-model, fast-xml-parser, etc. via `@rule-io/rcml` and `@rule-io/templates`.
- `packages/sdk/README.md` still pointed at `npx tsx scripts/validate-rcml.ts` (deleted) and the old `npm version` + `npm publish` release flow. Switched to `npx @rule-io/cli validate-rcml` and a pointer to the root README's `nx release` section.

## Out of scope (worth a follow-up)

The CI runtime-dep allowlist check in `.github/workflows/ci.yml` would fail today on `@rule-io/rcml` and `@rule-io/templates`. CI only triggers on `main`, so `dev` has been accumulating disallowed runtime deps undetected.

## Test plan

- [x] `grep -rn "scripts/validate-rcml\|seven packages\|zero external deps" --include='*.md' .` — clean (CHANGELOG hits are historical entries, kept).
- [x] All four relative markdown links resolve on disk (`packages/sdk/README.md`, `packages/cli/README.md`, `packages/templates/README.md`, root `README.md#release-process`).
- [x] `npx nx show projects` still lists 9 publishable + the workspace root, matching the README's package table.
- [ ] Render diffs in GitHub's Markdown previewer once the PR is up — confirm the redrawn dep graph and tables render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)