### PR TITLE
feat(client): opt-in rate limiting in HttpTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ tsconfig.json               # path mappings for IDE autocompletion
 
 ## Contributing
 
+> **Before creating a feature branch**, make sure your local `develop` is up to date with `main`. Release commits land on `main` first and are fast-forwarded into `develop` afterwards — branching from a stale `develop` will pull those already-merged commits into your PR diff.
+>
+> ```bash
+> git fetch origin main
+> git checkout develop
+> git merge --ff-only origin/main
+> ```
+>
+> Then create your branch from the updated `develop`.
+
 - Start a branch from `develop`.
 - Use conventional commits (`feat(client): …`, `fix(rcml): …`, etc.) — they drive the version bumps.
 - Open a PR targeting `develop`; CI runs `nx affected -t eslint:lint test-ci build --parallel=3` on your changes.

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -7,6 +7,11 @@
 import { RuleClientError } from './errors.js';
 
 import { RULE_API_V2_BASE_URL, RULE_API_V3_BASE_URL } from './constants.js';
+import {
+  resolveRateLimitOptions,
+  type RateLimitOptions,
+  type ResolvedRateLimitOptions,
+} from './core/rate-limit.js';
 
 /** User-facing client configuration. All fields except `apiKey` have defaults. */
 export interface RuleClientConfig {
@@ -19,6 +24,15 @@ export interface RuleClientConfig {
   fetch?: typeof fetch;
   /** Enable debug logging. */
   debug?: boolean;
+  /**
+   * Opt-in client-side rate limiting. When present, every HTTP request is
+   * gated by a concurrency semaphore and retried on 429 according to the
+   * supplied options (server `Retry-After` is honored when available).
+   *
+   * Omit to disable — the client fires requests with no concurrency cap and
+   * surfaces 429s directly to the caller.
+   */
+  rateLimiting?: RateLimitOptions;
 }
 
 /** Fully-resolved configuration with every default applied. */
@@ -28,6 +42,8 @@ export interface ResolvedClientConfig {
   baseUrlV3: string;
   fetch: typeof fetch;
   debug: boolean;
+  /** Resolved rate-limit options, or `undefined` when rate limiting is off. */
+  rateLimiting?: ResolvedRateLimitOptions;
 }
 
 /**
@@ -50,5 +66,9 @@ export function resolveConfig(input: RuleClientConfig | string): ResolvedClientC
     baseUrlV3: config.baseUrlV3 ?? RULE_API_V3_BASE_URL,
     fetch: config.fetch ?? globalThis.fetch,
     debug: config.debug ?? false,
+    rateLimiting:
+      config.rateLimiting !== undefined
+        ? resolveRateLimitOptions(config.rateLimiting)
+        : undefined,
   };
 }

--- a/packages/client/src/core/rate-limit.test.ts
+++ b/packages/client/src/core/rate-limit.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RuleApiError } from '../errors.js';
+
+import {
+  computeRetryDelayMs,
+  createSemaphore,
+  RateLimitGate,
+  resolveRateLimitOptions,
+  type ResolvedRateLimitOptions,
+} from './rate-limit.js';
+
+function fixedRandom(value: number): () => number {
+  return () => value;
+}
+
+function makeOpts(
+  overrides: Partial<ResolvedRateLimitOptions> = {}
+): ResolvedRateLimitOptions {
+  return {
+    maxConcurrency: 4,
+    maxRetries: 2,
+    baseDelayMs: 1000,
+    maxDelayMs: 8000,
+    maxRetryAfterMs: 60_000,
+    onRetry: () => {},
+    sleep: () => Promise.resolve(),
+    random: fixedRandom(0.5),
+    ...overrides,
+  };
+}
+
+describe('resolveRateLimitOptions', () => {
+  it('applies defaults when fields are omitted', () => {
+    const opts = resolveRateLimitOptions({});
+
+    expect(opts.maxConcurrency).toBe(4);
+    expect(opts.maxRetries).toBe(2);
+    expect(opts.baseDelayMs).toBe(1000);
+    expect(opts.maxDelayMs).toBe(8000);
+    expect(opts.maxRetryAfterMs).toBe(60_000);
+  });
+
+  it('clamps numeric fields to safe minimums', () => {
+    const opts = resolveRateLimitOptions({
+      maxConcurrency: 0,
+      maxRetries: -3,
+      baseDelayMs: -1,
+      maxDelayMs: -1,
+      maxRetryAfterMs: -1,
+    });
+
+    expect(opts.maxConcurrency).toBe(1);
+    expect(opts.maxRetries).toBe(0);
+    expect(opts.baseDelayMs).toBe(0);
+    expect(opts.maxDelayMs).toBe(0);
+    expect(opts.maxRetryAfterMs).toBe(0);
+  });
+
+  it('passes user overrides through', () => {
+    const onRetry = vi.fn();
+    const sleep = vi.fn(() => Promise.resolve());
+    const random = vi.fn(() => 0.42);
+
+    const opts = resolveRateLimitOptions({
+      maxConcurrency: 7,
+      maxRetries: 5,
+      onRetry,
+      sleep,
+      random,
+    });
+
+    expect(opts.maxConcurrency).toBe(7);
+    expect(opts.maxRetries).toBe(5);
+    expect(opts.onRetry).toBe(onRetry);
+    expect(opts.sleep).toBe(sleep);
+    expect(opts.random).toBe(random);
+  });
+});
+
+describe('computeRetryDelayMs', () => {
+  it('honors Retry-After when within the cap', () => {
+    const result = computeRetryDelayMs(0, 30, makeOpts({ random: fixedRandom(0) }));
+
+    expect(result).toEqual({ delayMs: 30_000, honoredRetryAfter: true });
+  });
+
+  it('applies upward jitter (0–10 %) on top of Retry-After', () => {
+    const result = computeRetryDelayMs(0, 10, makeOpts({ random: fixedRandom(0.5) }));
+
+    // 10 s * (1 + 0.5 * 0.1) = 10500 ms
+    expect(result).toEqual({ delayMs: 10_500, honoredRetryAfter: true });
+  });
+
+  it('returns null when Retry-After exceeds maxRetryAfterMs', () => {
+    const result = computeRetryDelayMs(
+      0,
+      120,
+      makeOpts({ maxRetryAfterMs: 60_000 })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('clamps negative Retry-After to zero', () => {
+    const result = computeRetryDelayMs(0, -5, makeOpts({ random: fixedRandom(0) }));
+
+    expect(result).toEqual({ delayMs: 0, honoredRetryAfter: true });
+  });
+
+  it('uses exponential backoff when Retry-After is absent', () => {
+    // attempt 0 → base * 2^0 = 1000 ms; jitter 0.75 + 0.5 * 0.5 = 1.0
+    const r0 = computeRetryDelayMs(0, undefined, makeOpts({ random: fixedRandom(0.5) }));
+
+    expect(r0).toEqual({ delayMs: 1000, honoredRetryAfter: false });
+
+    // attempt 2 → base * 2^2 = 4000 ms
+    const r2 = computeRetryDelayMs(2, undefined, makeOpts({ random: fixedRandom(0.5) }));
+
+    expect(r2).toEqual({ delayMs: 4000, honoredRetryAfter: false });
+  });
+
+  it('caps exponential backoff at maxDelayMs', () => {
+    // attempt 5 would be 32 000 ms uncapped; cap is 8 000.
+    const result = computeRetryDelayMs(
+      5,
+      undefined,
+      makeOpts({ random: fixedRandom(0.5), maxDelayMs: 8000 })
+    );
+
+    expect(result?.delayMs).toBe(8000);
+  });
+});
+
+describe('createSemaphore', () => {
+  it('admits up to capacity concurrently and queues the rest', async () => {
+    const acquire = createSemaphore(2);
+
+    const r1 = await acquire();
+    const r2 = await acquire();
+
+    let third = false;
+    const p3 = acquire().then((release) => {
+      third = true;
+
+      return release;
+    });
+
+    // p3 hasn't resolved yet because both slots are held.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(third).toBe(false);
+
+    r1();
+    const r3 = await p3;
+
+    expect(third).toBe(true);
+
+    r2();
+    r3();
+  });
+
+  it('preserves FIFO order across queued waiters', async () => {
+    const acquire = createSemaphore(1);
+    const order: number[] = [];
+
+    const r0 = await acquire();
+    const p1 = acquire().then((release) => {
+      order.push(1);
+      release();
+    });
+    const p2 = acquire().then((release) => {
+      order.push(2);
+      release();
+    });
+    const p3 = acquire().then((release) => {
+      order.push(3);
+      release();
+    });
+
+    r0();
+    await Promise.all([p1, p2, p3]);
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('does not let active exceed capacity across release/acquire microtask gaps', async () => {
+    const capacity = 3;
+    const acquire = createSemaphore(capacity);
+    let active = 0;
+    let peak = 0;
+
+    async function task(): Promise<void> {
+      const release = await acquire();
+
+      active++;
+      if (active > peak) peak = active;
+      // Yield a microtask to interleave release/acquire ordering.
+      await Promise.resolve();
+      active--;
+      release();
+    }
+
+    await Promise.all(Array.from({ length: 20 }, () => task()));
+
+    expect(peak).toBeLessThanOrEqual(capacity);
+  });
+});
+
+describe('RateLimitGate', () => {
+  function rateLimited(retryAfterSeconds?: number): RuleApiError {
+    const error = new RuleApiError('Rate limited', 429);
+
+    if (retryAfterSeconds !== undefined) error.retryAfterSeconds = retryAfterSeconds;
+
+    return error;
+  }
+
+  it('passes successful results through without retrying', async () => {
+    const gate = new RateLimitGate(makeOpts());
+    const fn = vi.fn(() => Promise.resolve('ok'));
+
+    expect(await gate.run('label', fn)).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows non-429 errors immediately without retrying', async () => {
+    const gate = new RateLimitGate(makeOpts());
+    const error = new RuleApiError('boom', 500);
+    const fn = vi.fn(() => Promise.reject(error));
+
+    await expect(gate.run('label', fn)).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 429 up to maxRetries, then surfaces the last error', async () => {
+    const sleep = vi.fn(() => Promise.resolve());
+    const error = rateLimited();
+    const gate = new RateLimitGate(makeOpts({ maxRetries: 2, sleep }));
+    const fn = vi.fn(() => Promise.reject(error));
+
+    await expect(gate.run('label', fn)).rejects.toBe(error);
+    // 1 initial + 2 retries = 3 calls
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After over exponential backoff', async () => {
+    const sleep = vi.fn(() => Promise.resolve());
+    const error = rateLimited(10);
+    const gate = new RateLimitGate(
+      makeOpts({ maxRetries: 1, sleep, random: fixedRandom(0) })
+    );
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('ok');
+
+    expect(await gate.run('label', fn)).toBe('ok');
+    expect(sleep).toHaveBeenCalledWith(10_000);
+  });
+
+  it('rethrows immediately when Retry-After exceeds maxRetryAfterMs', async () => {
+    const sleep = vi.fn(() => Promise.resolve());
+    const error = rateLimited(120);
+    const gate = new RateLimitGate(
+      makeOpts({ maxRetries: 5, maxRetryAfterMs: 60_000, sleep })
+    );
+    const fn = vi.fn(() => Promise.reject(error));
+
+    await expect(gate.run('label', fn)).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('frees the slot during sleep so other callers can progress', async () => {
+    let resumeSleep: (() => void) | undefined;
+    const sleep = (): Promise<void> =>
+      new Promise<void>((resolve) => {
+        resumeSleep = resolve;
+      });
+    const error = rateLimited(1);
+    const gate = new RateLimitGate(
+      makeOpts({ maxConcurrency: 1, maxRetries: 1, sleep, random: fixedRandom(0) })
+    );
+
+    const slowFn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('slow ok');
+
+    const fastFn = vi.fn(() => Promise.resolve('fast ok'));
+
+    const slow = gate.run('slow', slowFn);
+
+    // Yield enough microtasks for slow to acquire, fail, release, and call sleep.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    const fast = gate.run('fast', fastFn);
+
+    expect(await fast).toBe('fast ok');
+
+    // Slow can finish only once we resume its sleep — and only then does it
+    // re-acquire the slot.
+    resumeSleep?.();
+    expect(await slow).toBe('slow ok');
+  });
+
+  it('invokes onRetry with attempt info', async () => {
+    const onRetry = vi.fn();
+    const error = rateLimited(2);
+    const gate = new RateLimitGate(
+      makeOpts({ maxRetries: 1, onRetry, random: fixedRandom(0) })
+    );
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('ok');
+
+    await gate.run('GET /x', fn);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith({
+      label: 'GET /x',
+      attempt: 1,
+      delayMs: 2000,
+      error,
+      honoredRetryAfter: true,
+    });
+  });
+
+  it('caps in-flight runs at maxConcurrency', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const released: Array<() => void> = [];
+    const gate = new RateLimitGate(makeOpts({ maxConcurrency: 2 }));
+
+    const fn = (): Promise<void> => {
+      inFlight++;
+      if (inFlight > peak) peak = inFlight;
+
+      return new Promise<void>((resolve) => {
+        released.push(() => {
+          inFlight--;
+          resolve();
+        });
+      });
+    };
+
+    const all = Promise.all(
+      Array.from({ length: 5 }, (_, i) => gate.run(`task-${i}`, fn))
+    );
+
+    // Let the first batch acquire.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    // Release one at a time so the queue drains in order.
+    while (released.length > 0) {
+      const next = released.shift();
+
+      next?.();
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    }
+
+    await all;
+
+    expect(peak).toBe(2);
+  });
+});

--- a/packages/client/src/core/rate-limit.ts
+++ b/packages/client/src/core/rate-limit.ts
@@ -1,0 +1,251 @@
+/**
+ * Optional client-side rate limiting for `HttpTransport`.
+ *
+ * Two mechanisms layered behind a single gate:
+ *
+ *   1. **Concurrency semaphore** — caps in-flight HTTP requests per client.
+ *      Keeps a single client from saturating Rule.io's per-account budget.
+ *   2. **Retry on 429** — when `RuleApiError.isRateLimited()`, sleep and
+ *      retry up to N times. Server-supplied `Retry-After` (parsed by the
+ *      transport into `error.retryAfterSeconds`) is honored when present;
+ *      exponential backoff with jitter is the fallback.
+ *
+ * Honoring `Retry-After` is load-bearing: Rule.io's documented 49 % error-rate
+ * trigger means retrying inside the server-suggested window counts toward the
+ * trigger and accelerates a longer block.
+ */
+
+import { RuleApiError } from '../errors.js';
+
+/**
+ * User-facing rate-limit configuration. All fields optional with defaults.
+ *
+ * @example
+ * ```typescript
+ * const client = new RuleClient({
+ *   apiKey: process.env.RULE_API_KEY!,
+ *   rateLimiting: {
+ *     maxConcurrency: 4,
+ *     maxRetries: 2,
+ *     onRetry: ({ label, attempt, delayMs, honoredRetryAfter }) => {
+ *       console.warn(
+ *         `[rate-limit] retry ${attempt} of ${label} in ${delayMs} ms` +
+ *           (honoredRetryAfter ? ' (server Retry-After)' : ' (backoff)')
+ *       );
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export interface RateLimitOptions {
+  /** Maximum concurrent in-flight HTTP requests. Default: 4. */
+  maxConcurrency?: number;
+  /** Number of retries on 429 (so total attempts = retries + 1). Default: 2. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff when no `Retry-After` header. Default: 1000. */
+  baseDelayMs?: number;
+  /** Cap in ms for the exponential-backoff fallback. Default: 8000. */
+  maxDelayMs?: number;
+  /**
+   * Cap in ms for honoring a server-supplied `Retry-After`. If the header
+   * asks for a wait longer than this, the gate gives up and rethrows the
+   * 429 rather than stalling the caller. Default: 60_000 (60 s).
+   */
+  maxRetryAfterMs?: number;
+  /** Hook invoked on each retry attempt. */
+  onRetry?: (info: RetryInfo) => void;
+  /** Sleep function (overridable for tests). */
+  sleep?: (ms: number) => Promise<void>;
+  /** RNG for jitter, in [0, 1). Overridable for tests. */
+  random?: () => number;
+}
+
+/**
+ * Diagnostic payload passed to {@link RateLimitOptions.onRetry} on each
+ * retry attempt. See {@link RateLimitOptions} for a usage example.
+ */
+export interface RetryInfo {
+  /** Caller-supplied label, e.g. an HTTP method + URL. */
+  label: string;
+  /** 1-indexed attempt number of the upcoming retry. */
+  attempt: number;
+  /** Computed delay in ms before the upcoming retry. */
+  delayMs: number;
+  /** The error that triggered the retry (always a 429 `RuleApiError`). */
+  error: unknown;
+  /**
+   * `true` when `delayMs` was derived from the server's `Retry-After`
+   * header; `false` when from exponential backoff.
+   */
+  honoredRetryAfter: boolean;
+}
+
+/** Resolved configuration with every default applied. */
+export interface ResolvedRateLimitOptions {
+  maxConcurrency: number;
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  maxRetryAfterMs: number;
+  onRetry: (info: RetryInfo) => void;
+  sleep: (ms: number) => Promise<void>;
+  random: () => number;
+}
+
+const DEFAULTS: ResolvedRateLimitOptions = {
+  maxConcurrency: 4,
+  maxRetries: 2,
+  baseDelayMs: 1000,
+  maxDelayMs: 8000,
+  maxRetryAfterMs: 60_000,
+  onRetry: () => {},
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random: Math.random,
+};
+
+export function resolveRateLimitOptions(
+  input: RateLimitOptions
+): ResolvedRateLimitOptions {
+  return {
+    maxConcurrency: Math.max(1, input.maxConcurrency ?? DEFAULTS.maxConcurrency),
+    maxRetries: Math.max(0, input.maxRetries ?? DEFAULTS.maxRetries),
+    baseDelayMs: Math.max(0, input.baseDelayMs ?? DEFAULTS.baseDelayMs),
+    maxDelayMs: Math.max(0, input.maxDelayMs ?? DEFAULTS.maxDelayMs),
+    maxRetryAfterMs: Math.max(0, input.maxRetryAfterMs ?? DEFAULTS.maxRetryAfterMs),
+    onRetry: input.onRetry ?? DEFAULTS.onRetry,
+    sleep: input.sleep ?? DEFAULTS.sleep,
+    random: input.random ?? DEFAULTS.random,
+  };
+}
+
+/**
+ * Tiny FIFO semaphore. `acquire()` resolves with a `release` function and
+ * preserves arrival order. Slot transfer is atomic on `release`: when a
+ * waiter is queued, the released slot is handed to it directly without
+ * decrementing `active`, so a parallel `acquire()` cannot race in during
+ * the microtask gap between release and the waiter resuming.
+ */
+export function createSemaphore(capacity: number): () => Promise<() => void> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const release = (): void => {
+    const next = queue.shift();
+
+    if (next) {
+      next();
+    } else {
+      active--;
+    }
+  };
+
+  return async function acquire(): Promise<() => void> {
+    if (active < capacity && queue.length === 0) {
+      active++;
+
+      return release;
+    }
+
+    await new Promise<void>((resolve) => queue.push(resolve));
+
+    return release;
+  };
+}
+
+/**
+ * Compute the delay before the next retry, or `null` to signal "give up
+ * and rethrow" (used when the server asks for a wait longer than the
+ * caller is willing to absorb).
+ *
+ * `attempt` is 0-indexed (first retry is `attempt = 0`).
+ */
+export function computeRetryDelayMs(
+  attempt: number,
+  retryAfterSeconds: number | undefined,
+  opts: ResolvedRateLimitOptions
+): { delayMs: number; honoredRetryAfter: boolean } | null {
+  if (retryAfterSeconds !== undefined) {
+    const requestedMs = Math.max(0, retryAfterSeconds * 1000);
+
+    if (requestedMs > opts.maxRetryAfterMs) return null;
+    // Small upward jitter (0–10 %) avoids the thundering-herd case where
+    // every client wakes the instant the rate-limit window rolls over.
+    const jitter = 1 + opts.random() * 0.1;
+
+    return { delayMs: Math.round(requestedMs * jitter), honoredRetryAfter: true };
+  }
+
+  const exponential = opts.baseDelayMs * Math.pow(2, attempt);
+  const capped = Math.min(exponential, opts.maxDelayMs);
+  const jitter = 0.75 + opts.random() * 0.5;
+
+  return { delayMs: Math.round(capped * jitter), honoredRetryAfter: false };
+}
+
+/**
+ * Holds the semaphore and retry policy. `run()` is the single entry point —
+ * call it with a label and an async function and it gates concurrency and
+ * retries 429 responses according to the resolved options.
+ */
+export class RateLimitGate {
+  private readonly acquire: () => Promise<() => void>;
+
+  constructor(private readonly opts: ResolvedRateLimitOptions) {
+    this.acquire = createSemaphore(opts.maxConcurrency);
+  }
+
+  async run<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.opts.maxRetries; attempt++) {
+      const rawRelease = await this.acquire();
+      // Each acquired slot must release exactly once. The retry path
+      // releases before sleeping (so other callers can progress), then
+      // the `finally` would double-free without this guard.
+      let released = false;
+
+      const release = (): void => {
+        if (released) return;
+        released = true;
+        rawRelease();
+      };
+
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error;
+
+        if (
+          !(error instanceof RuleApiError) ||
+          !error.isRateLimited() ||
+          attempt === this.opts.maxRetries
+        ) {
+          throw error;
+        }
+
+        const next = computeRetryDelayMs(attempt, error.retryAfterSeconds, this.opts);
+
+        // Server asked for a longer wait than we're willing to absorb —
+        // surface the 429 immediately rather than stalling the caller.
+        if (next === null) throw error;
+        this.opts.onRetry({
+          label,
+          attempt: attempt + 1,
+          delayMs: next.delayMs,
+          error,
+          honoredRetryAfter: next.honoredRetryAfter,
+        });
+        // Free the slot before sleeping so other callers can make
+        // progress while we back off; otherwise N concurrent retries
+        // would all hold their slots and deadlock the semaphore.
+        release();
+        await this.opts.sleep(next.delayMs);
+        continue;
+      } finally {
+        release();
+      }
+    }
+
+    throw lastError;
+  }
+}

--- a/packages/client/src/core/transport.test.ts
+++ b/packages/client/src/core/transport.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RuleApiError } from '../errors.js';
 
@@ -10,15 +10,24 @@ import {
   createMockTextResponse,
   type MockFetch,
 } from './mock-fetch.js';
+import {
+  resolveRateLimitOptions,
+  type RateLimitOptions,
+} from './rate-limit.js';
 import { HttpTransport, type TransportConfig } from './transport.js';
 
-function makeTransport(fetchMock: MockFetch, debug = false): HttpTransport {
+function makeTransport(
+  fetchMock: MockFetch,
+  debug = false,
+  rateLimiting?: RateLimitOptions
+): HttpTransport {
   const config: TransportConfig = {
     apiKey: 'test-key',
     baseUrlV2: 'https://app.rule.io/api/v2',
     baseUrlV3: 'https://app.rule.io/api/v3',
     fetch: fetchMock,
     debug,
+    ...(rateLimiting ? { rateLimiting: resolveRateLimitOptions(rateLimiting) } : {}),
   };
 
   return new HttpTransport(config);
@@ -420,6 +429,98 @@ describe('HttpTransport', () => {
         rateLimitRemaining: undefined,
         errorPercentLimit: undefined,
       });
+    });
+  });
+
+  describe('rate-limit gate (opt-in)', () => {
+    it('does not retry or gate when rateLimiting is omitted', async () => {
+      // 429 surfaces directly; no retries.
+      fetchMock.mockResolvedValueOnce(createMockErrorResponse('', 429));
+      const t = makeTransport(fetchMock);
+
+      await expect(t.get('/x')).rejects.toMatchObject({ statusCode: 429 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 429 and resolves on the next success', async () => {
+      fetchMock
+        .mockResolvedValueOnce(createMockErrorResponse('', 429, { 'Retry-After': '1' }))
+        .mockResolvedValueOnce(createMockResponse({ ok: true }));
+
+      const sleep = vi.fn(() => Promise.resolve());
+      const t = makeTransport(fetchMock, false, {
+        maxConcurrency: 1,
+        maxRetries: 2,
+        sleep,
+        random: () => 0,
+      });
+
+      await expect(t.get('/x')).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // First retry waits the server-supplied 1 s (no jitter with random=0).
+      expect(sleep).toHaveBeenCalledWith(1000);
+    });
+
+    it('honors RuleApiError.retryAfterSeconds parsed from the timestamp form', async () => {
+      // Real-world: Rule.io v3 emits Retry-After as a server-local
+      // (Stockholm) wall timestamp and the transport parses it into seconds
+      // by referencing the response `Date` header. May 2026 = CEST (UTC+2),
+      // so 12:22:11 GMT corresponds to 14:22:11 Stockholm wall — a 5 s gap
+      // to the retry-after wall time.
+      fetchMock
+        .mockResolvedValueOnce(
+          createMockErrorResponse('', 429, {
+            'Retry-After': '2026-05-14 14:22:16',
+            Date: 'Thu, 14 May 2026 12:22:11 GMT',
+          })
+        )
+        .mockResolvedValueOnce(createMockResponse({ ok: true }));
+
+      const sleep = vi.fn(() => Promise.resolve());
+      const t = makeTransport(fetchMock, false, {
+        maxConcurrency: 1,
+        maxRetries: 1,
+        sleep,
+        random: () => 0,
+      });
+
+      await t.get('/x');
+      // 14:22:16 − 14:22:11 = 5 s
+      expect(sleep).toHaveBeenCalledWith(5000);
+    });
+
+    it('caps in-flight HTTP requests at maxConcurrency', async () => {
+      let inFlight = 0;
+      let peak = 0;
+      const releases: Array<() => void> = [];
+
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            inFlight++;
+            if (inFlight > peak) peak = inFlight;
+            releases.push(() => {
+              inFlight--;
+              resolve(createMockResponse({ ok: true }));
+            });
+          })
+      );
+
+      const t = makeTransport(fetchMock, false, { maxConcurrency: 2 });
+      const all = Promise.all(Array.from({ length: 5 }, () => t.get('/x')));
+
+      // Let the first batch enter fetch.
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      while (releases.length > 0) {
+        releases.shift()?.();
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+      }
+
+      await all;
+
+      expect(peak).toBe(2);
+      expect(fetchMock).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/packages/client/src/core/transport.ts
+++ b/packages/client/src/core/transport.ts
@@ -9,9 +9,12 @@
  * - v3 validation-error normalization
  * - 204 No Content → `{ success: true }` JSON convenience
  * - debug logging
+ * - opt-in client-side rate limiting (concurrency cap + 429 retry that
+ *   honors `Retry-After`), enabled by `TransportConfig.rateLimiting`.
  */
 
 import { RuleApiError, type RuleValidationErrors } from '../errors.js';
+import { RateLimitGate, type ResolvedRateLimitOptions } from './rate-limit.js';
 
 /**
  * Resolved transport configuration. Every field is required — the caller
@@ -23,6 +26,12 @@ export interface TransportConfig {
   baseUrlV3: string;
   fetch: typeof fetch;
   debug: boolean;
+  /**
+   * Optional resolved rate-limit options. When present, every HTTP request
+   * is gated by a concurrency semaphore and retried on 429. When absent,
+   * requests fire without gating and 429s surface directly.
+   */
+  rateLimiting?: ResolvedRateLimitOptions;
 }
 
 export type ApiVersion = 'v2' | 'v3';
@@ -43,7 +52,11 @@ interface JsonEnvelope {
 }
 
 export class HttpTransport {
-  constructor(private readonly config: TransportConfig) {}
+  private readonly gate: RateLimitGate | undefined;
+
+  constructor(private readonly config: TransportConfig) {
+    this.gate = config.rateLimiting ? new RateLimitGate(config.rateLimiting) : undefined;
+  }
 
   get<T>(endpoint: string, opts: RequestOptions = {}): Promise<T> {
     return this.requestJson<T>('GET', endpoint, opts);
@@ -114,11 +127,32 @@ export class HttpTransport {
    *
    * Callers that need the response object directly (e.g. async fire-and-forget
    * endpoints that ignore the body) use this instead of `requestJson`.
+   *
+   * When `rateLimiting` is configured, the call is gated by a concurrency
+   * semaphore and retried on 429 according to the resolved options.
    */
   async fetchRaw(
     method: string,
     endpoint: string,
     opts: RequestOptions = {}
+  ): Promise<Response> {
+    if (this.gate === undefined) {
+      return this.doFetchRaw(method, endpoint, opts);
+    }
+
+    return this.gate.run(`${method} ${endpoint}`, () =>
+      this.doFetchRaw(method, endpoint, opts)
+    );
+  }
+
+  /**
+   * The actual HTTP send. Extracted from {@link fetchRaw} so the rate-limit
+   * gate can wrap it without recursing through itself.
+   */
+  private async doFetchRaw(
+    method: string,
+    endpoint: string,
+    opts: RequestOptions
   ): Promise<Response> {
     const version: ApiVersion = opts.version ?? 'v3';
     const baseUrl = version === 'v3' ? this.config.baseUrlV3 : this.config.baseUrlV2;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -20,6 +20,7 @@ export type {
 
 // ── Client configuration ─────────────────────────────────────────────────────
 export type { RuleClientConfig } from './config.js';
+export type { RateLimitOptions, RetryInfo } from './core/rate-limit.js';
 
 // ── Subscribers (v2 + v3) ────────────────────────────────────────────────────
 export type {


### PR DESCRIPTION
## Summary
- Adds `rateLimiting?: RateLimitOptions` to `RuleClientConfig`. When configured, every HTTP request (`HttpTransport.fetchRaw`) is gated by a FIFO concurrency semaphore and retried on 429.
- Honors server-supplied `Retry-After` via `RuleApiError.retryAfterSeconds`. Falls back to exponential backoff with jitter when the header is absent.
- New `maxRetryAfterMs` cap rethrows the 429 immediately when the server asks for a longer wait than the caller is willing to absorb — keeps tool-call latency bounded.
- Opt-in only: omitting `rateLimiting` preserves the prior fire-and-surface-429 behavior. No breaking changes.

## Why
Rule.io's documented 49 % error-rate trigger means retrying inside the server-suggested window *counts toward* the trigger and accelerates a longer block. Letting the transport own retry-with-Retry-After is a single choke point — every request goes through here, including the namespace clients' paginated fan-outs (`listSubscribersByTagIds`, etc.) that previously slipped past a per-method gate one level up.

This replaces the Proxy-based wrapper that has been living in the rule-io-mcp-server repo (`src/util/rate-limit.ts`). That wrapper:
1. Couldn't see `Retry-After` because it gated SDK methods, not HTTP requests, and only had access to `RuleApiError.statusCode`.
2. Required ~290 lines of getter-detection / recursive-namespace machinery to wrap the lazy namespace clients without breaking `Date#toISOString` etc.
3. Under-counted requests when a single SDK method paginated internally — one slot held while N HTTP calls fired.

Moving the gate into `HttpTransport.fetchRaw` solves all three.

## Test plan
- [x] 20 new unit tests in `packages/client/src/core/rate-limit.test.ts` cover the resolver, semaphore (concurrency cap, FIFO order, microtask-gap safety), the delay computer (Retry-After honor / cap / negative clamp / exponential fallback / max-delay cap), and the gate (success passthrough, non-429 passthrough, retry-then-succeed, retry-exhaustion, Retry-After-over-cap rethrow, slot-freed-during-sleep, `onRetry` info, peak concurrency).
- [x] 4 new integration tests in `packages/client/src/core/transport.test.ts` exercise the gate end-to-end through `HttpTransport.fetchRaw`, including the real-world Rule.io v3 timestamp-form `Retry-After`.
- [x] All 446 existing + new tests pass; type-check + lint clean.

## Companion change
The MCP server PR will swap its Proxy wrapper for this in a follow-up PR once `@rulecom/client` ships a release with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)