### PR TITLE
fix(ci): fix release workflow for first npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Checkout the release commit that Job 1 just pushed.
-          ref: main
+          # Checkout the exact release tag so a concurrent push to main cannot
+          # cause the build/publish to use a different commit than was versioned.
+          ref: v${{ needs.prepare.outputs.version }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           OLD_VERSION=$(node -p "require('./packages/sdk/package.json').version")
 
-          npx nx release version --no-interactive --git-commit=false --git-tag=false
+          npx nx release version --git-commit=false --git-tag=false
 
           NEW_VERSION=$(node -p "require('./packages/sdk/package.json').version")
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
@@ -62,7 +62,7 @@ jobs:
             exit 0
           fi
 
-          npx nx release changelog "$NEW_VERSION" --no-interactive --git-commit=false --git-tag=false
+          npx nx release changelog "$NEW_VERSION" --git-commit=false --git-tag=false
 
           git add -A
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
@@ -105,6 +105,7 @@ jobs:
         run: npx nx run-many -t build --projects=client,rcml,sdk
 
       - name: Publish
-        run: npx nx release publish
+        # TODO: remove --first-release after the first npm publish succeeds
+        run: npx nx release publish --first-release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/nx.json
+++ b/nx.json
@@ -41,11 +41,10 @@
     "projects": ["client", "rcml", "sdk"],
     "projectsRelationship": "fixed",
     "version": {
-      "preVersionCommand": "npx nx run-many -t build --projects=client,rcml,sdk",
       "specifierSource": "conventional-commits",
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk",
-      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}"],
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       }


### PR DESCRIPTION
## Summary

- Remove `--no-interactive` flag from `nx release version` and `nx release changelog` (not a valid argument — was causing the CI job to fail)
- Add `--first-release` to `nx release publish` for the first npm publish (suppresses the pre-flight registry check that would 404 on a never-published package)
- Remove redundant `preVersionCommand` from `nx.json` (the publish job already rebuilds from source)
- Remove `dist/{projectRoot}` from `manifestRootsToUpdate` (dist is gitignored and always rebuilt fresh in the publish job)

Also includes prior commits: concurrency guard for the release workflow, push trigger fix, dependency vulnerability fixes, and README branching strategy docs.

> **Note:** After the first npm publish succeeds, remove `--first-release` from the publish step in `.github/workflows/release.yml`.

## Test plan

- [ ] Merge via merge commit (not squash/rebase) to preserve conventional commit history for `nx release version`
- [ ] Confirm the Release CI job passes on merge to main
- [ ] Approve the `npm-production` environment gate to publish
- [ ] Verify packages appear on npm under the `beta` dist-tag
- [ ] Remove `--first-release` from the publish step after confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)