### PR TITLE
fix(client): localize Rule.io API quirks in getAnalytics & updateAutomation

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -44,6 +44,7 @@ import type {
   RuleAutomationCreateRequest,
   RuleAutomationUpdateRequest,
   RuleAutomationResponse,
+  RuleSendoutType,
   RuleAutomationListParams,
   RuleAutomationListResponse,
   RuleMessageCreateRequest,
@@ -1047,14 +1048,23 @@ export class RuleClient {
   }
 
   /**
-   * Update an automation. Supports partial updates — only include the fields
-   * you want to change.
+   * Update an automation. Accepts a partial input — any field omitted is
+   * preserved from the current automation.
+   *
+   * IMPORTANT: Rule.io's `PUT /editor/automail/{id}` rejects partial bodies —
+   * it requires `name`, `active`, `trigger`, and `sendout_type` together.
+   * This method performs read-modify-write internally (one extra GET per
+   * update) so callers can pass only the fields they want to change.
    *
    * IMPORTANT: The trigger.type must be uppercase ("TAG" or "SEGMENT").
    * The API error messages incorrectly suggest lowercase, but uppercase is required.
    *
    * @param id - Automation ID
    * @param update - Partial update request (all fields optional)
+   * @throws RuleApiError(404) if no automation exists with the given id
+   * @throws RuleConfigError if the existing automation lacks a trigger or
+   *   sendout_type and the update does not provide one (the PUT body would be
+   *   incomplete and the API would reject it)
    *
    * @example
    * ```typescript
@@ -1074,9 +1084,57 @@ export class RuleClient {
     id: number,
     update: Partial<RuleAutomationUpdateRequest>
   ): Promise<RuleAutomationResponse> {
+    const existing = await this.getAutomation(id);
+
+    if (!existing?.data) {
+      throw new RuleApiError(`Automation ${id} not found`, 404);
+    }
+
+    const current = existing.data;
+
+    // Response shape wraps sendout_type as { value, key, description }; the
+    // request shape requires the numeric value. Tolerate either form in case
+    // the response is ever flattened upstream.
+    const currentSendout: number | undefined =
+      typeof current.sendout_type === 'number'
+        ? current.sendout_type
+        : current.sendout_type?.value;
+
+    const trigger = update.trigger ?? current.trigger;
+    const sendoutType = update.sendout_type ?? currentSendout;
+    // Don't fall back to a boolean default for `active` — the API requires it
+    // in the PUT body, and silently defaulting to `false` could deactivate an
+    // automation when the caller only meant to rename it.
+    const active = update.active ?? current.active;
+
+    if (!trigger) {
+      throw new RuleConfigError(
+        `Cannot update automation ${id}: existing record has no trigger and update did not provide one`
+      );
+    }
+
+    if (sendoutType == null) {
+      throw new RuleConfigError(
+        `Cannot update automation ${id}: existing record has no sendout_type and update did not provide one`
+      );
+    }
+
+    if (active == null) {
+      throw new RuleConfigError(
+        `Cannot update automation ${id}: existing record has no active state and update did not provide one`
+      );
+    }
+
+    const fullBody: RuleAutomationUpdateRequest = {
+      name: update.name ?? current.name,
+      active,
+      trigger,
+      sendout_type: sendoutType as RuleSendoutType,
+    };
+
     return this.requestV3<RuleAutomationResponse>(`/editor/automail/${id}`, {
       method: 'PUT',
-      body: JSON.stringify(update),
+      body: JSON.stringify(fullBody),
     });
   }
 
@@ -2590,9 +2648,15 @@ export class RuleClient {
       metrics = params.metrics;
     }
 
+    // The /analytics endpoint rejects datetime form (`YYYY-MM-DD HH:MM:SS`) and
+    // accepts only bare dates, even though sibling v3 endpoints (e.g.
+    // exportStatistics) accept both. Strip any time portion so consumers using
+    // a shared date normalizer don't have to special-case this endpoint.
+    const stripTime = (d: string): string => d.split(/[ T]/)[0];
+
     const qs = RuleClient.buildQueryString({
-      date_from: params.date_from,
-      date_to: params.date_to,
+      date_from: stripTime(params.date_from),
+      date_to: stripTime(params.date_to),
       object_type: objectType,
       'object_ids[]': objectIds,
       'metrics[]': metrics,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2673,7 +2673,7 @@ export class RuleClient {
     }
 
     // The /analytics endpoint rejects any datetime form (e.g. ISO-8601 or
-    // space-separated `YYYY-MM-DD hh:mm:ss`) and accepts only bare dates,
+    // space-separated `YYYY-MM-DD HH:mm:ss`) and accepts only bare dates,
     // even though sibling v3 endpoints (e.g. exportStatistics) accept both.
     // Strip any time portion so consumers using a shared date normalizer
     // don't have to special-case this endpoint.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1063,9 +1063,9 @@ export class RuleClient {
    * @param id - Automation ID
    * @param update - Partial update request (all fields optional)
    * @throws RuleApiError(404) if no automation exists with the given id
-   * @throws RuleConfigError if the existing automation lacks a trigger or
-   *   sendout_type and the update does not provide one (the PUT body would be
-   *   incomplete and the API would reject it)
+   * @throws RuleConfigError if the existing automation lacks `trigger`,
+   *   `sendout_type`, or `active` and the update does not provide one (the
+   *   PUT body would be incomplete and the API would reject it)
    *
    * @example
    * ```typescript

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1053,8 +1053,9 @@ export class RuleClient {
    *
    * IMPORTANT: Rule.io's `PUT /editor/automail/{id}` rejects partial bodies —
    * it requires `name`, `active`, `trigger`, and `sendout_type` together.
-   * This method performs read-modify-write internally (one extra GET per
-   * update) so callers can pass only the fields they want to change.
+   * This method performs read-modify-write internally so callers can pass only
+   * the fields they want to change. When the input already includes all four
+   * required fields, the GET is skipped and the PUT runs directly.
    *
    * IMPORTANT: The trigger.type must be uppercase ("TAG" or "SEGMENT").
    * The API error messages incorrectly suggest lowercase, but uppercase is required.
@@ -1084,6 +1085,26 @@ export class RuleClient {
     id: number,
     update: Partial<RuleAutomationUpdateRequest>
   ): Promise<RuleAutomationResponse> {
+    // Fast path: when the caller already supplies every field the API requires,
+    // skip the read and PUT directly. Saves one round-trip for full-body
+    // updates like clone-email and the deploy CLIs once they pass full bodies.
+    if (
+      update.name !== undefined &&
+      update.active !== undefined &&
+      update.trigger !== undefined &&
+      update.sendout_type !== undefined
+    ) {
+      return this.requestV3<RuleAutomationResponse>(`/editor/automail/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          name: update.name,
+          active: update.active,
+          trigger: update.trigger,
+          sendout_type: update.sendout_type,
+        }),
+      });
+    }
+
     const existing = await this.getAutomation(id);
 
     if (!existing?.data) {
@@ -2648,10 +2669,11 @@ export class RuleClient {
       metrics = params.metrics;
     }
 
-    // The /analytics endpoint rejects datetime form (`YYYY-MM-DD HH:MM:SS`) and
-    // accepts only bare dates, even though sibling v3 endpoints (e.g.
-    // exportStatistics) accept both. Strip any time portion so consumers using
-    // a shared date normalizer don't have to special-case this endpoint.
+    // The /analytics endpoint rejects any datetime form (e.g. ISO-8601 or
+    // space-separated `YYYY-MM-DD hh:mm:ss`) and accepts only bare dates,
+    // even though sibling v3 endpoints (e.g. exportStatistics) accept both.
+    // Strip any time portion so consumers using a shared date normalizer
+    // don't have to special-case this endpoint.
     const stripTime = (d: string): string => d.split(/[ T]/)[0];
 
     const qs = RuleClient.buildQueryString({

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1088,11 +1088,14 @@ export class RuleClient {
     // Fast path: when the caller already supplies every field the API requires,
     // skip the read and PUT directly. Saves one round-trip for full-body
     // updates like clone-email and the deploy CLIs once they pass full bodies.
+    // Guard with `!= null` (not `!== undefined`) so a JS caller passing
+    // `{ trigger: null }` falls through to the slow path's nullish handling
+    // instead of sending a `null` field straight to the API.
     if (
-      update.name !== undefined &&
-      update.active !== undefined &&
-      update.trigger !== undefined &&
-      update.sendout_type !== undefined
+      update.name != null &&
+      update.active != null &&
+      update.trigger != null &&
+      update.sendout_type != null
     ) {
       return this.requestV3<RuleAutomationResponse>(`/editor/automail/${id}`, {
         method: 'PUT',

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1110,8 +1110,20 @@ export class RuleClient {
 
     const existing = await this.getAutomation(id);
 
-    if (!existing?.data) {
+    // getAutomation() returns null only on HTTP 404 — anything else with
+    // missing `data` is a malformed/error envelope on a 2xx response, and
+    // we should surface that distinctly instead of remapping to 404.
+    if (existing === null) {
       throw new RuleApiError(`Automation ${id} not found`, 404);
+    }
+
+    if (!existing.data) {
+      const detail = existing.error ?? existing.message ?? 'response had no data';
+
+      throw new RuleApiError(
+        `Cannot update automation ${id}: unexpected response from getAutomation (${detail})`,
+        500
+      );
     }
 
     const current = existing.data;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1085,17 +1085,39 @@ export class RuleClient {
     id: number,
     update: Partial<RuleAutomationUpdateRequest>
   ): Promise<RuleAutomationResponse> {
+    // Coerce sendout_type to its numeric request form, accepting either the
+    // numeric value or the response wrapper `{ value, key, description }`.
+    // A consumer round-tripping a getAutomation() response into update can
+    // legitimately pass the object form; both paths must handle it.
+    const toNumericSendout = (
+      v: unknown
+    ): RuleSendoutType | undefined => {
+      if (typeof v === 'number') return v as RuleSendoutType;
+
+      if (v != null && typeof v === 'object' && 'value' in v) {
+        const val = (v as { value: unknown }).value;
+
+        if (typeof val === 'number') return val as RuleSendoutType;
+      }
+
+      return undefined;
+    };
+
+    const updateSendout = toNumericSendout(update.sendout_type);
+
     // Fast path: when the caller already supplies every field the API requires,
     // skip the read and PUT directly. Saves one round-trip for full-body
     // updates like clone-email and the deploy CLIs once they pass full bodies.
     // Guard with `!= null` (not `!== undefined`) so a JS caller passing
     // `{ trigger: null }` falls through to the slow path's nullish handling
-    // instead of sending a `null` field straight to the API.
+    // instead of sending a `null` field straight to the API. Also require
+    // sendout_type to coerce to a number — the response-wrapper object falls
+    // through to the slow path where it's normalized consistently.
     if (
       update.name != null &&
       update.active != null &&
       update.trigger != null &&
-      update.sendout_type != null
+      updateSendout != null
     ) {
       return this.requestV3<RuleAutomationResponse>(`/editor/automail/${id}`, {
         method: 'PUT',
@@ -1103,7 +1125,7 @@ export class RuleClient {
           name: update.name,
           active: update.active,
           trigger: update.trigger,
-          sendout_type: update.sendout_type,
+          sendout_type: updateSendout,
         }),
       });
     }
@@ -1128,16 +1150,10 @@ export class RuleClient {
 
     const current = existing.data;
 
-    // Response shape wraps sendout_type as { value, key, description }; the
-    // request shape requires the numeric value. Tolerate either form in case
-    // the response is ever flattened upstream.
-    const currentSendout: number | undefined =
-      typeof current.sendout_type === 'number'
-        ? current.sendout_type
-        : current.sendout_type?.value;
+    const currentSendout = toNumericSendout(current.sendout_type);
 
     const trigger = update.trigger ?? current.trigger;
-    const sendoutType = update.sendout_type ?? currentSendout;
+    const sendoutType = updateSendout ?? currentSendout;
     // Don't fall back to a boolean default for `active` — the API requires it
     // in the PUT body, and silently defaulting to `false` could deactivate an
     // automation when the caller only meant to rename it.
@@ -1165,7 +1181,7 @@ export class RuleClient {
       name: update.name ?? current.name,
       active,
       trigger,
-      sendout_type: sendoutType as RuleSendoutType,
+      sendout_type: sendoutType,
     };
 
     return this.requestV3<RuleAutomationResponse>(`/editor/automail/${id}`, {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1110,9 +1110,10 @@ export class RuleClient {
     // updates like clone-email and the deploy CLIs once they pass full bodies.
     // Guard with `!= null` (not `!== undefined`) so a JS caller passing
     // `{ trigger: null }` falls through to the slow path's nullish handling
-    // instead of sending a `null` field straight to the API. Also require
-    // sendout_type to coerce to a number — the response-wrapper object falls
-    // through to the slow path where it's normalized consistently.
+    // instead of sending a `null` field straight to the API. `sendout_type`
+    // accepts either form (number or response-wrapper object) — it was
+    // coerced to a number by `toNumericSendout` above, and the coerced
+    // value is what we PUT.
     if (
       update.name != null &&
       update.active != null &&

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1014,7 +1014,10 @@ export type RuleAnalyticsMessageType = 'email' | 'text_message';
 
 /**
  * Base date range shared by all analytics queries.
- * All date strings must be in `YYYY-MM-DD` format.
+ *
+ * Dates may be passed as `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS` /
+ * `YYYY-MM-DDTHH:MM:SS` — the SDK strips any time portion before sending,
+ * since the analytics endpoint only accepts bare dates.
  */
 export interface RuleAnalyticsDateRange {
   /** Start date (inclusive), e.g. "2024-01-01" */

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1015,9 +1015,10 @@ export type RuleAnalyticsMessageType = 'email' | 'text_message';
 /**
  * Base date range shared by all analytics queries.
  *
- * Dates may be passed as `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS` /
- * `YYYY-MM-DDTHH:MM:SS` — the SDK strips any time portion before sending,
- * since the analytics endpoint only accepts bare dates.
+ * Dates may be passed as bare `YYYY-MM-DD` or as a datetime string in
+ * space-separated (`YYYY-MM-DD hh:mm:ss`) or ISO-8601 form
+ * (`YYYY-MM-DDThh:mm:ss[Z|±hh:mm]`). The SDK strips any time portion before
+ * sending, since the analytics endpoint only accepts bare dates.
  */
 export interface RuleAnalyticsDateRange {
   /** Start date (inclusive), e.g. "2024-01-01" */

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1015,9 +1015,9 @@ export type RuleAnalyticsMessageType = 'email' | 'text_message';
 /**
  * Base date range shared by all analytics queries.
  *
- * Dates may be passed as bare `YYYY-MM-DD` or as a datetime string in
- * space-separated (`YYYY-MM-DD hh:mm:ss`) or ISO-8601 form
- * (`YYYY-MM-DDThh:mm:ss[Z|±hh:mm]`). The SDK strips any time portion before
+ * Dates may be passed as bare `YYYY-MM-DD` or as a 24-hour datetime string
+ * in space-separated (`YYYY-MM-DD HH:mm:ss`) or ISO-8601 form
+ * (`YYYY-MM-DDTHH:mm:ss[Z|±HH:mm]`). The SDK strips any time portion before
  * sending, since the analytics endpoint only accepts bare dates.
  */
 export interface RuleAnalyticsDateRange {

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -815,6 +815,19 @@ describe('RuleClient', () => {
     });
 
     it('should update an automation with all fields', async () => {
+      // GET (read-modify-write fetches existing first)
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Old',
+            active: false,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+      // PUT
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
           data: { id: 1, name: 'Updated', active: true },
@@ -830,11 +843,18 @@ describe('RuleClient', () => {
       });
 
       expect(result.data?.name).toBe('Updated');
-      const [url, options] = mockFetch.mock.calls[0];
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      expect(url).toBe('https://app.rule.io/api/v3/editor/automail/1');
-      expect(options.method).toBe('PUT');
-      const body = JSON.parse(options.body);
+      const [getUrl, getOptions] = mockFetch.mock.calls[0];
+
+      expect(getUrl).toBe('https://app.rule.io/api/v3/editor/automail/1');
+      expect(getOptions.method).toBe('GET');
+
+      const [putUrl, putOptions] = mockFetch.mock.calls[1];
+
+      expect(putUrl).toBe('https://app.rule.io/api/v3/editor/automail/1');
+      expect(putOptions.method).toBe('PUT');
+      const body = JSON.parse(putOptions.body);
 
       expect(body.name).toBe('Updated');
       expect(body.active).toBe(true);
@@ -842,39 +862,206 @@ describe('RuleClient', () => {
       expect(body.sendout_type).toBe(2);
     });
 
-    it('should update an automation with partial fields (name only)', async () => {
+    it('should send a full PUT body when only name is updated (read-modify-write)', async () => {
+      // GET — existing automation
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          data: { id: 1, name: 'Renamed' },
+          data: {
+            id: 1,
+            name: 'Old',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 2, key: 'TRANSACTIONAL', description: '' },
+          },
         })
+      );
+      // PUT
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'Renamed' } })
       );
 
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
       const result = await client.updateAutomation(1, { name: 'Renamed' });
 
       expect(result.data?.name).toBe('Renamed');
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
 
-      expect(body).toEqual({ name: 'Renamed' });
-      expect(body).not.toHaveProperty('active');
-      expect(body).not.toHaveProperty('trigger');
-      expect(body).not.toHaveProperty('sendout_type');
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+      // Rule.io's PUT requires the full object — partial input is merged.
+      expect(body).toEqual({
+        name: 'Renamed',
+        active: true,
+        trigger: { type: 'TAG', id: 7 },
+        sendout_type: 2,
+      });
     });
 
-    it('should update an automation with partial fields (active only)', async () => {
+    it('should send a full PUT body when only active is updated (preserves other fields)', async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          data: { id: 1, name: 'Test', active: false },
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'SEGMENT', id: 99 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
         })
+      );
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'Test', active: false } })
       );
 
       const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
 
       await client.updateAutomation(1, { active: false });
 
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
 
-      expect(body).toEqual({ active: false });
+      expect(body).toEqual({
+        name: 'Test',
+        active: false,
+        trigger: { type: 'SEGMENT', id: 99 },
+        sendout_type: 1,
+      });
+    });
+
+    it('should convert sendout_type response object form to numeric in PUT body', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 2, key: 'TRANSACTIONAL', description: 'Trans' },
+          },
+        })
+      );
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'X' } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.updateAutomation(1, { name: 'X' });
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+      expect(body.sendout_type).toBe(2);
+      expect(typeof body.sendout_type).toBe('number');
+    });
+
+    it('should throw RuleApiError(404) when the automation does not exist', async () => {
+      // getAutomation returns null on 404
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Not found' }, 404)
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.updateAutomation(999, { name: 'Whatever' })
+      ).rejects.toMatchObject({
+        name: 'RuleApiError',
+        statusCode: 404,
+      });
+
+      // No PUT fired — only the GET attempt.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw RuleConfigError when existing record has no trigger and update omits it', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            // no trigger
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.updateAutomation(1, { name: 'Renamed' })
+      ).rejects.toThrow(RuleConfigError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw RuleConfigError when existing record has no sendout_type and update omits it', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            // no sendout_type
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.updateAutomation(1, { name: 'Renamed' })
+      ).rejects.toThrow(RuleConfigError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw RuleConfigError when existing record has no active state and update omits it', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            // no active
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.updateAutomation(1, { name: 'Renamed' })
+      ).rejects.toThrow(RuleConfigError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should let the update override an existing trigger', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'Test' } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.updateAutomation(1, {
+        trigger: { type: 'SEGMENT', id: 42 },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+      expect(body.trigger).toEqual({ type: 'SEGMENT', id: 42 });
     });
 
     it('should render a template and return HTML', async () => {
@@ -2908,6 +3095,64 @@ describe('RuleClient', () => {
       expect(url).not.toContain('object_ids');
       expect(url).not.toContain('metrics');
     });
+
+    // The /analytics endpoint rejects datetime form even though sibling v3
+    // endpoints accept it. The SDK strips the time portion so consumers can
+    // pass either form.
+    it('should strip space-separated time from date_from / date_to', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.getAnalytics({
+        date_from: '2024-01-01 00:00:00',
+        date_to: '2024-01-31 23:59:59',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+
+      expect(url).toContain('date_from=2024-01-01');
+      expect(url).toContain('date_to=2024-01-31');
+      expect(url).not.toContain('00%3A00%3A00');
+      expect(url).not.toContain('23%3A59%3A59');
+    });
+
+    it('should strip ISO-8601 T-separated time from date_from / date_to', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.getAnalytics({
+        date_from: '2024-01-01T00:00:00Z',
+        date_to: '2024-01-31T23:59:59Z',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+
+      expect(url).toContain('date_from=2024-01-01');
+      expect(url).toContain('date_to=2024-01-31');
+      expect(url).not.toContain('T00');
+      expect(url).not.toContain('T23');
+    });
+
+    it('should pass bare YYYY-MM-DD dates through unchanged', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: [] }));
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.getAnalytics({
+        date_from: '2024-01-01',
+        date_to: '2024-01-31',
+        object_type: 'CAMPAIGN',
+        object_ids: ['1'],
+        metrics: ['sent'],
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+
+      expect(url).toContain('date_from=2024-01-01&');
+      expect(url).toMatch(/date_to=2024-01-31(&|$)/);
+    });
   });
 
   describe('v3 Delete 204 handling', () => {
@@ -3721,6 +3966,19 @@ describe('RuleClient', () => {
     });
 
     it('updateAutomail() should delegate to updateAutomation()', async () => {
+      // GET (read-modify-write)
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Old',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+      // PUT
       mockFetch.mockResolvedValueOnce(
         createMockResponse({ data: { id: 1, name: 'Updated' } })
       );

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -5,7 +5,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RuleClient } from '../src/client.js';
 import { RuleApiError, RuleConfigError } from '@rule-io/core';
-import type { RuleAnalyticsParams, RuleAutomationTrigger } from '../src/types.js';
+import type {
+  RuleAnalyticsParams,
+  RuleAutomationTrigger,
+  RuleSendoutType,
+} from '../src/types.js';
 import type { RcmlDocument } from '@rule-io/rcml';
 
 /** Minimal valid RcmlDocument for tests that need a template value. */
@@ -845,6 +849,64 @@ describe('RuleClient', () => {
         trigger: { type: 'TAG', id: 42 },
         sendout_type: 2,
       });
+    });
+
+    it('should coerce update.sendout_type from response object form to numeric (fast path & slow path)', async () => {
+      // Fast path: caller round-trips the response wrapper as the input.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'X' } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await client.updateAutomation(1, {
+        name: 'X',
+        active: true,
+        trigger: { type: 'TAG', id: 7 },
+        sendout_type: {
+          value: 2,
+          key: 'TRANSACTIONAL',
+          description: 'Trans',
+        } as unknown as RuleSendoutType,
+      });
+
+      // Object form coerces to number; fast path still fires (one fetch, no GET).
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const fastBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+
+      expect(fastBody.sendout_type).toBe(2);
+      expect(typeof fastBody.sendout_type).toBe('number');
+
+      // Slow path: same object form, but with a partial input that forces RMW.
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'Test' } })
+      );
+
+      await client.updateAutomation(1, {
+        sendout_type: {
+          value: 2,
+          key: 'TRANSACTIONAL',
+          description: 'Trans',
+        } as unknown as RuleSendoutType,
+      });
+
+      const slowBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+      expect(slowBody.sendout_type).toBe(2);
+      expect(typeof slowBody.sendout_type).toBe('number');
     });
 
     it('should not fast-path when a required field is null (JS caller bypassing types)', async () => {

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RuleClient } from '../src/client.js';
 import { RuleApiError, RuleConfigError } from '@rule-io/core';
-import type { RuleAnalyticsParams } from '../src/types.js';
+import type { RuleAnalyticsParams, RuleAutomationTrigger } from '../src/types.js';
 import type { RcmlDocument } from '@rule-io/rcml';
 
 /** Minimal valid RcmlDocument for tests that need a template value. */
@@ -845,6 +845,45 @@ describe('RuleClient', () => {
         trigger: { type: 'TAG', id: 42 },
         sendout_type: 2,
       });
+    });
+
+    it('should not fast-path when a required field is null (JS caller bypassing types)', async () => {
+      // GET — slow path takes over because trigger is null.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: 1,
+            name: 'Test',
+            active: true,
+            trigger: { type: 'TAG', id: 7 },
+            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
+          },
+        })
+      );
+      // PUT
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ data: { id: 1, name: 'X' } })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      // A JS caller could pass null even though the type forbids it. The fast
+      // path must fall through so the slow path's `??` merges from `current`.
+      await client.updateAutomation(1, {
+        name: 'X',
+        active: true,
+        trigger: null as unknown as RuleAutomationTrigger,
+        sendout_type: 2,
+      });
+
+      // Two fetches → slow path was taken.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+
+      // Trigger comes from the existing record, not the null we passed.
+      expect(body.trigger).toEqual({ type: 'TAG', id: 7 });
+      expect(body).not.toHaveProperty('trigger', null);
     });
 
     it('should send a full PUT body when only name is updated (read-modify-write)', async () => {

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -814,20 +814,8 @@ describe('RuleClient', () => {
       expect(body.active).toBe(true);
     });
 
-    it('should update an automation with all fields', async () => {
-      // GET (read-modify-write fetches existing first)
-      mockFetch.mockResolvedValueOnce(
-        createMockResponse({
-          data: {
-            id: 1,
-            name: 'Old',
-            active: false,
-            trigger: { type: 'TAG', id: 7 },
-            sendout_type: { value: 1, key: 'CAMPAIGN', description: '' },
-          },
-        })
-      );
-      // PUT
+    it('should skip the read-modify-write GET when the caller supplies all required fields', async () => {
+      // Only the PUT — no GET should fire on the fast path.
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
           data: { id: 1, name: 'Updated', active: true },
@@ -843,23 +831,20 @@ describe('RuleClient', () => {
       });
 
       expect(result.data?.name).toBe('Updated');
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
 
-      const [getUrl, getOptions] = mockFetch.mock.calls[0];
+      const [url, options] = mockFetch.mock.calls[0];
 
-      expect(getUrl).toBe('https://app.rule.io/api/v3/editor/automail/1');
-      expect(getOptions.method).toBe('GET');
+      expect(url).toBe('https://app.rule.io/api/v3/editor/automail/1');
+      expect(options.method).toBe('PUT');
+      const body = JSON.parse(options.body);
 
-      const [putUrl, putOptions] = mockFetch.mock.calls[1];
-
-      expect(putUrl).toBe('https://app.rule.io/api/v3/editor/automail/1');
-      expect(putOptions.method).toBe('PUT');
-      const body = JSON.parse(putOptions.body);
-
-      expect(body.name).toBe('Updated');
-      expect(body.active).toBe(true);
-      expect(body.trigger).toEqual({ type: 'TAG', id: 42 });
-      expect(body.sendout_type).toBe(2);
+      expect(body).toEqual({
+        name: 'Updated',
+        active: true,
+        trigger: { type: 'TAG', id: 42 },
+        sendout_type: 2,
+      });
     });
 
     it('should send a full PUT body when only name is updated (read-modify-write)', async () => {

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -995,6 +995,29 @@ describe('RuleClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it('should distinguish a 2xx-with-no-data envelope from a true 404', async () => {
+      // 2xx response with an error envelope and no `data` — must NOT be
+      // remapped to 404; surface the server detail instead.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          success: false,
+          error: 'Internal data store unavailable',
+        })
+      );
+
+      const client = new RuleClient({ apiKey: 'test-key', fetch: mockFetch });
+
+      await expect(
+        client.updateAutomation(1, { name: 'Renamed' })
+      ).rejects.toMatchObject({
+        name: 'RuleApiError',
+        statusCode: 500,
+        message: expect.stringContaining('Internal data store unavailable'),
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('should throw RuleConfigError when existing record has no trigger and update omits it', async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({


### PR DESCRIPTION
## Summary

Two Rule.io API quirks were leaking into every consumer of this SDK
(notably the downstream `rule-io-mcp-server`). This PR localizes both
workarounds inside `RuleClient` so they live in one place.

- **\`getAnalytics\`** — \`GET /api/v3/analytics\` rejects datetime form
  even though sibling v3 endpoints accept it. The SDK now strips any
  time portion from \`date_from\` / \`date_to\` before sending. Consumers
  can pass \`YYYY-MM-DD\`, \`YYYY-MM-DD HH:MM:SS\`, or ISO-8601 form
  indifferently.

- **\`updateAutomation\`** — \`PUT /api/v3/editor/automail/{id}\` rejects
  partial bodies despite the SDK's \`Partial<...>\` signature; it requires
  \`name\`, \`active\`, \`trigger\`, \`sendout_type\` together. The SDK now
  performs read-modify-write internally: fetch the existing automation,
  merge the partial input, PUT the full body. Handles the response shape's
  \`sendout_type: { value, key, description }\` → numeric request shape.

## Why this fix lives in the SDK

The mcp-server already had per-tool workarounds for both quirks. Three
in-tree CLI commands (\`deploy-{shopify,bookzen,samfora}.ts\`) call
\`updateAutomation(id, { active: true })\` — broken under the old SDK,
working under this one. Single change benefits every consumer.

## Behavior changes

- \`updateAutomation\` now does an extra GET per call (one round-trip).
  Documented in JSDoc.
- New error paths in \`updateAutomation\`:
  - \`RuleApiError(404)\` when the automation doesn't exist (clearer than
    the old PUT 404).
  - \`RuleConfigError\` when the merged record still lacks \`trigger\`,
    \`sendout_type\`, or \`active\` — would 422 otherwise; up-front error is
    clearer.

## Test plan

- [x] \`npx nx run client:vitest:test\` — 252 passed (10 new for these fixes)
- [x] \`npx nx run client:eslint:lint\` — 0 errors
- [x] \`npx nx run client:build\` — clean
- [x] \`npm run build\` (full repo) — clean
- [x] \`npm test\` (full repo) — clean

## Out of scope

- Upstream API changes (analytics datetime support, PATCH endpoint for
  automail) — tracked in #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)