### PR TITLE
feat(client): expose v3 rate-limit headers on RuleApiError (#136)

### DIFF
--- a/packages/client/src/core/transport.test.ts
+++ b/packages/client/src/core/transport.test.ts
@@ -204,4 +204,157 @@ describe('HttpTransport', () => {
       });
     });
   });
+
+  describe('rate-limit headers (v3 only)', () => {
+    it('exposes Retry-After + RequestsCount + ErrorPercent on a v3 429', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'Retry-After': '45',
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2000',
+          'X-ErrorPercent-Limit': '49',
+          'X-ErrorPercent-Current': '50',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 45,
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 0,
+        errorPercentLimit: 49,
+        errorPercentCurrent: 50,
+      });
+    });
+
+    it('computes rateLimitRemaining as Allowed − Current on v3 errors', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 503, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '7',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 503,
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 1993,
+      });
+    });
+
+    it('clamps rateLimitRemaining to 0 if Current exceeds Allowed', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 429, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2050',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitRemaining: 0,
+      });
+    });
+
+    it('prefers documented X-RateLimit-* headers if Rule.io ever ships them', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'X-RateLimit-Limit': '5000',
+          'X-RateLimit-Remaining': '12',
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '1999',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitLimit: 5000,
+        rateLimitRemaining: 12,
+      });
+    });
+
+    it('leaves rate-limit fields undefined when v3 emits no headers', async () => {
+      fetchMock.mockResolvedValueOnce(createMockErrorResponse({}, 401));
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 401,
+        retryAfterSeconds: undefined,
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+        errorPercentLimit: undefined,
+        errorPercentCurrent: undefined,
+      });
+    });
+
+    it('ignores the HTTP-date form of Retry-After (TODO: parse it)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: undefined,
+      });
+    });
+
+    it('rejects negative header values (parser is non-negative-int)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'oops' }, 429, {
+          'RequestsCount-Allowed': '-1',
+          'RequestsCount-Current': '-1',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+      });
+    });
+
+    it('exposes rate-limit headers alongside validationErrors on v3 422', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse(
+          { errors: { name: ['The name field is required.'] } },
+          422,
+          {
+            'RequestsCount-Allowed': '2000',
+            'RequestsCount-Current': '1',
+          }
+        )
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.put('/x')).rejects.toMatchObject({
+        statusCode: 422,
+        validationErrors: { name: ['The name field is required.'] },
+        rateLimitLimit: 2000,
+        rateLimitRemaining: 1999,
+      });
+    });
+
+    it('does NOT populate rate-limit fields on a v2 error', async () => {
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse({ error: 'Rate limited' }, 429, {
+          'RequestsCount-Allowed': '2000',
+          'RequestsCount-Current': '2000',
+          'X-ErrorPercent-Limit': '49',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x', { version: 'v2' })).rejects.toMatchObject({
+        statusCode: 429,
+        rateLimitLimit: undefined,
+        rateLimitRemaining: undefined,
+        errorPercentLimit: undefined,
+      });
+    });
+  });
 });

--- a/packages/client/src/core/transport.ts
+++ b/packages/client/src/core/transport.ts
@@ -176,11 +176,19 @@ export class HttpTransport {
 
       this.log('Rate limited. Retry after', retryAfter, 'seconds');
 
-      return new RuleApiError('Rate limited by Rule.io API', 429);
+      const error = new RuleApiError('Rate limited by Rule.io API', 429);
+
+      if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
+      return error;
     }
 
     if (response.status === 401) {
-      return new RuleApiError('Invalid Rule.io API key', 401);
+      const error = new RuleApiError('Invalid Rule.io API key', 401);
+
+      if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
+      return error;
     }
 
     let message = version === 'v3' ? 'Rule.io v3 API error' : 'Rule.io API error';
@@ -216,8 +224,69 @@ export class HttpTransport {
 
     if (validationErrors) error.validationErrors = validationErrors;
 
+    if (version === 'v3') applyRateLimitHeaders(error, response.headers);
+
     return error;
   }
+}
+
+const NON_NEGATIVE_INT = /^\s*\d+\s*$/;
+
+function readNonNegativeInt(headers: Headers, name: string): number | undefined {
+  const raw = headers.get(name);
+
+  return raw !== null && NON_NEGATIVE_INT.test(raw) ? Number.parseInt(raw, 10) : undefined;
+}
+
+// Maps Rule.io v3's rate-limit headers onto a RuleApiError. The headers Rule.io
+// actually emits diverge from the names in their public docs:
+//
+//   docs claim            | live v3 header          | semantics
+//   --------------------- | ----------------------- | --------------------------------
+//   X-RateLimit-Limit     | RequestsCount-Allowed   | max requests per window
+//   X-RateLimit-Remaining | RequestsCount-Current   | requests **used** (not remaining!)
+//   Retry-After           | Retry-After             | seconds to wait (likely 429-only)
+//   (undocumented)        | X-ErrorPercent-Limit    | the 49% trigger ceiling
+//   (undocumented)        | X-ErrorPercent-Current  | observed error rate
+//
+// We read the live names but prefer the documented ones if Rule.io ever ships
+// them. `rateLimitRemaining` is computed (`Allowed − Current`) when only the
+// live pair is available.
+//
+// Only the integer-seconds form of Retry-After is parsed; the HTTP-date form
+// (RFC 7231) is ignored. TODO: HTTP-date if Rule.io ever adopts it.
+function applyRateLimitHeaders(error: RuleApiError, headers: Headers): RuleApiError {
+  const retryAfter = readNonNegativeInt(headers, 'Retry-After');
+
+  if (retryAfter !== undefined) error.retryAfterSeconds = retryAfter;
+
+  const documentedLimit = readNonNegativeInt(headers, 'X-RateLimit-Limit');
+  const liveAllowed = readNonNegativeInt(headers, 'RequestsCount-Allowed');
+  const liveCurrent = readNonNegativeInt(headers, 'RequestsCount-Current');
+
+  if (documentedLimit !== undefined) {
+    error.rateLimitLimit = documentedLimit;
+  } else if (liveAllowed !== undefined) {
+    error.rateLimitLimit = liveAllowed;
+  }
+
+  const documentedRemaining = readNonNegativeInt(headers, 'X-RateLimit-Remaining');
+
+  if (documentedRemaining !== undefined) {
+    error.rateLimitRemaining = documentedRemaining;
+  } else if (liveAllowed !== undefined && liveCurrent !== undefined) {
+    error.rateLimitRemaining = Math.max(0, liveAllowed - liveCurrent);
+  }
+
+  const errorPercentLimit = readNonNegativeInt(headers, 'X-ErrorPercent-Limit');
+
+  if (errorPercentLimit !== undefined) error.errorPercentLimit = errorPercentLimit;
+
+  const errorPercentCurrent = readNonNegativeInt(headers, 'X-ErrorPercent-Current');
+
+  if (errorPercentCurrent !== undefined) error.errorPercentCurrent = errorPercentCurrent;
+
+  return error;
 }
 
 function normalizeValidationErrors(

--- a/packages/client/src/errors.test.ts
+++ b/packages/client/src/errors.test.ts
@@ -57,6 +57,28 @@ describe('RuleApiError', () => {
     err.validationErrors = { email: ['invalid format'] };
     expect(err.validationErrors).toEqual({ email: ['invalid format'] });
   });
+
+  it('rate-limit + error-percent fields are optional and writable', () => {
+    const err = new RuleApiError('rate limited', 429);
+
+    expect(err.retryAfterSeconds).toBeUndefined();
+    expect(err.rateLimitLimit).toBeUndefined();
+    expect(err.rateLimitRemaining).toBeUndefined();
+    expect(err.errorPercentLimit).toBeUndefined();
+    expect(err.errorPercentCurrent).toBeUndefined();
+
+    err.retryAfterSeconds = 30;
+    err.rateLimitLimit = 2000;
+    err.rateLimitRemaining = 0;
+    err.errorPercentLimit = 49;
+    err.errorPercentCurrent = 50;
+
+    expect(err.retryAfterSeconds).toBe(30);
+    expect(err.rateLimitLimit).toBe(2000);
+    expect(err.rateLimitRemaining).toBe(0);
+    expect(err.errorPercentLimit).toBe(49);
+    expect(err.errorPercentCurrent).toBe(50);
+  });
 });
 
 describe('RuleClientError', () => {

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -39,6 +39,62 @@ export class RuleApiError extends Error {
    */
   public validationErrors?: RuleValidationErrors;
 
+  /**
+   * Seconds the server asks the client to wait before retrying, parsed from
+   * the `Retry-After` response header (v3 endpoints only).
+   *
+   * Rule.io's rate-limit contract triggers on a 49% error rate, so retrying
+   * before this delay actively accelerates the block. Consumer retry layers
+   * should prefer this value over a local backoff guess.
+   *
+   * Only the integer-seconds form is parsed today; the HTTP-date form
+   * (RFC 7231) is ignored. Field is `undefined` when the header is absent
+   * or unparseable.
+   */
+  public retryAfterSeconds?: number;
+
+  /**
+   * Maximum requests permitted in the current rate-limit window
+   * (v3 endpoints only).
+   *
+   * Sourced from `RequestsCount-Allowed` (the header v3 actually emits) or
+   * `X-RateLimit-Limit` (the documented name — used if Rule.io ever aligns).
+   *
+   * `undefined` when neither header is present.
+   */
+  public rateLimitLimit?: number;
+
+  /**
+   * Remaining requests in the current rate-limit window (v3 endpoints only).
+   *
+   * Sourced from `X-RateLimit-Remaining` if Rule.io ever ships it; otherwise
+   * computed as `RequestsCount-Allowed − RequestsCount-Current` (clamped to
+   * a non-negative integer).
+   *
+   * `undefined` when no header data is available to derive the value.
+   */
+  public rateLimitRemaining?: number;
+
+  /**
+   * The error-rate ceiling that, once crossed, triggers a rate-limit block.
+   * Parsed from `X-ErrorPercent-Limit` (v3 endpoints only). Rule.io's
+   * documented value is `49`.
+   *
+   * Consumer retry layers should treat this together with `errorPercentCurrent`
+   * — retrying after a 4xx counts toward the error-percent budget.
+   *
+   * `undefined` when the header is absent.
+   */
+  public errorPercentLimit?: number;
+
+  /**
+   * The current observed error-rate, parsed from `X-ErrorPercent-Current`
+   * (v3 endpoints only).
+   *
+   * `undefined` when the header is absent.
+   */
+  public errorPercentCurrent?: number;
+
   /** @deprecated This property is never populated. It will be removed in the next major version. */
   readonly requestId?: string;
 


### PR DESCRIPTION
Closes #136.

## Summary

Surfaces Rule.io's v3 rate-limit metadata on `RuleApiError` so consumer retry layers can honor `Retry-After` and respect the 49% error-rate trigger that's the load-bearing concern of the issue. Adds five optional fields:

```ts
class RuleApiError {
  retryAfterSeconds?: number;
  rateLimitLimit?: number;
  rateLimitRemaining?: number;
  errorPercentLimit?: number;
  errorPercentCurrent?: number;
}
```

Scope: **v3 only**. The v2 path is untouched.

## Doc / live-API divergence

The issue spec quoted Rule.io's published header names (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After`). A live probe against the production v3 API confirms those headers are **not** emitted on 200 / 404 / 422 / 401 responses — instead, v3 emits:

| Documented at apidoc.rule.se | Actually emitted by v3              | Semantics                                |
| ---------------------------- | ----------------------------------- | ---------------------------------------- |
| `X-RateLimit-Limit`          | `RequestsCount-Allowed: 2000`       | max requests per window                  |
| `X-RateLimit-Remaining`      | `RequestsCount-Current: 12`         | requests **used** (NOT remaining!)       |
| `Retry-After`                | not seen on 200/404/422/401         | likely 429-only                          |
| *(undocumented in apidoc)*   | `X-ErrorPercent-Limit: 49`          | the 49% trigger ceiling                  |
| *(undocumented in apidoc)*   | `X-ErrorPercent-Current: 0`         | observed error rate                      |

The **policy** (2000 / 10 min, 49% trigger) is in line with the docs — confirmed with Rule.io developers. The **headers carrying the values** are not.

The transport reads the live names, computes `rateLimitRemaining = Allowed − Current` (clamped non-negative), exposes the error-percent pair (the actual signal for the 49% trigger), and still prefers the documented names if Rule.io ever ships them. This means the SDK works correctly today and stays correct if Rule.io aligns the headers later.

## What's not in scope

- v2 path — left untouched per direction
- HTTP-date form of `Retry-After` (RFC 7231) — only integer-seconds is parsed; HTTP-date is a TODO comment
- Built-in SDK retry on 429 — separate decision (called out in the issue as a follow-up)
- Surfacing rate-limit headers on **successful** responses

## Live verification

Probe against production v3, triggering a real 422 via `templates.create({})`:

```
status=422
retryAfterSeconds=undefined
rateLimitLimit=2000        (from RequestsCount-Allowed)
rateLimitRemaining=1998    (computed: Allowed − Current=2, clamped non-negative)
errorPercentLimit=49       (from X-ErrorPercent-Limit)
errorPercentCurrent=0      (from X-ErrorPercent-Current)
validationErrors={"name":["The name field is required."],"message_type":["..."]}
```

401 path (Cloudflare pre-auth, no headers carried) leaves all 5 fields `undefined` — matches JSDoc.

## Test plan

- [x] `nx run client:vitest:test` — 419 passing, including 8 new transport tests (live names, computed remaining, clamp, futureproof, no-headers, HTTP-date ignored, negative-rejection, validationErrors alongside, v2 isolation) and 1 new errors-class round-trip test
- [x] `nx run client:eslint:lint` — clean for changed files
- [x] Live API probe against production v3 (above)
- [ ] Copilot review

## Notes for reviewers

- Additive change; existing `instanceof RuleApiError`, `error.statusCode`, `error.validationErrors` checks unchanged.
- New fields propagate through `@rulecom/sdk` automatically via `export *`.
- `Object.keys(error)` will now expose the populated rate-limit keys — flag for anyone serializing errors to logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)