### PR TITLE
fix(ci): fix tag push and publish job checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           git add -A
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
           git tag "v${NEW_VERSION}"
-          git push --follow-tags
+          git push origin HEAD "refs/tags/v${NEW_VERSION}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
           echo "released=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       contents: write   # needed to push the release commit back to main
     outputs:
       released: ${{ steps.bump.outputs.released }}
-      version: ${{ steps.bump.outputs.version }}
+      version:  ${{ steps.bump.outputs.version }}
+      sha:      ${{ steps.bump.outputs.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +69,7 @@ jobs:
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
           git tag "v${NEW_VERSION}"
           git push --follow-tags
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
           echo "released=true" >> "$GITHUB_OUTPUT"
 
@@ -87,9 +89,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Checkout the exact release tag so a concurrent push to main cannot
-          # cause the build/publish to use a different commit than was versioned.
-          ref: v${{ needs.prepare.outputs.version }}
+          # Use the exact SHA from the prepare job — more reliable than a tag ref,
+          # which can fail if GitHub's tag propagation hasn't completed yet.
+          ref: ${{ needs.prepare.outputs.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           git add -A
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
           git tag "v${NEW_VERSION}"
-          git push origin HEAD "refs/tags/v${NEW_VERSION}"
+          git push --atomic origin HEAD:refs/heads/main "refs/tags/v${NEW_VERSION}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
           echo "released=true" >> "$GITHUB_OUTPUT"

--- a/nx.json
+++ b/nx.json
@@ -45,9 +45,7 @@
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk",
       "manifestRootsToUpdate": ["{projectRoot}"],
-      "versionActionsOptions": {
-        "skipLockFileUpdate": true
-      }
+      "versionActionsOptions": {}
     },
     "changelog": {
       "workspaceChangelog": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12883,7 +12883,7 @@
     },
     "packages/template-engine": {
       "name": "@rulecom/template-engine",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rulecom/rcml": "*"
@@ -12903,7 +12903,7 @@
     },
     "packages/vendor": {
       "name": "@rulecom/vendor",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rulecom/rcml": "*"
@@ -12914,7 +12914,7 @@
     },
     "packages/vendor-bookzen": {
       "name": "@rulecom/vendor-bookzen",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rulecom/client": "*",
@@ -12928,7 +12928,7 @@
     },
     "packages/vendor-samfora": {
       "name": "@rulecom/vendor-samfora",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rulecom/rcml": "*",
@@ -12941,7 +12941,7 @@
     },
     "packages/vendor-shopify": {
       "name": "@rulecom/vendor-shopify",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rulecom/rcml": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12789,11 +12789,11 @@
     },
     "packages/client": {
       "name": "@rulecom/client",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
-        "@rulecom/rcml": "0.4.0-beta.0"
+        "@rulecom/rcml": "0.4.0-beta.1"
       },
       "engines": {
         "node": ">=20"
@@ -12810,7 +12810,7 @@
     },
     "packages/rcml": {
       "name": "@rulecom/rcml",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -12871,11 +12871,11 @@
     },
     "packages/sdk": {
       "name": "@rulecom/sdk",
-      "version": "0.4.0-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/client": "0.4.0-beta.0",
-        "@rulecom/rcml": "0.4.0-beta.0"
+        "@rulecom/client": "0.4.0-beta.1",
+        "@rulecom/rcml": "0.4.0-beta.1"
       },
       "engines": {
         "node": ">=20"
@@ -12886,7 +12886,7 @@
       "version": "0.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "0.4.0-beta.0"
+        "@rulecom/rcml": "*"
       },
       "engines": {
         "node": ">=20"
@@ -12906,7 +12906,7 @@
       "version": "0.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "0.4.0-beta.0"
+        "@rulecom/rcml": "*"
       },
       "engines": {
         "node": ">=20"
@@ -12917,10 +12917,10 @@
       "version": "0.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/client": "0.4.0-beta.0",
-        "@rulecom/rcml": "0.4.0-beta.0",
-        "@rulecom/template-engine": "0.4.0-beta.0",
-        "@rulecom/vendor": "0.4.0-beta.0"
+        "@rulecom/client": "*",
+        "@rulecom/rcml": "*",
+        "@rulecom/template-engine": "*",
+        "@rulecom/vendor": "*"
       },
       "engines": {
         "node": ">=20"
@@ -12931,9 +12931,9 @@
       "version": "0.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "0.4.0-beta.0",
-        "@rulecom/template-engine": "0.4.0-beta.0",
-        "@rulecom/vendor": "0.4.0-beta.0"
+        "@rulecom/rcml": "*",
+        "@rulecom/template-engine": "*",
+        "@rulecom/vendor": "*"
       },
       "engines": {
         "node": ">=20"
@@ -12944,9 +12944,9 @@
       "version": "0.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "0.4.0-beta.0",
-        "@rulecom/template-engine": "0.4.0-beta.0",
-        "@rulecom/vendor": "0.4.0-beta.0"
+        "@rulecom/rcml": "*",
+        "@rulecom/template-engine": "*",
+        "@rulecom/vendor": "*"
       },
       "engines": {
         "node": ">=20"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rulecom/client",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "HTTP API client for the Rule.io email marketing platform.",
   "type": "module",
   "main": "./src/index.js",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.2",
-    "@rulecom/rcml": "0.4.0-beta.0"
+    "@rulecom/rcml": "0.4.0-beta.1"
   },
   "engines": {
     "node": ">=20"

--- a/packages/client/src/core/transport.test.ts
+++ b/packages/client/src/core/transport.test.ts
@@ -206,7 +206,7 @@ describe('HttpTransport', () => {
   });
 
   describe('rate-limit headers (v3 only)', () => {
-    it('exposes Retry-After + RequestsCount + ErrorPercent on a v3 429', async () => {
+    it('exposes integer Retry-After + RequestsCount + ErrorPercent on a v3 429 (synthetic)', async () => {
       fetchMock.mockResolvedValueOnce(
         createMockErrorResponse({ error: 'Rate limited' }, 429, {
           'Retry-After': '45',
@@ -225,6 +225,71 @@ describe('HttpTransport', () => {
         rateLimitRemaining: 0,
         errorPercentLimit: 49,
         errorPercentCurrent: 50,
+      });
+    });
+
+    it('parses Retry-After in Rule.io v3\'s actual 429 form (YYYY-MM-DD HH:MM:SS, no tz)', async () => {
+      // Real-world headers captured from a probe against production v3 in May
+      // 2026: Retry-After is a server-local timestamp (no tz), and the
+      // RequestsCount pair is *not* echoed on 429s — only X-ErrorPercent-* is.
+      // The `Date` header carries the server's "now" — we use it as the
+      // reference frame so the tz offset cancels.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse(
+          'Too Many Requests. You can continue at 2026-05-14 14:22:16.',
+          429,
+          {
+            // Retry-After is 10 minutes after the response Date header.
+            'Retry-After': '2026-05-14 14:22:16',
+            Date: 'Thu, 14 May 2026 12:12:16 GMT',
+            'X-ErrorPercent-Limit': '49',
+            'X-ErrorPercent-Current': '0',
+          }
+        )
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 600, // 10 minutes
+        errorPercentLimit: 49,
+        errorPercentCurrent: 0,
+        rateLimitLimit: undefined, // not echoed on 429
+        rateLimitRemaining: undefined,
+      });
+    });
+
+    it('clamps negative retryAfterSeconds to 0 if the timestamp is already in the past', async () => {
+      // Edge case: clock skew or stale response. Don't return a negative
+      // wait — clamp to 0 so consumers retry immediately rather than
+      // hitting an arithmetic surprise.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse('', 429, {
+          'Retry-After': '2026-05-14 11:00:00',
+          Date: 'Thu, 14 May 2026 12:00:00 GMT',
+          'X-ErrorPercent-Limit': '49',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        retryAfterSeconds: 0,
+      });
+    });
+
+    it('leaves retryAfterSeconds undefined for the timestamp form when no Date header is present', async () => {
+      // The Date header is what makes the timestamp form parseable without
+      // knowing the server's tz — without it we'd have to guess.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse('', 429, {
+          'Retry-After': '2026-05-14 14:22:16',
+          // no Date header
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        retryAfterSeconds: undefined,
       });
     });
 

--- a/packages/client/src/core/transport.test.ts
+++ b/packages/client/src/core/transport.test.ts
@@ -204,4 +204,157 @@ describe('HttpTransport', () => {
       });
     });
   });
+
+  describe('rate-limit headers (v3 only)', () => {
+    it('exposes Retry-After + RequestsCount + ErrorPercent on a v3 429', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'Retry-After': '45',
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2000',
+          'X-ErrorPercent-Limit': '49',
+          'X-ErrorPercent-Current': '50',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 45,
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 0,
+        errorPercentLimit: 49,
+        errorPercentCurrent: 50,
+      });
+    });
+
+    it('computes rateLimitRemaining as Allowed − Current on v3 errors', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 503, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '7',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 503,
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 1993,
+      });
+    });
+
+    it('clamps rateLimitRemaining to 0 if Current exceeds Allowed', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 429, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2050',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitRemaining: 0,
+      });
+    });
+
+    it('prefers documented X-RateLimit-* headers if Rule.io ever ships them', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'X-RateLimit-Limit': '5000',
+          'X-RateLimit-Remaining': '12',
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '1999',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitLimit: 5000,
+        rateLimitRemaining: 12,
+      });
+    });
+
+    it('leaves rate-limit fields undefined when v3 emits no headers', async () => {
+      fetchMock.mockResolvedValueOnce(createMockErrorResponse({}, 401));
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 401,
+        retryAfterSeconds: undefined,
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+        errorPercentLimit: undefined,
+        errorPercentCurrent: undefined,
+      });
+    });
+
+    it('ignores the HTTP-date form of Retry-After (TODO: parse it)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: undefined,
+      });
+    });
+
+    it('rejects negative header values (parser is non-negative-int)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 429, {
+          'RequestsCount-Allowed': '-1',
+          'RequestsCount-Current': '-1',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+      });
+    });
+
+    it('exposes rate-limit headers alongside validationErrors on v3 422', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse(
+          { errors: { name: ['The name field is required.'] } },
+          422,
+          {
+            'RequestsCount-Allowed': '2000',
+            'RequestsCount-Current': '1',
+          }
+        )
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.put('/x')).rejects.toMatchObject({
+        statusCode: 422,
+        validationErrors: { name: ['The name field is required.'] },
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 1999,
+      });
+    });
+
+    it('does NOT populate rate-limit fields on a v2 error', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2000',
+          'X-ErrorPercent-Limit': '49',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x', { version: 'v2' })).rejects.toMatchObject({
+        statusCode: 429,
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+        errorPercentLimit: undefined,
+      });
+    });
+  });
 });

--- a/packages/client/src/core/transport.ts
+++ b/packages/client/src/core/transport.ts
@@ -231,6 +231,7 @@ export class HttpTransport {
 }
 
 const NON_NEGATIVE_INT = /^\s*\d+\s*$/;
+const RULE_TIMESTAMP = /^\s*(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s*$/;
 
 function readNonNegativeInt(headers: Headers, name: string): number | undefined {
   const raw = headers.get(name);
@@ -238,25 +239,101 @@ function readNonNegativeInt(headers: Headers, name: string): number | undefined 
   return raw !== null && NON_NEGATIVE_INT.test(raw) ? Number.parseInt(raw, 10) : undefined;
 }
 
-// Maps Rule.io v3's rate-limit headers onto a RuleApiError. The headers Rule.io
-// actually emits diverge from the names in their public docs:
+// Rule.io is a Swedish company; the live v3 API emits `Retry-After` as a
+// server-local timestamp without a timezone marker, in Stockholm time
+// (CET / CEST with DST). `Intl.DateTimeFormat` resolves the offset for us
+// including DST. If Rule.io ever relocates its servers, this becomes wrong;
+// the safer alternative would be punting to `undefined`. We choose to be
+// useful by default and document the assumption.
+const RULE_SERVER_TZ = 'Europe/Stockholm';
+
+const ruleServerWallFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: RULE_SERVER_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+function serverWallIso(utcMs: number): string {
+  const parts: Record<string, string> = {};
+
+  for (const part of ruleServerWallFormatter.formatToParts(new Date(utcMs))) {
+    if (part.type !== 'literal') parts[part.type] = part.value;
+  }
+
+  // `Intl` can return 24:00:00 instead of 00:00:00 in some locales/runtimes.
+  const hour = parts.hour === '24' ? '00' : parts.hour;
+
+  return `${parts.year}-${parts.month}-${parts.day}T${hour}:${parts.minute}:${parts.second}Z`;
+}
+
+/**
+ * Parse the `Retry-After` header into seconds-from-now.
+ *
+ * Three input forms are accepted:
+ *
+ * 1. Integer seconds (per Rule.io's published docs and RFC 7231) — returned as-is.
+ * 2. `YYYY-MM-DD HH:MM:SS` without a timezone (the form Rule.io's live v3 API
+ *    emits on real 429s, e.g. `2026-05-14 14:22:16`). The timestamp is in the
+ *    server's local timezone (Europe/Stockholm). We use the response's `Date`
+ *    header as the "server now" reference: convert it to the server's
+ *    wall-clock frame, then diff against the retry-after wall components.
+ *    The tz offset cancels (DST included).
+ * 3. RFC 7231 HTTP-date — TODO; not yet observed from Rule.io.
+ *
+ * Returns `undefined` when the header is absent or the value can't be parsed,
+ * or when the form-2 parse fails to find a usable `Date` header.
+ */
+function parseRetryAfter(headers: Headers): number | undefined {
+  const raw = headers.get('Retry-After');
+
+  if (raw === null) return undefined;
+
+  if (NON_NEGATIVE_INT.test(raw)) return Number.parseInt(raw, 10);
+
+  const match = RULE_TIMESTAMP.exec(raw);
+
+  if (!match) return undefined;
+
+  const dateHeader = headers.get('Date');
+
+  if (dateHeader === null) return undefined;
+
+  const serverNowUtcMs = Date.parse(dateHeader);
+
+  if (Number.isNaN(serverNowUtcMs)) return undefined;
+
+  const serverWallMs = Date.parse(serverWallIso(serverNowUtcMs));
+  const retryWallMs = Date.parse(`${match[1]}T${match[2]}Z`);
+
+  if (Number.isNaN(serverWallMs) || Number.isNaN(retryWallMs)) return undefined;
+
+  return Math.max(0, Math.round((retryWallMs - serverWallMs) / 1000));
+}
+
+// Maps Rule.io v3's rate-limit headers onto a RuleApiError. Live v3 emits
+// different header sets on different status codes:
 //
-//   docs claim            | live v3 header          | semantics
-//   --------------------- | ----------------------- | --------------------------------
-//   X-RateLimit-Limit     | RequestsCount-Allowed   | max requests per window
-//   X-RateLimit-Remaining | RequestsCount-Current   | requests **used** (not remaining!)
-//   Retry-After           | Retry-After             | seconds to wait (likely 429-only)
-//   (undocumented)        | X-ErrorPercent-Limit    | the 49% trigger ceiling
-//   (undocumented)        | X-ErrorPercent-Current  | observed error rate
+//   on 200 / 4xx (non-429)        | on 429
+//   ----------------------------- | ----------------------------------
+//   RequestsCount-Allowed         | (absent — counter not echoed)
+//   RequestsCount-Current         | (absent — counter not echoed)
+//   X-ErrorPercent-Limit          | X-ErrorPercent-Limit
+//   X-ErrorPercent-Current        | X-ErrorPercent-Current
+//   (no Retry-After)              | Retry-After: YYYY-MM-DD HH:MM:SS
+//                                 |   (server-local timestamp, no tz)
 //
-// We read the live names but prefer the documented ones if Rule.io ever ships
-// them. `rateLimitRemaining` is computed (`Allowed − Current`) when only the
-// live pair is available.
-//
-// Only the integer-seconds form of Retry-After is parsed; the HTTP-date form
-// (RFC 7231) is ignored. TODO: HTTP-date if Rule.io ever adopts it.
+// The X-RateLimit-* family Rule.io's docs claim is never emitted in practice
+// (probed May 2026, including a real 429). We still read those names because
+// they're cheap and would Just Work if Rule.io ever aligns. We compute
+// `rateLimitRemaining = Allowed - Current` (clamped non-negative) when the
+// RequestsCount pair is present (i.e. on non-429 responses).
 function applyRateLimitHeaders(error: RuleApiError, headers: Headers): RuleApiError {
-  const retryAfter = readNonNegativeInt(headers, 'Retry-After');
+  const retryAfter = parseRetryAfter(headers);
 
   if (retryAfter !== undefined) error.retryAfterSeconds = retryAfter;
 

--- a/packages/client/src/core/transport.ts
+++ b/packages/client/src/core/transport.ts
@@ -176,11 +176,19 @@ export class HttpTransport {
 
       this.log('Rate limited. Retry after', retryAfter, 'seconds');
 
-      return new RuleApiError('Rate limited by Rule.io API', 429);
+      const error = new RuleApiError('Rate limited by Rule.io API', 429);
+
+      if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
+      return error;
     }
 
     if (response.status === 401) {
-      return new RuleApiError('Invalid Rule.io API key', 401);
+      const error = new RuleApiError('Invalid Rule.io API key', 401);
+
+      if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
+      return error;
     }
 
     let message = version === 'v3' ? 'Rule.io v3 API error' : 'Rule.io API error';
@@ -216,8 +224,69 @@ export class HttpTransport {
 
     if (validationErrors) error.validationErrors = validationErrors;
 
+    if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
     return error;
   }
+}
+
+const NON_NEGATIVE_INT = /^\s*\d+\s*$/;
+
+function readNonNegativeInt(headers: Headers, name: string): number | undefined {
+  const raw = headers.get(name);
+
+  return raw !== null && NON_NEGATIVE_INT.test(raw) ? Number.parseInt(raw, 10) : undefined;
+}
+
+// Maps Rule.io v3's rate-limit headers onto a RuleApiError. The headers Rule.io
+// actually emits diverge from the names in their public docs:
+//
+//   docs claim            | live v3 header          | semantics
+//   --------------------- | ----------------------- | --------------------------------
+//   X-RateLimit-Limit     | RequestsCount-Allowed   | max requests per window
+//   X-RateLimit-Remaining | RequestsCount-Current   | requests **used** (not remaining!)
+//   Retry-After           | Retry-After             | seconds to wait (likely 429-only)
+//   (undocumented)        | X-ErrorPercent-Limit    | the 49% trigger ceiling
+//   (undocumented)        | X-ErrorPercent-Current  | observed error rate
+//
+// We read the live names but prefer the documented ones if Rule.io ever ships
+// them. `rateLimitRemaining` is computed (`Allowed − Current`) when only the
+// live pair is available.
+//
+// Only the integer-seconds form of Retry-After is parsed; the HTTP-date form
+// (RFC 7231) is ignored. TODO: HTTP-date if Rule.io ever adopts it.
+function applyRateLimitHeaders(error: RuleApiError, headers: Headers): RuleApiError {
+  const retryAfter = readNonNegativeInt(headers, 'Retry-After');
+
+  if (retryAfter !== undefined) error.retryAfterSeconds = retryAfter;
+
+  const documentedLimit = readNonNegativeInt(headers, 'X-RateLimit-Limit');
+  const liveAllowed = readNonNegativeInt(headers, 'RequestsCount-Allowed');
+  const liveCurrent = readNonNegativeInt(headers, 'RequestsCount-Current');
+
+  if (documentedLimit !== undefined) {
+    error.rateLimitLimit = documentedLimit;
+  } else if (liveAllowed !== undefined) {
+    error.rateLimitLimit = liveAllowed;
+  }
+
+  const documentedRemaining = readNonNegativeInt(headers, 'X-RateLimit-Remaining');
+
+  if (documentedRemaining !== undefined) {
+    error.rateLimitRemaining = documentedRemaining;
+  } else if (liveAllowed !== undefined && liveCurrent !== undefined) {
+    error.rateLimitRemaining = Math.max(0, liveAllowed - liveCurrent);
+  }
+
+  const errorPercentLimit = readNonNegativeInt(headers, 'X-ErrorPercent-Limit');
+
+  if (errorPercentLimit !== undefined) error.errorPercentLimit = errorPercentLimit;
+
+  const errorPercentCurrent = readNonNegativeInt(headers, 'X-ErrorPercent-Current');
+
+  if (errorPercentCurrent !== undefined) error.errorPercentCurrent = errorPercentCurrent;
+
+  return error;
 }
 
 function normalizeValidationErrors(

--- a/packages/client/src/errors.test.ts
+++ b/packages/client/src/errors.test.ts
@@ -57,6 +57,28 @@ describe('RuleApiError', () => {
     err.validationErrors = { email: ['invalid format'] };
     expect(err.validationErrors).toEqual({ email: ['invalid format'] });
   });
+
+  it('rate-limit + error-percent fields are optional and writable', () => {
+    const err = new RuleApiError('rate limited', 429);
+
+    expect(err.retryAfterSeconds).toBeUndefined();
+    expect(err.rateLimitLimit).toBeUndefined();
+    expect(err.rateLimitRemaining).toBeUndefined();
+    expect(err.errorPercentLimit).toBeUndefined();
+    expect(err.errorPercentCurrent).toBeUndefined();
+
+    err.retryAfterSeconds = 30;
+    err.rateLimitLimit = 2000;
+    err.rateLimitRemaining = 0;
+    err.errorPercentLimit = 49;
+    err.errorPercentCurrent = 50;
+
+    expect(err.retryAfterSeconds).toBe(30);
+    expect(err.rateLimitLimit).toBe(2000);
+    expect(err.rateLimitRemaining).toBe(0);
+    expect(err.errorPercentLimit).toBe(49);
+    expect(err.errorPercentCurrent).toBe(50);
+  });
 });
 
 describe('RuleClientError', () => {

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -47,9 +47,14 @@ export class RuleApiError extends Error {
    * before this delay actively accelerates the block. Consumer retry layers
    * should prefer this value over a local backoff guess.
    *
-   * Only the integer-seconds form is parsed today; the HTTP-date form
-   * (RFC 7231) is ignored. Field is `undefined` when the header is absent
-   * or unparseable.
+   * Two input forms are accepted:
+   *  - integer seconds (per RFC 7231 / Rule.io's published docs)
+   *  - `YYYY-MM-DD HH:MM:SS` without a timezone (the form Rule.io v3 actually
+   *    emits on real 429s). The delta to `now` is computed against the
+   *    response `Date` header so the server's tz offset cancels.
+   *
+   * RFC 7231 HTTP-date is not yet supported (TODO). Field is `undefined`
+   * when the header is absent or can't be parsed.
    */
   public retryAfterSeconds?: number;
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -39,6 +39,62 @@ export class RuleApiError extends Error {
    */
   public validationErrors?: RuleValidationErrors;
 
+  /**
+   * Seconds the server asks the client to wait before retrying, parsed from
+   * the `Retry-After` response header (v3 endpoints only).
+   *
+   * Rule.io's rate-limit contract triggers on a 49% error rate, so retrying
+   * before this delay actively accelerates the block. Consumer retry layers
+   * should prefer this value over a local backoff guess.
+   *
+   * Only the integer-seconds form is parsed today; the HTTP-date form
+   * (RFC 7231) is ignored. Field is `undefined` when the header is absent
+   * or unparseable.
+   */
+  public retryAfterSeconds?: number;
+
+  /**
+   * Maximum requests permitted in the current rate-limit window
+   * (v3 endpoints only).
+   *
+   * Sourced from `RequestsCount-Allowed` (the header v3 actually emits) or
+   * `X-RateLimit-Limit` (the documented name — used if Rule.io ever aligns).
+   *
+   * `undefined` when neither header is present.
+   */
+  public rateLimitLimit?: number;
+
+  /**
+   * Remaining requests in the current rate-limit window (v3 endpoints only).
+   *
+   * Sourced from `X-RateLimit-Remaining` if Rule.io ever ships it; otherwise
+   * computed as `RequestsCount-Allowed − RequestsCount-Current` (clamped to
+   * a non-negative integer).
+   *
+   * `undefined` when no header data is available to derive the value.
+   */
+  public rateLimitRemaining?: number;
+
+  /**
+   * The error-rate ceiling that, once crossed, triggers a rate-limit block.
+   * Parsed from `X-ErrorPercent-Limit` (v3 endpoints only). Rule.io's
+   * documented value is `49`.
+   *
+   * Consumer retry layers should treat this together with `errorPercentCurrent`
+   * — retrying after a 4xx counts toward the error-percent budget.
+   *
+   * `undefined` when the header is absent.
+   */
+  public errorPercentLimit?: number;
+
+  /**
+   * The current observed error-rate, parsed from `X-ErrorPercent-Current`
+   * (v3 endpoints only).
+   *
+   * `undefined` when the header is absent.
+   */
+  public errorPercentCurrent?: number;
+
   /** @deprecated This property is never populated. It will be removed in the next major version. */
   readonly requestId?: string;
 

--- a/packages/rcml/package.json
+++ b/packages/rcml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rulecom/rcml",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "RCML email template builders and type definitions for the Rule.io SDK.",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rulecom/sdk",
-  "version": "0.4.0-beta.0",
-  "description": "TypeScript SDK for Rule.io email marketing API with RCML template builders \u2014 meta-package re-exporting @rulecom/rcml and @rulecom/client.",
+  "version": "0.4.0-beta.1",
+  "description": "TypeScript SDK for Rule.io email marketing API with RCML template builders — meta-package re-exporting @rulecom/rcml and @rulecom/client.",
   "type": "module",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -32,8 +32,8 @@
     "directory": "packages/sdk"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.0",
-    "@rulecom/client": "0.4.0-beta.0"
+    "@rulecom/rcml": "0.4.0-beta.1",
+    "@rulecom/client": "0.4.0-beta.1"
   },
   "engines": {
     "node": ">=20"

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rulecom/template-engine",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "Minimal XML template compiler used by Rule.io vendor email-template packages. v1.4 uses XML Processing Instructions for directives, a flat data scope, and Transloco-style `t('key', { param: expr })` message calls.",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -30,7 +30,7 @@
     "directory": "packages/template-engine"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.0"
+    "@rulecom/rcml": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rulecom/template-engine",
   "version": "0.4.0-beta.0",
   "description": "Minimal XML template compiler used by Rule.io vendor email-template packages. v1.4 uses XML Processing Instructions for directives, a flat data scope, and Transloco-style `t('key', { param: expr })` message calls.",

--- a/packages/vendor-bookzen/package.json
+++ b/packages/vendor-bookzen/package.json
@@ -31,10 +31,10 @@
     "directory": "packages/vendor-bookzen"
   },
   "dependencies": {
-    "@rulecom/client": "0.4.0-beta.0",
-    "@rulecom/rcml": "0.4.0-beta.0",
-    "@rulecom/template-engine": "0.4.0-beta.0",
-    "@rulecom/vendor": "0.4.0-beta.0"
+    "@rulecom/client": "*",
+    "@rulecom/rcml": "*",
+    "@rulecom/template-engine": "*",
+    "@rulecom/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-bookzen/package.json
+++ b/packages/vendor-bookzen/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rulecom/vendor-bookzen",
   "version": "0.4.0-beta.0",
   "description": "Bookzen preset for the Rule.io SDK \u2014 hospitality automation flows (reservation confirmation, cancellation, reminder, feedback, request).",

--- a/packages/vendor-bookzen/package.json
+++ b/packages/vendor-bookzen/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rulecom/vendor-bookzen",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "Bookzen preset for the Rule.io SDK \u2014 hospitality automation flows (reservation confirmation, cancellation, reminder, feedback, request).",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/vendor-samfora/package.json
+++ b/packages/vendor-samfora/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rulecom/vendor-samfora",
   "version": "0.4.0-beta.0",
   "description": "Samfora preset for the Rule.io SDK \u2014 Swedish donation-platform automation flows.",

--- a/packages/vendor-samfora/package.json
+++ b/packages/vendor-samfora/package.json
@@ -31,9 +31,9 @@
     "directory": "packages/vendor-samfora"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.0",
-    "@rulecom/template-engine": "0.4.0-beta.0",
-    "@rulecom/vendor": "0.4.0-beta.0"
+    "@rulecom/rcml": "*",
+    "@rulecom/template-engine": "*",
+    "@rulecom/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-samfora/package.json
+++ b/packages/vendor-samfora/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rulecom/vendor-samfora",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "Samfora preset for the Rule.io SDK \u2014 Swedish donation-platform automation flows.",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/vendor-shopify/package.json
+++ b/packages/vendor-shopify/package.json
@@ -30,9 +30,9 @@
     "directory": "packages/vendor-shopify"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.0",
-    "@rulecom/template-engine": "0.4.0-beta.0",
-    "@rulecom/vendor": "0.4.0-beta.0"
+    "@rulecom/rcml": "*",
+    "@rulecom/template-engine": "*",
+    "@rulecom/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-shopify/package.json
+++ b/packages/vendor-shopify/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rulecom/vendor-shopify",
   "version": "0.4.0-beta.0",
   "description": "Shopify preset for the Rule.io SDK \u2014 e-commerce automation flows (order confirmation, shipping, abandoned cart, cancellation, welcome).",

--- a/packages/vendor-shopify/package.json
+++ b/packages/vendor-shopify/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rulecom/vendor-shopify",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "Shopify preset for the Rule.io SDK \u2014 e-commerce automation flows (order confirmation, shipping, abandoned cart, cancellation, welcome).",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@rulecom/vendor",
-  "version": "0.4.0-beta.0",
+  "version": "0.4.0-beta.1",
   "description": "Shared vendor utilities for the Rule.io SDK.",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@rulecom/vendor",
   "version": "0.4.0-beta.0",
   "description": "Shared vendor utilities for the Rule.io SDK.",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/vendor"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.0"
+    "@rulecom/rcml": "*"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

**CI fixes:**
- Use \`--atomic\` push with explicit \`HEAD:refs/heads/main\` refspec so the release commit and tag land together or not at all — avoids partial push state and detached-HEAD ambiguity
- Use release commit SHA (not tag ref) for publish job checkout — tag refs pushed by a sibling job can fail to resolve due to GitHub replication lag

**Package/version fixes (required to unblock CI):**
- Bring all \`packages/*/package.json\` to \`0.4.0-beta.1\` (already released on main for the release-group packages; private packages aligned for fixed-versioning consistency)
- Change non-published private packages (\`template-engine\`, \`vendor\`, \`vendor-*\`) internal \`@rulecom/*\` deps to \`"*"\` — exact-version pinning broke \`npm ci\` on PR merge commits when a release bumped versions without updating non-release-group packages (these packages are \`"private": true\` and never published to npm, so \`"*"\` has no external consumers)
- Add \`"private": true\` to all non-published packages to prevent accidental publish and make the \`"*"\` ranges safe
- Remove \`skipLockFileUpdate\` from \`nx.json\` so the release workflow regenerates the lock file after every version bump
- Regenerate \`package-lock.json\` to match current workspace state

## Test plan

- [ ] Merge via merge commit to preserve conventional commit history
- [ ] Confirm Release CI computes \`0.4.0-beta.2\` (fix commits since \`v0.4.0-beta.1\`)
- [ ] Approve \`npm-production\` environment gate
- [ ] Verify \`@rulecom/client\`, \`@rulecom/rcml\`, \`@rulecom/sdk\` appear on npm under \`beta\` dist-tag
- [ ] Remove \`--first-release\` from the publish step after confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)