### PR TITLE
feat(client): port listSubscribersByTagIds to monorepo (#117)

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -32,6 +32,9 @@ import type {
   RuleSubscriberResponse,
   RuleSubscriberFieldsResponse,
   RuleSubscriberTagsResponse,
+  RuleSubscribersV2ListResponse,
+  ListSubscribersByTagIdsParams,
+  ListSubscribersByTagIdsResult,
   RuleTagsResponse,
   RuleAutomationCreateRequest,
   RuleAutomationUpdateRequest,
@@ -404,6 +407,22 @@ type QueryParamValues = Record<string, QueryParamValue | QueryParamValue[]>;
  * await client.addSubscriberTags('customer@example.com', ['accommodation'], 'force');
  * ```
  */
+
+function parseNextPage(nextUrl: string | null): number | null {
+  if (!nextUrl) return null;
+
+  try {
+    const pageStr = new URL(nextUrl).searchParams.get('page');
+
+    if (!pageStr) return null;
+    const page = Number.parseInt(pageStr, 10);
+
+    return Number.isFinite(page) && page > 0 ? page : null;
+  } catch {
+    return null;
+  }
+}
+
 export class RuleClient {
   private config: Required<RuleClientConfig>;
 
@@ -900,6 +919,66 @@ export class RuleClient {
 
       throw error;
     }
+  }
+
+  /**
+   * List subscribers filtered by tag intersection.
+   *
+   * Returns one page at a time. Subscribers are filtered client-side (Rule.io
+   * ignores server-side tag filters as of 2026-04), so this method requires
+   * scanning the entire list. Caller drives pagination by passing `next_page`
+   * back until it returns null.
+   *
+   * @param params - Pagination and filter parameters
+   * @returns Paginated result with matched subscribers and next page cursor
+   * @throws RuleConfigError if tag_ids is empty
+   *
+   * @example
+   * ```typescript
+   * // Collect all subscribers with tag IDs 42 AND 99
+   * const all: RuleSubscriberV2[] = [];
+   * let page: number | null = 1;
+   * while (page !== null) {
+   *   const res = await client.listSubscribersByTagIds({
+   *     tag_ids: [42, 99],
+   *     page,
+   *     limit: 500,
+   *   });
+   *   all.push(...res.subscribers);
+   *   page = res.next_page;
+   * }
+   * ```
+   */
+  async listSubscribersByTagIds(
+    params: ListSubscribersByTagIdsParams
+  ): Promise<ListSubscribersByTagIdsResult> {
+    if (!params.tag_ids || params.tag_ids.length === 0) {
+      throw new RuleConfigError('tag_ids must not be empty');
+    }
+
+    const qs = RuleClient.buildQueryString({
+      page: params.page,
+      limit: params.limit,
+    });
+    const response = await this.request<RuleSubscribersV2ListResponse>(
+      `/subscribers${qs}`,
+      { method: 'GET' }
+    );
+
+    const scanned = response.subscribers ?? [];
+    const required = params.tag_ids;
+    const matched = scanned.filter((sub) => {
+      const subTagIds = new Set(sub.tags?.map((t) => t.id) ?? []);
+
+      return required.every((id) => subTagIds.has(id));
+    });
+
+    return {
+      subscribers: matched,
+      matched: matched.length,
+      scanned: scanned.length,
+      next_page: parseNextPage(response.meta?.next ?? null),
+    };
   }
 
   // ==========================================================================

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -54,6 +54,64 @@ export interface RuleSubscriberTagsResponse extends RuleApiResponse {
   tags?: Array<{ name: string }>;
 }
 
+/**
+ * A subscriber record from the v2 list endpoint.
+ *
+ * Tags are included inline, which enables client-side tag filtering without
+ * N+1 calls. `tags` allows `null` or absent because the API's representation
+ * for subscribers with zero tags is not strictly guaranteed across accounts —
+ * observed shapes include `[]`, `null`, and the field being omitted.
+ */
+export interface RuleSubscriberV2 {
+  id: number;
+  email: string | null;
+  phone_number: string | null;
+  language: string;
+  opted_in: boolean;
+  suppressed: boolean;
+  created_at: string;
+  updated_at: string;
+  tags?: Array<{ id: number; name: string }> | null;
+}
+
+/**
+ * Raw shape of `GET /api/v2/subscribers`. `meta.next` is a URL to the next
+ * page (includes `?page=N` query param) or null when exhausted.
+ */
+export interface RuleSubscribersV2ListResponse extends RuleApiResponse {
+  subscribers?: RuleSubscriberV2[];
+  meta?: { next?: string | null };
+}
+
+/**
+ * Parameters for `listSubscribersByTagIds`.
+ */
+export interface ListSubscribersByTagIdsParams {
+  /** Tag IDs the subscriber must ALL have (intersection). Must be non-empty. */
+  tag_ids: number[];
+  /** v2 uses `limit`, not `per_page`. Default 100, max ~1000. */
+  limit?: number;
+  page?: number;
+}
+
+/**
+ * Result shape for `listSubscribersByTagIds`. One page at a time — caller
+ * drives pagination by passing `next_page` back until it returns null.
+ */
+export interface ListSubscribersByTagIdsResult {
+  /** Subscribers on this page that matched all required tag_ids. */
+  subscribers: RuleSubscriberV2[];
+  /** Count of subscribers that matched (equals `subscribers.length`). */
+  matched: number;
+  /** Count of subscribers scanned on this page before filtering. */
+  scanned: number;
+  /**
+   * Page number to request next. Null when `meta.next` is absent, null,
+   * malformed, or missing a `page` query parameter.
+   */
+  next_page: number | null;
+}
+
 // ============================================================================
 // v2 Tags API Types
 // ============================================================================

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -268,6 +268,213 @@ describe('RuleClient', () => {
     });
   });
 
+  describe('listSubscribersByTagIds', () => {
+    // Shared fixture for building subscriber records with arbitrary tag IDs.
+    function sub(id: number, email: string, tagIds: number[]) {
+      return {
+        id,
+        email,
+        phone_number: null,
+        language: 'en',
+        opted_in: true,
+        suppressed: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        tags: tagIds.map((tid) => ({ id: tid, name: `tag-${tid}` })),
+      };
+    }
+
+    it('filters subscribers by a single tag id', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          subscribers: [sub(1, 'a@example.com', [42]), sub(2, 'b@example.com', [7])],
+          meta: { next: null },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [42] });
+
+      expect(result.scanned).toBe(2);
+      expect(result.matched).toBe(1);
+      expect(result.subscribers).toHaveLength(1);
+      expect(result.subscribers[0].email).toBe('a@example.com');
+      expect(result.next_page).toBeNull();
+    });
+
+    it('requires intersection (ALL tag_ids) when multiple are passed', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          subscribers: [
+            sub(1, 'only1@example.com', [1]),
+            sub(2, 'only2@example.com', [2]),
+            sub(3, 'both@example.com', [1, 2]),
+            sub(4, 'superset@example.com', [1, 2, 3]),
+          ],
+          meta: { next: null },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [1, 2] });
+
+      expect(result.scanned).toBe(4);
+      expect(result.matched).toBe(2);
+      expect(result.subscribers.map((s) => s.email)).toEqual([
+        'both@example.com',
+        'superset@example.com',
+      ]);
+    });
+
+    it('returns empty result when nothing on the page matches', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          subscribers: [sub(1, 'a@example.com', [7])],
+          meta: { next: null },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [42] });
+
+      expect(result.scanned).toBe(1);
+      expect(result.matched).toBe(0);
+      expect(result.subscribers).toEqual([]);
+    });
+
+    it('handles empty subscribers array', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ subscribers: [], meta: { next: null } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [1] });
+
+      expect(result.scanned).toBe(0);
+      expect(result.matched).toBe(0);
+      expect(result.next_page).toBeNull();
+    });
+
+    it('treats subscribers missing a tags field as having no tags', async () => {
+      // Rule.io's representation of a zero-tag subscriber is not strictly
+      // guaranteed — could be `tags: []`, `tags: null`, or the field absent.
+      // All three must filter out when tag_ids are required.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          subscribers: [
+            { ...sub(1, 'notags@example.com', []), tags: undefined },
+            { ...sub(2, 'nulltags@example.com', []), tags: null },
+            sub(3, 'emptytags@example.com', []),
+          ],
+          meta: { next: null },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [1] });
+
+      expect(result.scanned).toBe(3);
+      expect(result.matched).toBe(0);
+    });
+
+    it('parses page number from meta.next URL', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          subscribers: [sub(1, 'a@example.com', [1])],
+          meta: { next: 'https://app.rule.io/api/v2/subscribers?page=3&limit=100' },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const result = await client.listSubscribersByTagIds({ tag_ids: [1] });
+
+      expect(result.next_page).toBe(3);
+    });
+
+    it('returns null next_page when meta.next is absent, null, or malformed', async () => {
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      // meta absent
+      mockFetch.mockResolvedValueOnce(createMockResponse({ subscribers: [] }));
+      expect((await client.listSubscribersByTagIds({ tag_ids: [1] })).next_page).toBeNull();
+
+      // meta.next = null
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ subscribers: [], meta: { next: null } })
+      );
+      expect((await client.listSubscribersByTagIds({ tag_ids: [1] })).next_page).toBeNull();
+
+      // meta.next lacks page param
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ subscribers: [], meta: { next: 'https://x.example/?limit=50' } })
+      );
+      expect((await client.listSubscribersByTagIds({ tag_ids: [1] })).next_page).toBeNull();
+
+      // meta.next is not a valid URL
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ subscribers: [], meta: { next: 'not-a-url' } })
+      );
+      expect((await client.listSubscribersByTagIds({ tag_ids: [1] })).next_page).toBeNull();
+    });
+
+    it('throws RuleConfigError and does not call fetch when tag_ids is empty', async () => {
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.listSubscribersByTagIds({ tag_ids: [] })
+      ).rejects.toThrow(RuleConfigError);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('passes page and limit as query-string params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ subscribers: [], meta: { next: null } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.listSubscribersByTagIds({ tag_ids: [1], page: 2, limit: 500 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+
+      expect(url).toContain('/subscribers?');
+      expect(url).toContain('page=2');
+      expect(url).toContain('limit=500');
+    });
+
+    it('supports caller-driven pagination loop across multiple pages', async () => {
+      // Page 1 → next_page = 2; page 2 → next_page = null
+      mockFetch
+        .mockResolvedValueOnce(
+          createMockResponse({
+            subscribers: [sub(1, 'p1@example.com', [1])],
+            meta: { next: 'https://app.rule.io/api/v2/subscribers?page=2&limit=100' },
+          })
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            subscribers: [sub(2, 'p2@example.com', [1])],
+            meta: { next: null },
+          })
+        );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+      const collected: string[] = [];
+      let page: number | null = 1;
+
+      while (page !== null) {
+        const res = await client.listSubscribersByTagIds({ tag_ids: [1], page });
+
+        collected.push(...res.subscribers.map((s) => s.email!));
+        page = res.next_page;
+      }
+
+      expect(collected).toEqual(['p1@example.com', 'p2@example.com']);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getSubscriber', () => {
     it('should return subscriber data', async () => {
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

Backports PR #108 from `main` into the monorepo `@rule-io/client` package. Implements client-side tag intersection over `/v2/subscribers` because Rule.io silently ignores server-side tag filters (as of 2026-04).

## What's included

- **Method**: `listSubscribersByTagIds(params)` on `RuleClient` — scans `/api/v2/subscribers`, filters client-side by tag intersection, returns paginated results with `next_page` cursor
- **Helper**: `parseNextPage()` — extracts page number from `meta.next` URL  
- **Types**: Four new exports — `RuleSubscriberV2`, `RuleSubscribersV2ListResponse`, `ListSubscribersByTagIdsParams`, `ListSubscribersByTagIdsResult`
- **Tests**: 10 cases covering single/multi-tag filtering, intersection logic, pagination, edge cases, and error validation

## Test Plan

- [x] All 10 test cases pass (tag filtering, intersection, empty results, null tag handling, URL parsing, error cases, pagination)
- [x] Lint passes
- [x] Types exported from `@rule-io/client` and umbrella `@rule-io/sdk`
- [x] Backward compatible (new exports only, no breaking changes)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)