### PR TITLE
fix(client): parse Rule.io v3's actual Retry-After format on 429s (#136 follow-up)

### DIFF
--- a/packages/client/src/core/transport.test.ts
+++ b/packages/client/src/core/transport.test.ts
@@ -206,7 +206,7 @@ describe('HttpTransport', () => {
   });
 
   describe('rate-limit headers (v3 only)', () => {
-    it('exposes Retry-After + RequestsCount + ErrorPercent on a v3 429', async () => {
+    it('exposes integer Retry-After + RequestsCount + ErrorPercent on a v3 429 (synthetic)', async () => {
       fetchMock.mockResolvedValueOnce(
         createMockErrorResponse({ error: 'Rate limited' }, 429, {
           'Retry-After': '45',
@@ -225,6 +225,71 @@ describe('HttpTransport', () => {
         rateLimitRemaining: 0,
         errorPercentLimit: 49,
         errorPercentCurrent: 50,
+      });
+    });
+
+    it('parses Retry-After in Rule.io v3\'s actual 429 form (YYYY-MM-DD HH:MM:SS, no tz)', async () => {
+      // Real-world headers captured from a probe against production v3 in May
+      // 2026: Retry-After is a server-local timestamp (no tz), and the
+      // RequestsCount pair is *not* echoed on 429s — only X-ErrorPercent-* is.
+      // The `Date` header carries the server's "now" — we use it as the
+      // reference frame so the tz offset cancels.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse(
+          'Too Many Requests. You can continue at 2026-05-14 14:22:16.',
+          429,
+          {
+            // Retry-After is 10 minutes after the response Date header.
+            'Retry-After': '2026-05-14 14:22:16',
+            Date: 'Thu, 14 May 2026 12:12:16 GMT',
+            'X-ErrorPercent-Limit': '49',
+            'X-ErrorPercent-Current': '0',
+          }
+        )
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterSeconds: 600, // 10 minutes
+        errorPercentLimit: 49,
+        errorPercentCurrent: 0,
+        rateLimitLimit: undefined, // not echoed on 429
+        rateLimitRemaining: undefined,
+      });
+    });
+
+    it('clamps negative retryAfterSeconds to 0 if the timestamp is already in the past', async () => {
+      // Edge case: clock skew or stale response. Don't return a negative
+      // wait — clamp to 0 so consumers retry immediately rather than
+      // hitting an arithmetic surprise.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse('', 429, {
+          'Retry-After': '2026-05-14 11:00:00',
+          Date: 'Thu, 14 May 2026 12:00:00 GMT',
+          'X-ErrorPercent-Limit': '49',
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        retryAfterSeconds: 0,
+      });
+    });
+
+    it('leaves retryAfterSeconds undefined for the timestamp form when no Date header is present', async () => {
+      // The Date header is what makes the timestamp form parseable without
+      // knowing the server's tz — without it we'd have to guess.
+      fetchMock.mockResolvedValueOnce(
+        createMockErrorResponse('', 429, {
+          'Retry-After': '2026-05-14 14:22:16',
+          // no Date header
+        })
+      );
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({
+        retryAfterSeconds: undefined,
       });
     });
 

--- a/packages/client/src/core/transport.ts
+++ b/packages/client/src/core/transport.ts
@@ -231,6 +231,7 @@ export class HttpTransport {
 }
 
 const NON_NEGATIVE_INT = /^\s*\d+\s*$/;
+const RULE_TIMESTAMP = /^\s*(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})\s*$/;
 
 function readNonNegativeInt(headers: Headers, name: string): number | undefined {
   const raw = headers.get(name);
@@ -238,25 +239,101 @@ function readNonNegativeInt(headers: Headers, name: string): number | undefined 
   return raw !== null && NON_NEGATIVE_INT.test(raw) ? Number.parseInt(raw, 10) : undefined;
 }
 
-// Maps Rule.io v3's rate-limit headers onto a RuleApiError. The headers Rule.io
-// actually emits diverge from the names in their public docs:
+// Rule.io is a Swedish company; the live v3 API emits `Retry-After` as a
+// server-local timestamp without a timezone marker, in Stockholm time
+// (CET / CEST with DST). `Intl.DateTimeFormat` resolves the offset for us
+// including DST. If Rule.io ever relocates its servers, this becomes wrong;
+// the safer alternative would be punting to `undefined`. We choose to be
+// useful by default and document the assumption.
+const RULE_SERVER_TZ = 'Europe/Stockholm';
+
+const ruleServerWallFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: RULE_SERVER_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+function serverWallIso(utcMs: number): string {
+  const parts: Record<string, string> = {};
+
+  for (const part of ruleServerWallFormatter.formatToParts(new Date(utcMs))) {
+    if (part.type !== 'literal') parts[part.type] = part.value;
+  }
+
+  // `Intl` can return 24:00:00 instead of 00:00:00 in some locales/runtimes.
+  const hour = parts.hour === '24' ? '00' : parts.hour;
+
+  return `${parts.year}-${parts.month}-${parts.day}T${hour}:${parts.minute}:${parts.second}Z`;
+}
+
+/**
+ * Parse the `Retry-After` header into seconds-from-now.
+ *
+ * Three input forms are accepted:
+ *
+ * 1. Integer seconds (per Rule.io's published docs and RFC 7231) — returned as-is.
+ * 2. `YYYY-MM-DD HH:MM:SS` without a timezone (the form Rule.io's live v3 API
+ *    emits on real 429s, e.g. `2026-05-14 14:22:16`). The timestamp is in the
+ *    server's local timezone (Europe/Stockholm). We use the response's `Date`
+ *    header as the "server now" reference: convert it to the server's
+ *    wall-clock frame, then diff against the retry-after wall components.
+ *    The tz offset cancels (DST included).
+ * 3. RFC 7231 HTTP-date — TODO; not yet observed from Rule.io.
+ *
+ * Returns `undefined` when the header is absent or the value can't be parsed,
+ * or when the form-2 parse fails to find a usable `Date` header.
+ */
+function parseRetryAfter(headers: Headers): number | undefined {
+  const raw = headers.get('Retry-After');
+
+  if (raw === null) return undefined;
+
+  if (NON_NEGATIVE_INT.test(raw)) return Number.parseInt(raw, 10);
+
+  const match = RULE_TIMESTAMP.exec(raw);
+
+  if (!match) return undefined;
+
+  const dateHeader = headers.get('Date');
+
+  if (dateHeader === null) return undefined;
+
+  const serverNowUtcMs = Date.parse(dateHeader);
+
+  if (Number.isNaN(serverNowUtcMs)) return undefined;
+
+  const serverWallMs = Date.parse(serverWallIso(serverNowUtcMs));
+  const retryWallMs = Date.parse(`${match[1]}T${match[2]}Z`);
+
+  if (Number.isNaN(serverWallMs) || Number.isNaN(retryWallMs)) return undefined;
+
+  return Math.max(0, Math.round((retryWallMs - serverWallMs) / 1000));
+}
+
+// Maps Rule.io v3's rate-limit headers onto a RuleApiError. Live v3 emits
+// different header sets on different status codes:
 //
-//   docs claim            | live v3 header          | semantics
-//   --------------------- | ----------------------- | --------------------------------
-//   X-RateLimit-Limit     | RequestsCount-Allowed   | max requests per window
-//   X-RateLimit-Remaining | RequestsCount-Current   | requests **used** (not remaining!)
-//   Retry-After           | Retry-After             | seconds to wait (likely 429-only)
-//   (undocumented)        | X-ErrorPercent-Limit    | the 49% trigger ceiling
-//   (undocumented)        | X-ErrorPercent-Current  | observed error rate
+//   on 200 / 4xx (non-429)        | on 429
+//   ----------------------------- | ----------------------------------
+//   RequestsCount-Allowed         | (absent — counter not echoed)
+//   RequestsCount-Current         | (absent — counter not echoed)
+//   X-ErrorPercent-Limit          | X-ErrorPercent-Limit
+//   X-ErrorPercent-Current        | X-ErrorPercent-Current
+//   (no Retry-After)              | Retry-After: YYYY-MM-DD HH:MM:SS
+//                                 |   (server-local timestamp, no tz)
 //
-// We read the live names but prefer the documented ones if Rule.io ever ships
-// them. `rateLimitRemaining` is computed (`Allowed − Current`) when only the
-// live pair is available.
-//
-// Only the integer-seconds form of Retry-After is parsed; the HTTP-date form
-// (RFC 7231) is ignored. TODO: HTTP-date if Rule.io ever adopts it.
+// The X-RateLimit-* family Rule.io's docs claim is never emitted in practice
+// (probed May 2026, including a real 429). We still read those names because
+// they're cheap and would Just Work if Rule.io ever aligns. We compute
+// `rateLimitRemaining = Allowed - Current` (clamped non-negative) when the
+// RequestsCount pair is present (i.e. on non-429 responses).
 function applyRateLimitHeaders(error: RuleApiError, headers: Headers): RuleApiError {
-  const retryAfter = readNonNegativeInt(headers, 'Retry-After');
+  const retryAfter = parseRetryAfter(headers);
 
   if (retryAfter !== undefined) error.retryAfterSeconds = retryAfter;
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -47,9 +47,14 @@ export class RuleApiError extends Error {
    * before this delay actively accelerates the block. Consumer retry layers
    * should prefer this value over a local backoff guess.
    *
-   * Only the integer-seconds form is parsed today; the HTTP-date form
-   * (RFC 7231) is ignored. Field is `undefined` when the header is absent
-   * or unparseable.
+   * Two input forms are accepted:
+   *  - integer seconds (per RFC 7231 / Rule.io's published docs)
+   *  - `YYYY-MM-DD HH:MM:SS` without a timezone (the form Rule.io v3 actually
+   *    emits on real 429s). The delta to `now` is computed against the
+   *    response `Date` header so the server's tz offset cancels.
+   *
+   * RFC 7231 HTTP-date is not yet supported (TODO). Field is `undefined`
+   * when the header is absent or can't be parsed.
    */
   public retryAfterSeconds?: number;
 


### PR DESCRIPTION
Follow-up to #137 (which merged) — addresses a real-world parsing gap discovered after merge.

## Why this is a separate PR

#137 merged immediately after Copilot's "no comments" review. ~5 minutes later a deliberate live-429 probe (after exhausting the 2000-req/10-min budget on a sandbox key) revealed that Rule.io v3 emits `Retry-After` in a non-standard form the merged parser rejects:

```
Retry-After: 2026-05-14 14:22:16
Date: Thu, 14 May 2026 12:12:16 GMT
```

The merged code's regex `/^\s*\d+\s*$/` only matches integer seconds, so on a real 429 consumers would get `retryAfterSeconds: undefined` — silently dropping the very value the field exists to surface.

## What this fixes

Extends `parseRetryAfter` in `packages/client/src/core/transport.ts` to accept the `YYYY-MM-DD HH:MM:SS` form (server-local, no timezone). Since the value carries no timezone marker, we reformat the response `Date` header (RFC 1123 GMT) into Stockholm wall-clock as the "server now" reference and diff the wall components — the unknown tz offset cancels (DST included via `Intl.DateTimeFormat`).

`Europe/Stockholm` is hardcoded as `RULE_SERVER_TZ` because Rule.io is a Swedish company; if they relocate hosting, the constant is a one-line update.

Also rewrites the inline comment block in `transport.ts` to reflect the actual emitted-headers picture across status codes (which the original PR's comment got wrong by extrapolating from non-429 probes).

## Live verification

Real 429 captured in production v3 (sandbox key, 2000-req budget exhausted):

```
status=429
retry-after: 2026-05-14 14:22:16
date: Thu, 14 May 2026 12:12:16 GMT
x-errorpercent-current: 0
x-errorpercent-limit: 49
content-type: text/html; charset=UTF-8
body: "Too Many Requests. ... You can continue at 2026-05-14 14:22:16."
```

After parsing through the SDK with this fix:
- `retryAfterSeconds=600` (10 min — the documented window)
- `errorPercentLimit=49`, `errorPercentCurrent=0`
- `rateLimitLimit=undefined`, `rateLimitRemaining=undefined` (the `RequestsCount-*` pair is **not** echoed on 429s, only on non-429 responses)

Findings also recorded in `.claude/RULE_IO_API_REFERENCE.md` and project memory.

## Tests

- [x] `nx run client:vitest:test` — 422 client tests passing, including:
  - new test using verbatim probe data: `Retry-After: 2026-05-14 14:22:16` + `Date: GMT` → expects 600s
  - past-timestamp clamp to 0
  - missing Date header → `retryAfterSeconds: undefined`
  - existing integer-seconds form (synthetic — futureproof for if Rule.io aligns)
- [x] Lint clean for changed files
- [ ] Copilot review

## Notes for reviewers

- Pure parser fix. No public API change vs. #137; same `retryAfterSeconds` field, broader input acceptance.
- Hardcoded `RULE_SERVER_TZ = 'Europe/Stockholm'` is the one assumption that could need updating if Rule.io changes hosting region — flagged in code comment.
- The original PR's table claiming `X-RateLimit-*` is "absent everywhere" was based on probes of non-429 responses only and was overclaimed; the real-429 probe confirms `Retry-After` IS present on 429s, just in a non-standard format. Comment block is now accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)