### PR TITLE
fix(ci): replace workflow_run with push trigger for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,7 @@
 name: Release
 
-# Only fire after the CI workflow passes on main — this ensures lint, tests,
-# and build are green before we touch any version numbers.
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  push:
     branches: [main]
 
 jobs:
@@ -14,7 +10,6 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   prepare:
     name: Version & Changelog
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # needed to push the release commit back to main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
 
+# Only one release run at a time. cancel-in-progress: false queues the
+# next run rather than cancelling it — cancelling mid-release could leave
+# a partial tag or a pushed version commit with no matching npm publish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ────────────────────────────────────────────────────────────────────────────
   # Job 1: bump versions, generate changelog, commit + tag + push

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ feature branches → develop → release PR → main → automated release workf
 
 Merging to `main` triggers CI. npm publishing is **gated by GitHub Environment approval** (`npm-production`) — the workflow auto-prepares the release but a human must approve before anything lands on the registry.
 
+### Merge strategy
+
+Always use **rebase merge** when landing `develop` → `main`.
+
+`nx release version` calculates the version bump by reading Conventional Commits directly from the git log. The merge strategy determines what Nx sees:
+
+| Strategy | What Nx Release sees | Risk |
+|---|---|---|
+| **Rebase merge** ✓ | Every `feat:`, `fix:`, `BREAKING CHANGE:` intact | None — correct bump every time |
+| Squash merge | One commit with the squash message | Minor bump if message is `feat:` — **no release** if message is `chore:` or generic. Also leaves `develop` with ghost commits that conflict on the next PR. |
+| Merge commit | Individual commits (Nx traverses through merge commits) | Works, but leaves a noisier linear history |
+
+After each merge to `main`, fast-forward `develop`:
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
 ### Versioning rules
 
 **Beta stage (`0.x`):**

--- a/README.md
+++ b/README.md
@@ -121,21 +121,21 @@ Merging to `main` triggers CI. npm publishing is **gated by GitHub Environment a
 
 ### Merge strategy
 
-Always use **rebase merge** when landing `develop` → `main`.
+Always use **merge commit** when landing `develop` → `main`.
 
 `nx release version` calculates the version bump by reading Conventional Commits directly from the git log. The merge strategy determines what Nx sees:
 
 | Strategy | What Nx Release sees | Risk |
 |---|---|---|
-| **Rebase merge** ✓ | Every `feat:`, `fix:`, `BREAKING CHANGE:` intact | None — correct bump every time |
+| **Merge commit** ✓ | Every `feat:`, `fix:`, `BREAKING CHANGE:` intact (Nx traverses through merge commits) | None — correct bump every time |
+| Rebase merge | Every commit intact, but new SHAs on `main` mean `develop` requires a `reset --hard` to re-sync | Extra friction keeping `develop` in sync |
 | Squash merge | One commit with the squash message | Minor bump if message is `feat:` — **no release** if message is `chore:` or generic. Also leaves `develop` with ghost commits that conflict on the next PR. |
-| Merge commit | Individual commits (Nx traverses through merge commits) | Works, but leaves a noisier linear history |
 
 After each merge to `main`, fast-forward `develop`:
 
 ```bash
 git fetch origin main
-git rebase origin/main
+git merge origin/main
 ```
 
 ### Versioning rules

--- a/README.md
+++ b/README.md
@@ -131,12 +131,15 @@ Always use **merge commit** when landing `develop` → `main`.
 | Rebase merge | Every commit intact, but new SHAs on `main` mean `develop` requires a `reset --hard` to re-sync | Extra friction keeping `develop` in sync |
 | Squash merge | One commit with the squash message | Minor bump if message is `feat:` — **no release** if message is `chore:` or generic. Also leaves `develop` with ghost commits that conflict on the next PR. |
 
-After each merge to `main`, fast-forward `develop`:
+After each merge to `main`, sync `develop`:
 
 ```bash
 git fetch origin main
-git merge origin/main
+git checkout develop
+git merge --ff-only origin/main
 ```
+
+`--ff-only` fails loudly if `develop` has diverged unexpectedly, preventing an accidental extra merge commit.
 
 ### Versioning rules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1076,9 +1076,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2544,6 +2544,56 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@nx/devkit": {
       "version": "22.7.0",
       "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.0.tgz",
@@ -3596,16 +3646,6 @@
         "tslib": "^2.8.1"
       }
     },
-    "node_modules/@swc-node/sourcemap-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@swc-node/sourcemap-support/node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4250,19 +4290,19 @@
       }
     },
     "node_modules/@verdaccio/auth": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-wvKPnjDZReT0gSxntUbcOYl23m2mHeMT9a/uhRMdw3pbraSgozatnf3UuoTd6Uyfm3vn+HHAHqzudUn1+yD4rw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-8.0.1.tgz",
+      "integrity": "sha512-jq3bg0YyU5GciWMRjS22OUuVvpoV+ftlAuF49K9ctFN0PYlrJipIPu4aMd3OC4dfYaC210QEApdSM2q49/VsJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.37",
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/loaders": "8.0.0-next-8.27",
-        "@verdaccio/signature": "8.0.0-next-8.29",
+        "@verdaccio/config": "8.1.0",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/loaders": "8.0.1",
+        "@verdaccio/signature": "8.0.1",
         "debug": "4.4.3",
         "lodash": "4.18.1",
-        "verdaccio-htpasswd": "13.0.0-next-8.37"
+        "verdaccio-htpasswd": "13.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -4273,13 +4313,13 @@
       }
     },
     "node_modules/@verdaccio/config": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-SbmDMJpora293B+TDYfxJL5LEaFh7gdh0MmkPJCBkmGlRPmynTfHcQzVzAll3+IMYFkrf1zZtq/qlgorjaoFoQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.1.0.tgz",
+      "integrity": "sha512-wMTffzodvyLa/Ob/Zd6SFRhyKQpTzBRPypvYwqLouLO+AMpUoZQ6KN197r8Xt+vclVa7ysUnGqscnKx94l2Rpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
         "debug": "4.4.3",
         "js-yaml": "4.1.1",
         "lodash": "4.18.1"
@@ -4293,9 +4333,9 @@
       }
     },
     "node_modules/@verdaccio/core": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-R8rDEa2mPjfHhEK2tWTMFnrfvyNmTd5ZrNz9X5/EiFVJPr/+oo9cTZkDXzY9+KREJUUIUFili4qynmBt0lw8nw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-rGJy2dnwVwx6QvQqh1YEfyjigX/pyKjMAqO+d6uDYGoBw8Y25sMmJqwuaZx8GTvC3HigcteZBHjkOxFiBgoNLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4372,9 +4412,9 @@
       }
     },
     "node_modules/@verdaccio/file-locking": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.1.tgz",
-      "integrity": "sha512-oqYLfv3Yg3mAgw9qhASBpjD50osj2AX4IwbkUtyuhhKGyoFU9eZdrbeW6tpnqUnj6yBMtAPm2eGD4BwQuX400g==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-10.3.3.tgz",
+      "integrity": "sha512-AT1v+1AZ7fJeyXYz35B57TTMPWctydrvdH6/Ct7p3akZeSKYJ9rQBjvdO0McxkFqpl6VAzlQVjq8ihLTPFQ4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4389,14 +4429,14 @@
       }
     },
     "node_modules/@verdaccio/hooks": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/hooks/-/hooks-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-n2t6fjXqSA+y402zO2Yh5UEe+rzMf1jhglj46MQf7IswCaST/SGLlJ5VCl6bU8LGbSr9FOz7BAtUXc64i3oCmA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-nqxwncwA4BRP+JGhXx4qfgOa3vTUh4kc+m/9VB2b+SF2AF05z8ViqcqnWT+ZMKx5p0rAGvVUfrIQ/lcBCEWlQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/logger": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/logger": "8.0.1",
         "debug": "4.4.3",
         "got-cjs": "12.5.4",
         "handlebars": "4.7.9"
@@ -4410,13 +4450,13 @@
       }
     },
     "node_modules/@verdaccio/loaders": {
-      "version": "8.0.0-next-8.27",
-      "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-8.0.0-next-8.27.tgz",
-      "integrity": "sha512-bDfHHCDrOCSdskAKeKxPArUi5aGXtsxEpRvO8MzghX50g1zJnVzLF1KEbsEY9ScFqGZAVYtZTcutysA0VOQ0Rg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-8.0.1.tgz",
+      "integrity": "sha512-RxOvAJMXSSMhNLuLYZwKXLKeK4LaznXL/+AYmW3HTHM+Ki6aJKJsmYIBzUmIoLz7aY9nYtYnPCR9ArE64e7nEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
         "debug": "4.4.3",
         "lodash": "4.18.1"
       },
@@ -4429,20 +4469,21 @@
       }
     },
     "node_modules/@verdaccio/local-storage-legacy": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage-legacy/-/local-storage-legacy-11.1.1.tgz",
-      "integrity": "sha512-P6ahH2W6/KqfJFKP+Eid7P134FHDLNvHa+i8KVgRVBeo2/IXb6FEANpM1mCVNvPANu0LCAmNJBOXweoUKViaoA==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/local-storage-legacy/-/local-storage-legacy-11.3.1.tgz",
+      "integrity": "sha512-KV66waxc03K1Lne1FfdhmURcULJQ4YdXY5qjAPZEwplRX1lCLx18pyvyRi3/98Cmt7VkIw0qA4DCXMTtwNkdIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.21",
-        "@verdaccio/file-locking": "10.3.1",
-        "@verdaccio/streams": "10.2.1",
-        "async": "3.2.6",
-        "debug": "4.4.1",
-        "lodash": "4.17.21",
+        "@verdaccio/core": "8.0.0-next-8.29",
+        "@verdaccio/file-locking": "10.3.3",
+        "@verdaccio/streams": "10.2.3",
+        "debug": "4.4.3",
+        "globby": "11.1.0",
+        "lodash": "4.18.1",
         "lowdb": "1.0.0",
-        "mkdirp": "1.0.4"
+        "mkdirp": "1.0.4",
+        "sanitize-filename": "1.6.4"
       },
       "engines": {
         "node": ">=18"
@@ -4453,9 +4494,9 @@
       }
     },
     "node_modules/@verdaccio/local-storage-legacy/node_modules/@verdaccio/core": {
-      "version": "8.0.0-next-8.21",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.21.tgz",
-      "integrity": "sha512-n3Y8cqf84cwXxUUdTTfEJc8fV55PONPKijCt2YaC0jilb5qp1ieB3d4brqTOdCdXuwkmnG2uLCiGpUd/RuSW0Q==",
+      "version": "8.0.0-next-8.29",
+      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.29.tgz",
+      "integrity": "sha512-ztsNbnHMGqpOJlC3x/Jz7+0Xzrul+UIQQAFsTFHO3pET8nyZWkh/1TH50olz0pZ/OS87O/+7mk04TK9hHD/eFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4464,7 +4505,7 @@
         "http-status-codes": "2.3.0",
         "minimatch": "7.4.6",
         "process-warning": "1.0.0",
-        "semver": "7.7.2"
+        "semver": "7.7.3"
       },
       "engines": {
         "node": ">=18"
@@ -4508,24 +4549,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@verdaccio/local-storage-legacy/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@verdaccio/local-storage-legacy/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4550,13 +4573,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@verdaccio/local-storage-legacy/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@verdaccio/local-storage-legacy/node_modules/minimatch": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
@@ -4574,9 +4590,9 @@
       }
     },
     "node_modules/@verdaccio/local-storage-legacy/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4597,13 +4613,13 @@
       }
     },
     "node_modules/@verdaccio/logger": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-xG27C1FsbTsHhvhB3OpisVzHUyrE9NSVrzVHapPuOPd6X1DpnHZoZ+UYBAS0MSO1tGS+NEHW9GHL0XiroULggA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-8.0.1.tgz",
+      "integrity": "sha512-O0HV+olvcYGCGLolvH3Lm0WnWA+vCGFT5jM4yWos9oXFScrMs5X7P5iTPRzpWL0BbUlL+ygsPrB/CiPEvl4YNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/logger-commons": "8.0.0-next-8.37",
+        "@verdaccio/logger-commons": "8.0.1",
         "pino": "9.14.0"
       },
       "engines": {
@@ -4615,14 +4631,14 @@
       }
     },
     "node_modules/@verdaccio/logger-commons": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-HVt7ttnKgioERB1lCc1UnqnJMJ8skAeivLe49uq3wEG3QtruQGCct5nosj+q1pjx8SaYpQA+qxs1+4UDddprVA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-8.0.1.tgz",
+      "integrity": "sha512-qp/wWSDKINtORtyU8RbMyswgt2AUNNH4oo7a76b/dndGDeoVMiuPZgGWbh0idHKVqyhYT8d2zRV4sUrgDV6cSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/logger-prettify": "8.0.0-next-8.5",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/logger-prettify": "8.0.0",
         "colorette": "2.0.20",
         "debug": "4.4.3"
       },
@@ -4635,9 +4651,9 @@
       }
     },
     "node_modules/@verdaccio/logger-prettify": {
-      "version": "8.0.0-next-8.5",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-prettify/-/logger-prettify-8.0.0-next-8.5.tgz",
-      "integrity": "sha512-zCsvdKgUQx2mSu7fnDOkA2r2QX6yMmBDsXGmqXmoov/cZ89deREn0uC7xIX7/YEo8EspBoXiUGzqI+S+qUWPyw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-prettify/-/logger-prettify-8.0.0.tgz",
+      "integrity": "sha512-Yfz8Nd4vgxdCk3CrV+vWMigsPmpsFDYy6PNKSnNrPchO+cfXxdqoBtYSS+LqeXI22gVtQ1JsduGSd8O8mLtIfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4657,15 +4673,15 @@
       }
     },
     "node_modules/@verdaccio/middleware": {
-      "version": "8.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-8.0.0-next-8.37.tgz",
-      "integrity": "sha512-8SqCdzKfANhaO/ZoSBBJHPlDWmXEJdq/1giV/ZKYtU4xVbBb/4ThKp2nNKk4s9+8S8XNNgX+7J5e/BgbIzzsEA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-8.0.1.tgz",
+      "integrity": "sha512-li1oQh30HHPi0wg4fF+1cKiYPdZPe35iTNuJZzKMIt8gPj4nCMVJ2Lfvj+n77LP+0BzqXmFfuLQuu4GmPcI/vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.37",
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/url": "13.0.0-next-8.37",
+        "@verdaccio/config": "8.1.0",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/url": "13.0.1",
         "debug": "4.4.3",
         "express": "4.22.1",
         "express-rate-limit": "5.5.1",
@@ -4691,13 +4707,13 @@
       }
     },
     "node_modules/@verdaccio/package-filter": {
-      "version": "13.0.0-next-8.5",
-      "resolved": "https://registry.npmjs.org/@verdaccio/package-filter/-/package-filter-13.0.0-next-8.5.tgz",
-      "integrity": "sha512-+RZzVI/Yqjpoiv2SL3C0cxMC8ucU6j+YPdP/Bg/KJVqPbGNTn4Ol/fuGNhMJO6meIRS5ekW0PSrAvrDJ6E+JCA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/package-filter/-/package-filter-13.0.1.tgz",
+      "integrity": "sha512-sIEtylJyaZ7etQXe3S5jlxdfGLugpm7FekXk24KoJPSOcSxRP+5ZUpEuJAtCUbywg5i8oaTVxdLY4Fq/aJfVqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
         "debug": "4.4.3",
         "semver": "7.7.4"
       },
@@ -4710,9 +4726,9 @@
       }
     },
     "node_modules/@verdaccio/search-indexer": {
-      "version": "8.0.0-next-8.6",
-      "resolved": "https://registry.npmjs.org/@verdaccio/search-indexer/-/search-indexer-8.0.0-next-8.6.tgz",
-      "integrity": "sha512-+vFkeqwXWlbpPO/vxC1N5Wbi8sSXYR5l9Z41fqQgSncaF/hfSKB/iHsid1psCusfsDPGuwEbm2usPEW0nDdRDg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@verdaccio/search-indexer/-/search-indexer-8.0.0.tgz",
+      "integrity": "sha512-Wqz8HsUeUFfcCPTN90XrhNd82Pjp5wXb2r/Tk5G3PuxRMSx1oVT6wzMOuTcmeuyAJkxKIo0ZhnlSIrvrYoQIdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4724,14 +4740,14 @@
       }
     },
     "node_modules/@verdaccio/signature": {
-      "version": "8.0.0-next-8.29",
-      "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-8.0.0-next-8.29.tgz",
-      "integrity": "sha512-D1OyGi7+/5zXdbf78qdmL4wpf7iGN+RNDGB2TdLVosSrd+PWGrXqMJB3q2r/DJQ8J3724YVOJgNKiXjxV+Y1Aw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-8.0.1.tgz",
+      "integrity": "sha512-m/pU1DBF4NTjG3Wn4TUWOFcQvGorTT2M+sUhzrJITAfsVv1/TbbOVLuuIMob6Wv5OB0QFaa86nbTfHmAtVai+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.37",
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/config": "8.1.0",
+        "@verdaccio/core": "8.1.0",
         "debug": "4.4.3",
         "jsonwebtoken": "9.0.3"
       },
@@ -4744,9 +4760,9 @@
       }
     },
     "node_modules/@verdaccio/streams": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.1.tgz",
-      "integrity": "sha512-OojIG/f7UYKxC4dYX8x5ax8QhRx1b8OYUAMz82rUottCuzrssX/4nn5QE7Ank0DUSX3C9l/HPthc4d9uKRJqJQ==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@verdaccio/streams/-/streams-10.2.3.tgz",
+      "integrity": "sha512-rDXAMZNIpAO5n/bz2xewrIy9RdL1jCYL4SF8A7NGv5GU6Bcx/rJk3/BqsVP29rfIKZWvdgS5uNVer1QpDe0skg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4759,14 +4775,14 @@
       }
     },
     "node_modules/@verdaccio/tarball": {
-      "version": "13.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-13.0.0-next-8.37.tgz",
-      "integrity": "sha512-Qxm6JQYEFfkeJd4YQII/2IAMiL++QnM6gqKXZbM5mNkAApyqx8ZbL1e9pe3aCDmBYs2mo0JGORCy3OaHZcsJGw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-13.0.1.tgz",
+      "integrity": "sha512-5iWelTXHopMoNGQdX2BTD8QVueNAaHXbI8W6TaV95HFeTuocNwYCW5zm2BullCjBE5uT0P/uqMIk8Uwf5VLK4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/url": "13.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/url": "13.0.1",
         "debug": "4.4.3",
         "gunzip-maybe": "1.4.2",
         "tar-stream": "3.1.7"
@@ -4802,13 +4818,13 @@
       }
     },
     "node_modules/@verdaccio/url": {
-      "version": "13.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-13.0.0-next-8.37.tgz",
-      "integrity": "sha512-Gtv5oDgVwGPGxzuXaIJLbmL8YkBKW2UZwDsrnbDoWRt1nWLtiOp4Vui1VISTqX7A9BB50YslLEgNLcPd2qRE+w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-13.0.1.tgz",
+      "integrity": "sha512-vZfhn7yAPHWOQA8t3QVubMLYCmYD6PNrP9BDebzvWHbSMcx+9ouNO52KNYM6RkTepSsq0sm5f//Bwt1HUPXpuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
         "debug": "4.4.3",
         "validator": "13.15.26"
       },
@@ -4821,13 +4837,13 @@
       }
     },
     "node_modules/@verdaccio/utils": {
-      "version": "8.1.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.37.tgz",
-      "integrity": "sha512-wfwn3z5M+w2KOV+xJFVv8tM8aOB4Ok5emfBDrDHrHMPDJ/fn3dEo6HoOra654PJ+zNwbTiMDvE5oAg/PLtnsUw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.1.tgz",
+      "integrity": "sha512-yfaiOIbI/aLF0BDZd3naeswG3z69fTRh00svq5SLEUCbreqyFOcelbzTgOjcO4M9pddJWi2/mK+TgdJQZ3MbPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/core": "8.1.0",
         "lodash": "4.18.1",
         "minimatch": "7.4.9"
       },
@@ -5196,6 +5212,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -5299,9 +5325,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -5427,9 +5453,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -5563,9 +5589,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5573,6 +5599,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserify-zlib": {
@@ -6388,6 +6427,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -7029,6 +7081,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7044,9 +7126,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7059,10 +7141,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -7071,10 +7153,40 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -7132,6 +7244,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -7446,6 +7571,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7531,16 +7677,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -7919,6 +8055,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -8880,6 +9026,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9350,6 +9506,33 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -10135,6 +10318,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -10516,6 +10714,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -10772,6 +10991,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -10804,6 +11034,30 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -10843,6 +11097,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -11048,6 +11312,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -11071,6 +11345,16 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11090,16 +11374,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/split2": {
@@ -11254,9 +11528,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -11443,6 +11717,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11491,6 +11778,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11840,6 +12137,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11888,29 +12192,29 @@
       }
     },
     "node_modules/verdaccio": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-6.5.2.tgz",
-      "integrity": "sha512-zFzUz/2b5z4svs7/wkX0JDSvOE3ViWdNcIs8qwnmUg2hKBbWeVoA5Kt/JWHRkUrCuwiIfAoEWobiKZmrAFqHqw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-6.6.0.tgz",
+      "integrity": "sha512-wAa8i8O1PwbQZVCDu4V9BVQ8Q+NRoReKRzN6QyH9MCFA09wlHrpWhAGLYY56hYzB9sx+LUCO8783XG9vlwtJcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cypress/request": "3.0.10",
-        "@verdaccio/auth": "8.0.0-next-8.37",
-        "@verdaccio/config": "8.0.0-next-8.37",
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/hooks": "8.0.0-next-8.37",
-        "@verdaccio/loaders": "8.0.0-next-8.27",
-        "@verdaccio/local-storage-legacy": "11.1.1",
-        "@verdaccio/logger": "8.0.0-next-8.37",
-        "@verdaccio/middleware": "8.0.0-next-8.37",
-        "@verdaccio/package-filter": "13.0.0-next-8.5",
-        "@verdaccio/search-indexer": "8.0.0-next-8.6",
-        "@verdaccio/signature": "8.0.0-next-8.29",
-        "@verdaccio/streams": "10.2.1",
-        "@verdaccio/tarball": "13.0.0-next-8.37",
+        "@verdaccio/auth": "8.0.1",
+        "@verdaccio/config": "8.1.0",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/hooks": "8.0.1",
+        "@verdaccio/loaders": "8.0.1",
+        "@verdaccio/local-storage-legacy": "11.3.1",
+        "@verdaccio/logger": "8.0.1",
+        "@verdaccio/middleware": "8.0.1",
+        "@verdaccio/package-filter": "13.0.1",
+        "@verdaccio/search-indexer": "8.0.0",
+        "@verdaccio/signature": "8.0.1",
+        "@verdaccio/streams": "10.2.3",
+        "@verdaccio/tarball": "13.0.1",
         "@verdaccio/ui-theme": "9.0.0-next-9.14",
-        "@verdaccio/url": "13.0.0-next-8.37",
-        "@verdaccio/utils": "8.1.0-next-8.37",
+        "@verdaccio/url": "13.0.1",
+        "@verdaccio/utils": "8.1.1",
         "async": "3.2.6",
         "clipanion": "4.0.0-rc.4",
         "compression": "1.8.1",
@@ -11922,15 +12226,15 @@
         "lodash": "4.18.1",
         "lru-cache": "7.18.3",
         "mime": "3.0.0",
-        "semver": "7.7.4",
-        "verdaccio-audit": "13.0.0-next-8.37",
-        "verdaccio-htpasswd": "13.0.0-next-8.37"
+        "semver": "7.8.0",
+        "verdaccio-audit": "13.0.1",
+        "verdaccio-htpasswd": "13.0.1"
       },
       "bin": {
         "verdaccio": "bin/verdaccio"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "type": "opencollective",
@@ -11938,14 +12242,14 @@
       }
     },
     "node_modules/verdaccio-audit": {
-      "version": "13.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-13.0.0-next-8.37.tgz",
-      "integrity": "sha512-ckn4xxNEkK5lflwb8a6xs2j6rVe//9sEH4rJHBqh2RelKYnFkxHbnN06gsdV2KtqSKDD9F4NE2UDA9SSs8E90w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-13.0.1.tgz",
+      "integrity": "sha512-0QErO6UFP9fMzj9r6usQ/j76MHV7YZVmJGC7MwjCqkH7EefCWaGOehI49a8IrQFCngQSSANL3k9n9kq5VTTVFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.37",
-        "@verdaccio/core": "8.0.0-next-8.37",
+        "@verdaccio/config": "8.1.0",
+        "@verdaccio/core": "8.1.0",
         "express": "4.22.1",
         "https-proxy-agent": "5.0.1",
         "node-fetch": "cjs"
@@ -11959,14 +12263,14 @@
       }
     },
     "node_modules/verdaccio-htpasswd": {
-      "version": "13.0.0-next-8.37",
-      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-13.0.0-next-8.37.tgz",
-      "integrity": "sha512-25MjzPLJG8mfPe4jtR8+3B8PCfBl0D2DRDnsP+KJPn8yBbUiO/GJaw2dyGOiVA7ZTyAWKDnN0WvmmIs+Ibj4+g==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-13.0.1.tgz",
+      "integrity": "sha512-UmIrE7mzqaHLis641NodftulFdQkwPGwSod5bCFnKNelPItL7Su0ojamX3OQudQLdjBeBAjralavvZhDtWPvDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.37",
-        "@verdaccio/file-locking": "13.0.0-next-8.7",
+        "@verdaccio/core": "8.1.0",
+        "@verdaccio/file-locking": "13.0.0",
         "apache-md5": "1.1.8",
         "bcryptjs": "2.4.3",
         "debug": "4.4.3",
@@ -11982,9 +12286,9 @@
       }
     },
     "node_modules/verdaccio-htpasswd/node_modules/@verdaccio/file-locking": {
-      "version": "13.0.0-next-8.7",
-      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-13.0.0-next-8.7.tgz",
-      "integrity": "sha512-XL12Okp4YQd0ogYMyGc+JrqrtVC+76V5hUGCK+s/VluSFSZaJQiLs4MoUPsKfwGhqXHCAm1JcNaz4L5LoXNbjQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-13.0.0.tgz",
+      "integrity": "sha512-wC7HzhKDC+5PDZqCmh5griU9O/PnxS0pKHDRUAKHvcaoWANPUP8PR3ONmZ9prJUIHRPexX+jQn3ATqF5ZetJcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12006,6 +12310,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/verdaccio/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/verror": {
@@ -12332,6 +12649,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12485,7 +12817,7 @@
         "@types/mdast": "^4.0.4",
         "@types/unist": "^3.0.3",
         "ajv": "^8.17.1",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.7.0",
         "mdast-util-directive": "^3.0.0",
         "prosemirror-model": "^1.24.1",
         "remark-directive": "^3.0.0",

--- a/packages/rcml/package.json
+++ b/packages/rcml/package.json
@@ -33,7 +33,7 @@
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.3",
     "ajv": "^8.17.1",
-    "fast-xml-parser": "^4.5.0",
+    "fast-xml-parser": "^5.7.0",
     "mdast-util-directive": "^3.0.0",
     "prosemirror-model": "^1.24.1",
     "remark-directive": "^3.0.0",


### PR DESCRIPTION
## Summary

### fix(ci): replace workflow_run with push trigger for release workflow

- Replaces the fragile `workflow_run` trigger in `release.yml` with a direct `push: branches: [main]` trigger
- Fixes the bootstrap problem that caused the release workflow to silently not run after the first-ever merge to `main`
- Eliminates the silent skip that occurred when CI was bypassed by `paths-ignore` (e.g. markdown-only PRs)

**CI gate trade-off:** the `workflow_run` success check has been removed from the workflow itself. The invariant ("CI must be green before a release") is now enforced by branch protection rules (required status checks before merge). Any push to `main` already implies CI passed; duplicating that check inside the release workflow adds latency and a new failure mode with no real benefit.

**Loop prevention:** the release commit includes `[skip ci]` in its message. GitHub Actions skips all `push`-triggered workflows for commits containing `[skip ci]`, so no second release run occurs. The `OLD_VERSION == NEW_VERSION` early-exit in the `prepare` job is a belt-and-suspenders fallback.

### fix(deps): resolve npm audit vulnerabilities

Separate from the CI fix — included in this PR to keep infra changes together and visible.

- Upgrades `fast-xml-parser` 4.x → 5.8.0 in `@rulecom/rcml` to fix **GHSA-gh4j-gqv2-49f6** (XML Comment/CDATA Injection, HIGH)
- Runs `npm audit fix` to patch transitive deps: `follow-redirects` (GHSA-r4q5-vmmm-2653), `yaml` (GHSA-48c2-rrv3-qjmp), and the verdaccio devDep ecosystem chain (MODERATE)
- Remaining 17 vulnerabilities all require `--force` changes to Nx or Verdaccio and are deferred to a follow-up

## Test plan

- [ ] Merge this PR and confirm the Release workflow appears in the Actions tab on `main`
- [ ] Confirm the release commit pushed by the workflow does **not** re-trigger a second release run (`[skip ci]` + no-new-version guard)
- [ ] `npm audit` on `main` after merge shows fewer vulnerabilities than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)