### PR TITLE
docs(readme): add "Which package should I install?" guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rule-io-sdk
 
-Nx monorepo for the Rule.io TypeScript SDK. Consumer-facing SDK docs live in [`packages/sdk`](packages/sdk/README.md); this README is for contributors and release maintainers.
+Nx monorepo for the Rule.io TypeScript SDK. Detailed usage docs live in [`packages/sdk`](packages/sdk/README.md) and the per-package READMEs; this README covers package selection, contributor workflow, and the release process.
 
 Publishes the following packages under the `@rule-io/*` npm scope:
 
@@ -16,7 +16,65 @@ Publishes the following packages under the `@rule-io/*` npm scope:
 | [`@rule-io/sdk`](packages/sdk) | Meta-package re-exporting the library packages above |
 | [`@rule-io/cli`](packages/cli) | `rule-io` command-line tool — deploy presets, validate RCML, inspect accounts |
 
-Dependency graph (clean DAG, no cycles — `←` reads as "depends on"; workspace edges only, external runtime deps live in each package's `package.json`):
+---
+
+## Which package should I install?
+
+Most consumers install **one** package — npm pulls in everything else as transitive dependencies.
+
+| If you want to… | Install | Notes |
+|---|---|---|
+| Call the Rule.io HTTP API | `@rule-io/client` | The 90% case. Brings in `core` + `rcml` automatically. |
+| Ship a Shopify e-commerce integration | `@rule-io/client` + `@rule-io/vendor-shopify` | Order confirmation, shipping, abandoned cart, cancellation, welcome. |
+| Ship a Bookzen hospitality integration | `@rule-io/client` + `@rule-io/vendor-bookzen` | Reservation confirmation, cancellation, reminder, feedback, request. |
+| Ship a Samfora donation integration | `@rule-io/client` + `@rule-io/vendor-samfora` | Swedish donation-platform flows. |
+| Compose custom RCML templates from primitives | `@rule-io/rcml` | Low-level builders only — pair with `@rule-io/client` to send. |
+| Run the CLI to deploy presets / validate RCML | `@rule-io/cli` | Installs the `rule-io` binary. |
+| Try everything in one install (prototypes, demos) | `@rule-io/sdk` | Meta-package re-exporting every library above. Larger `node_modules` — prefer the direct installs above for production. |
+
+### Examples
+
+Just calling the API:
+
+```bash
+npm install @rule-io/client
+```
+
+```ts
+import { RuleClient } from '@rule-io/client';
+
+const client = new RuleClient({ apiKey: process.env.RULE_API_KEY! });
+await client.addSubscriberTagsV3('user@example.com', { tags: ['welcome'] });
+```
+
+Shipping a Shopify integration:
+
+```bash
+npm install @rule-io/client @rule-io/vendor-shopify
+```
+
+```ts
+import { RuleClient } from '@rule-io/client';
+import { createOrderConfirmationEmail } from '@rule-io/vendor-shopify';
+```
+
+Kitchen sink for prototyping:
+
+```bash
+npm install @rule-io/sdk
+```
+
+```ts
+import { RuleClient, createOrderConfirmationEmail } from '@rule-io/sdk';
+```
+
+> `@rule-io/core` and `@rule-io/templates` are infrastructure packages — they almost never appear in a consumer's `package.json`. They arrive as transitive dependencies of the libraries above.
+
+---
+
+## Dependency graph
+
+Clean DAG, no cycles — `←` reads as "depends on"; workspace edges only, external runtime deps live in each package's `package.json`:
 
 ```
 core


### PR DESCRIPTION
## Summary

- Adds a decision table mapping 7 common consumer scenarios (just-the-API, each vendor preset, custom RCML, CLI, kitchen-sink) to the right install command
- Includes three concrete code examples for the most common paths
- Promotes the existing inline "Dependency graph" intro to its own H2 so it sits cleanly alongside the new selector
- Softens the opening sentence to reflect the new consumer-facing material

## Why

The monorepo publishes 9 packages but a consumer landing on the repo had no guidance on which to install for their use case. This is the kind of "first 5 minutes" friction that's cheap to fix now and expensive to fix once people start hitting it post-publish.

## Verification

Code samples were checked against real exports:
- `RuleClient` constructor signature (`packages/client/src/client.ts:429`)
- `addSubscriberTagsV3('email', { tags: [...] })` (`packages/client/src/client.ts:2151`)
- `createOrderConfirmationEmail` exported from `@rule-io/vendor-shopify`
- `@rule-io/sdk` re-exports cover both `RuleClient` and `createOrderConfirmationEmail`

Bookzen and Shopify template lists in the table match the actual `createXxxEmail` exports in each vendor package. Anchor links from `packages/sdk/README.md` (`#dev-workflow`, `#release-process`) still resolve.

## Test plan

- [ ] Render the README on GitHub and confirm tables + code blocks display correctly
- [ ] Click the cross-package links from `packages/sdk/README.md` and verify anchors still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)