### PR TITLE
fix(types): extend RuleDynamicSet shape to match API responses (#119)

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -231,8 +231,18 @@ export interface RuleTemplateResponse extends RuleApiResponse {
  */
 export interface RuleDynamicSet {
   id?: number;
-  message_id: number;
+  /**
+   * Present on getDynamicSet responses and on the nested default_dynamic_set
+   * inside Message responses. Omitted from listDynamicSets list items, so
+   * marked optional on the read type.
+   */
+  message_id?: number;
   template_id: number;
+  name?: string | null;
+  subject?: string | null;
+  pre_header?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
 }
 
 export interface RuleDynamicSetCreateRequest {

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -847,6 +847,52 @@ describe('RuleClient', () => {
     });
   });
 
+  describe('v3 read-side types preserve utm and dynamic-set fields', () => {
+    it('getDynamicSet surfaces name, pre_header, and utm fields', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 200,
+            message_id: 456,
+            template_id: 789,
+            name: 'Standard',
+            subject: 'Fallback Subject',
+            pre_header: 'Fallback preheader',
+            utm_campaign: 'order-return',
+            utm_term: null,
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.getDynamicSet(200);
+
+      expect(result?.data?.name).toBe('Standard');
+      expect(result?.data?.subject).toBe('Fallback Subject');
+      expect(result?.data?.pre_header).toBe('Fallback preheader');
+      expect(result?.data?.utm_campaign).toBe('order-return');
+      expect(result?.data?.utm_term).toBeNull();
+    });
+
+    it('listDynamicSets preserves name on list items', async () => {
+      // Real API shape (verified against email-snapshots/*): list endpoint
+      // returns only { id, name, template_id, __resource }. utm/subject/
+      // pre_header are only populated on getDynamicSet and on the nested
+      // default_dynamic_set inside Message responses.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: [{ id: 200, name: 'Standard', template_id: 789 }],
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listDynamicSets({ message_id: 456 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data?.[0].name).toBe('Standard');
+    });
+  });
+
   describe('v3 Custom Field Data API (Deprecated)', () => {
     it('should get custom field data for a subscriber', async () => {
       const mockData = {


### PR DESCRIPTION
## Summary

Backports PR #111 from main to dev monorepo. Extends `RuleDynamicSet` type to match the actual API response shape:
- Makes `message_id` optional (omitted from `listDynamicSets` list items)
- Adds five new optional `string | null` fields: `name`, `subject`, `pre_header`, `utm_campaign`, `utm_term`

## Changes

- **Type update**: `packages/client/src/types.ts` — `RuleDynamicSet` interface
- **Test coverage**: `packages/client/tests/client.test.ts` — two new tests in "v3 read-side types" describe block

## Safety

Grep of `packages/*` confirms no consumers depend on `message_id` being required in read responses. Request types (`RuleDynamicSetCreateRequest` and `RuleDynamicSetUpdateRequest`) still require `message_id: number` where appropriate.

Tests: 207 passed (including 2 new tests)
Type check: ✅ Pass
Build: ✅ Pass

Closes #119

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>