### PR TITLE
fix(rcml): apply theme font-style classes to body elements + local dev improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "release": "nx release",
     "local-registry": "nx run rule-io-sdk:local-registry",
     "publish:local": "nx run-many -t build && nx release publish --registry http://localhost:4873",
+    "republish:local": "rm -rf tmp/local-registry/storage/@rulecom && pnpm publish:local",
     "daemon:restart": "nx daemon --stop && nx daemon --start",
     "docs:generate": "nx run docs:generate",
     "docs:check": "nx run docs:check",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "nx release",
     "local-registry": "nx run rule-io-sdk:local-registry",
     "publish:local": "nx run-many -t build && nx release publish --registry http://localhost:4873",
-    "republish:local": "rm -rf tmp/local-registry/storage/@rulecom && pnpm publish:local",
+    "republish:local": "rm -rf tmp/local-registry/storage/@rulecom && npm run publish:local",
     "daemon:restart": "nx daemon --stop && nx daemon --start",
     "docs:generate": "nx run docs:generate",
     "docs:check": "nx run docs:check",

--- a/packages/rcml/src/email/apply-theme.test.ts
+++ b/packages/rcml/src/email/apply-theme.test.ts
@@ -743,11 +743,13 @@ describe('applyTheme — logo src propagation to body', () => {
     expect(logo?.attributes?.['src']).toBeUndefined()
   })
 
-  it('does not modify the body when no logo image is in the patch', () => {
+  it('does not mutate the original body even when no logo image is in the patch', () => {
     const doc = docWithLogoInBody()
-    const result = applyTheme(doc, { brandStyleId: 1 })
+    const bodySnapshot = JSON.stringify(doc.children[1])
 
-    expect(doc.children[1]).toBe(result.children[1])
+    applyTheme(doc, { brandStyleId: 1 })
+
+    expect(JSON.stringify(doc.children[1])).toBe(bodySnapshot)
   })
 
   it('does not mutate the input body', () => {

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -131,6 +131,7 @@ export function applyTheme(
       const logoUrl = patch.images?.find(
         (img) => img.type === EmailThemeImageType.Logo
       )?.url
+
       updatedBody = applyBodyDefaults(updatedBody, logoUrl)
     }
 

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -127,20 +127,20 @@ export function applyTheme(
       }
     }
 
-    {
-      const logoImages = patch.images?.filter(
-        (img) => img.type === EmailThemeImageType.Logo
-      )
-      const logoUrl = logoImages && logoImages.length > 0
-        ? logoImages[logoImages.length - 1]!.url
-        : undefined
-
-      updatedBody = applyBodyDefaults(updatedBody, logoUrl)
-    }
-
     if (patch.links && patch.links.length > 0) {
       upsertSocialOverlay(attrChildren, patch.links)
     }
+  }
+
+  {
+    const logoImages = patch.images?.filter(
+      (img) => img.type === EmailThemeImageType.Logo
+    )
+    const logoUrl = logoImages && logoImages.length > 0
+      ? logoImages[logoImages.length - 1]!.url
+      : undefined
+
+    updatedBody = applyBodyDefaults(updatedBody, logoUrl)
   }
 
   if (patch.fonts && patch.fonts.length > 0) {

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -23,7 +23,7 @@ import { DEFAULT_FONT_STYLES_MAP } from './theme-defaults.js'
 import {
   type AnyAttrChild,
   EmailThemeApplyError,
-  applyLogoSrcToBody,
+  applyBodyDefaults,
   cloneHead,
   findOrCreateAttributes,
   overlayFontsInHead,
@@ -109,7 +109,6 @@ export function applyTheme(
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (image.type === EmailThemeImageType.Logo) {
           upsertLogoClass(attrChildren, image.url)
-          updatedBody = applyLogoSrcToBody(updatedBody, image.url)
         }
       }
     }
@@ -126,6 +125,13 @@ export function applyTheme(
 
         upsertFontStyleClass(attrChildren, merged, partial.type)
       }
+    }
+
+    if (hasEntries(patch.images) || hasEntries(patch.fontStyles)) {
+      const logoUrl = patch.images?.find(
+        (img) => img.type === EmailThemeImageType.Logo
+      )?.url
+      updatedBody = applyBodyDefaults(updatedBody, logoUrl)
     }
 
     if (patch.links && patch.links.length > 0) {

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -134,11 +134,13 @@ export function applyTheme(
 
   {
     const logoImages = patch.images?.filter(
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       (img) => img.type === EmailThemeImageType.Logo
     )
-    const logoUrl = logoImages && logoImages.length > 0
-      ? logoImages[logoImages.length - 1]!.url
+    const lastLogo = logoImages && logoImages.length > 0
+      ? logoImages[logoImages.length - 1]
       : undefined
+    const logoUrl = lastLogo?.url
 
     updatedBody = applyBodyDefaults(updatedBody, logoUrl)
   }

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -127,8 +127,8 @@ export function applyTheme(
       }
     }
 
-    if (hasEntries(patch.images) || hasEntries(patch.fontStyles)) {
-      const logoUrl = patch.images?.find(
+    {
+      const logoUrl = patch.images?.findLast(
         (img) => img.type === EmailThemeImageType.Logo
       )?.url
 

--- a/packages/rcml/src/email/apply-theme.ts
+++ b/packages/rcml/src/email/apply-theme.ts
@@ -128,9 +128,12 @@ export function applyTheme(
     }
 
     {
-      const logoUrl = patch.images?.findLast(
+      const logoImages = patch.images?.filter(
         (img) => img.type === EmailThemeImageType.Logo
-      )?.url
+      )
+      const logoUrl = logoImages && logoImages.length > 0
+        ? logoImages[logoImages.length - 1]!.url
+        : undefined
 
       updatedBody = applyBodyDefaults(updatedBody, logoUrl)
     }

--- a/packages/rcml/src/email/schema/specs.ts
+++ b/packages/rcml/src/email/schema/specs.ts
@@ -685,7 +685,7 @@ const loopSpec = {
 
 const textSpec = {
   category: 'content',
-  description: 'Rich-text paragraph block. The content is a full RFM document — supports paragraphs, bullet/ordered lists, hard breaks, alignment blocks, inline marks, links, and dynamic placeholders. Renders as an HTML table cell.',
+  description: 'Rich-text paragraph block. The content is a full RFM document — supports paragraphs, bullet/ordered lists, hard breaks, alignment blocks, inline marks, links, and dynamic placeholders. Renders as an HTML table cell. Theme font and colour styling is applied via the rc-class attribute (default: "rcml-p-style"); applyTheme sets this automatically on unstyled nodes.',
   attrs: {
     align: {
       validator: V.TextAlign,
@@ -710,8 +710,8 @@ const textSpec = {
     },
     'rc-class': {
       validator: V.String,
-      description: 'Name of an rc-class defined in rc-head whose styles are inherited by this node.',
-      examples: ['body-text'],
+      description: 'Name of an rc-class defined in rc-head whose styles are inherited by this node. applyTheme automatically sets this to "rcml-p-style" (the theme paragraph style) on nodes that have no class. Override only when applying a different named style.',
+      examples: ['rcml-p-style'],
     },
     'font-family': {
       validator: V.FontFamily,
@@ -800,7 +800,7 @@ const textSpec = {
 
 const headingSpec = {
   category: 'content',
-  description: 'Heading block (h1–h6 semantics set inside the RFM content). Supports the same full RFM feature set as rc-text. Visually prominent text rendered as an HTML table cell.',
+  description: 'Heading block. Supports the same full RFM feature set as rc-text. Visually prominent text rendered as an HTML table cell. There is no level attribute — heading level semantics (H1–H4) are expressed through the rc-class attribute: use "rcml-h1-style", "rcml-h2-style", "rcml-h3-style", or "rcml-h4-style" to inherit the corresponding theme style. applyTheme defaults to "rcml-h1-style" on nodes that have no rc-class.',
   attrs: {
     align: {
       validator: V.TextAlign,
@@ -830,8 +830,8 @@ const headingSpec = {
     },
     'rc-class': {
       validator: V.String,
-      description: 'Name of an rc-class whose styles are inherited by this heading.',
-      examples: ['section-heading'],
+      description: 'Name of an rc-class defined in rc-head whose styles are inherited by this heading. applyTheme automatically sets this to "rcml-h1-style" (the theme H1 style) on nodes that have no class. Use other heading styles by setting the class explicitly.',
+      examples: ['rcml-h1-style', 'rcml-h2-style', 'rcml-h3-style', 'rcml-h4-style'],
     },
     'font-family': {
       validator: V.FontFamily,
@@ -920,7 +920,7 @@ const headingSpec = {
 
 const buttonSpec = {
   category: 'content',
-  description: 'Clickable call-to-action button. The label is an Inline RFM document (single paragraph — no lists or alignment blocks). Renders as a styled anchor tag inside a table cell.',
+  description: 'Clickable call-to-action button. The label is an Inline RFM document (single paragraph — no lists or alignment blocks). Renders as a styled anchor tag inside a table cell. Theme label font styling is applied via the rc-class attribute (default: "rcml-label-style"); applyTheme sets this automatically on unstyled nodes.',
   attrs: {
     align: {
       validator: V.Align,
@@ -982,8 +982,8 @@ const buttonSpec = {
     },
     'rc-class': {
       validator: V.String,
-      description: 'Name of an rc-class whose styles are inherited by this button.',
-      examples: ['primary-button'],
+      description: 'Name of an rc-class defined in rc-head whose styles are inherited by this button. applyTheme automatically sets this to "rcml-label-style" (the theme button-label style) on nodes that have no class. Override only when applying a different named style.',
+      examples: ['rcml-label-style'],
     },
     'font-family': {
       validator: V.FontFamily,
@@ -1233,7 +1233,7 @@ const imageSpec = {
 
 const logoSpec = {
   category: 'content',
-  description: 'Brand logo image. Functionally identical to rc-image but semantically distinct — the editor treats it as the document logo and it can inherit from a brand style.',
+  description: 'Brand logo image. Functionally identical to rc-image but semantically distinct — the editor treats it as the document logo and wires it to the brand theme. Theme logo URL and sizing are applied via the rc-class attribute (default: "rcml-logo-style"); applyTheme sets this automatically on unstyled nodes and also patches the src attribute with the brand logo URL.',
   attrs: {
     align: {
       validator: V.Align,
@@ -1328,8 +1328,8 @@ const logoSpec = {
     },
     'rc-class': {
       validator: V.String,
-      description: 'Name of an rc-class whose styles are inherited by this logo.',
-      examples: ['brand-logo'],
+      description: 'Name of an rc-class defined in rc-head whose styles are inherited by this logo. applyTheme automatically sets this to "rcml-logo-style" (the theme logo style) on nodes that have no class, and also applies the brand logo URL. Override only when applying a different named style.',
+      examples: ['rcml-logo-style'],
     },
   },
   isLeaf: true,

--- a/packages/rcml/src/email/theme/theme-rcml.ts
+++ b/packages/rcml/src/email/theme/theme-rcml.ts
@@ -526,37 +526,71 @@ type LooseNode = {
   children?: LooseNode[]
 }
 
+function referencesLogoClass(rcClass: string, mainClass: string, initialClass: string): boolean {
+  const classes = rcClass.split(/\s+/)
+
+  return classes.includes(mainClass) || classes.includes(initialClass)
+}
+
 /**
- * Deep-clone the body and propagate `logoUrl` onto every `<rc-logo>` node
- * whose `rc-class` references the logo class (main or initial seed). Also
- * ensures each updated node carries a `width` attribute, defaulting to
- * `'96px'` when unset, so the logo is always size-constrained.
- *
- * @param body    - The body node. Not mutated.
- * @param logoUrl - The logo image URL (already validated by the caller).
- * @returns       A new body with matching logo nodes updated.
+ * Maps tag name to the default `rc-class` name for nodes that have no
+ * existing `rc-class` attribute.
  *
  * @internal
  */
-export function applyLogoSrcToBody(body: RcmlBody, logoUrl: string): RcmlBody {
-  const cloned = JSON.parse(JSON.stringify(body)) as RcmlBody
-  const { main: mainClass, initial: initialClass } =
-    CLASS_NAMES_BY_IMAGE_TYPE_MAP[EmailThemeImageType.Logo]
+const DEFAULT_RC_CLASS_BY_TAG: Partial<Record<string, string>> = {
+  'rc-heading': CLASS_NAMES_BY_FONT_STYLE_TYPE_MAP[EmailThemeFontStyleType.H1],
+  'rc-text': CLASS_NAMES_BY_FONT_STYLE_TYPE_MAP[EmailThemeFontStyleType.Paragraph],
+  'rc-button': CLASS_NAMES_BY_FONT_STYLE_TYPE_MAP[EmailThemeFontStyleType.ButtonLabel],
+  'rc-logo': CLASS_NAMES_BY_IMAGE_TYPE_MAP[EmailThemeImageType.Logo].main,
+}
 
-  patchLogoNodes(cloned.children as unknown as LooseNode[], logoUrl, mainClass, initialClass)
+/**
+ * Deep-clone the body and apply two classes of defaults in a single pass:
+ *
+ * 1. For `rc-heading`, `rc-text`, `rc-button`, and `rc-logo` nodes with no
+ *    `rc-class` attribute, set the theme default class (`rcml-h1-style`,
+ *    `rcml-p-style`, `rcml-label-style`, `rcml-logo-style` respectively).
+ *
+ * 2. For `rc-logo` nodes that reference the logo class (main or initial
+ *    seed), propagate `logoUrl` as `src` and ensure a `width` default of
+ *    `'96px'` when unset. This only runs when `logoUrl` is provided.
+ *
+ * Nodes that already carry an `rc-class` attribute are left untouched by
+ * step 1. Step 2 applies regardless of whether step 1 just set the class.
+ *
+ * @param body    - The body node. Not mutated.
+ * @param logoUrl - Logo image URL. When provided, logo `src` is patched.
+ * @returns       A new body with defaults applied.
+ *
+ * @internal
+ */
+export function applyBodyDefaults(body: RcmlBody, logoUrl?: string): RcmlBody {
+  const cloned = JSON.parse(JSON.stringify(body)) as RcmlBody
+
+  patchBodyDefaults(cloned.children as unknown as LooseNode[], logoUrl)
 
   return cloned
 }
 
-function patchLogoNodes(
-  nodes: LooseNode[],
-  logoUrl: string,
-  mainClass: string,
-  initialClass: string
-): void {
+function patchBodyDefaults(nodes: LooseNode[], logoUrl: string | undefined): void {
   for (const node of nodes) {
-    if (node.tagName === 'rc-logo') {
+    // Step 1 — add default rc-class to unstyled content nodes
+    const defaultClass = DEFAULT_RC_CLASS_BY_TAG[node.tagName]
+
+    if (defaultClass) {
+      const existing = node.attributes?.['rc-class']
+
+      if (!existing || (typeof existing === 'string' && existing.trim() === '')) {
+        node.attributes = { ...(node.attributes ?? {}), 'rc-class': defaultClass }
+      }
+    }
+
+    // Step 2 — patch rc-logo src/width (rc-class is guaranteed present after step 1)
+    if (node.tagName === 'rc-logo' && logoUrl !== undefined) {
       const rcClass = node.attributes?.['rc-class']
+      const { main: mainClass, initial: initialClass } =
+        CLASS_NAMES_BY_IMAGE_TYPE_MAP[EmailThemeImageType.Logo]
 
       if (typeof rcClass === 'string' && referencesLogoClass(rcClass, mainClass, initialClass)) {
         const attrs = node.attributes ?? {}
@@ -570,15 +604,9 @@ function patchLogoNodes(
     }
 
     if (node.children) {
-      patchLogoNodes(node.children, logoUrl, mainClass, initialClass)
+      patchBodyDefaults(node.children, logoUrl)
     }
   }
-}
-
-function referencesLogoClass(rcClass: string, mainClass: string, initialClass: string): boolean {
-  const classes = rcClass.split(/\s+/)
-
-  return classes.includes(mainClass) || classes.includes(initialClass)
 }
 
 /**

--- a/packages/rcml/src/email/validate-email-template.test.ts
+++ b/packages/rcml/src/email/validate-email-template.test.ts
@@ -304,6 +304,69 @@ describe('validateEmailTemplate — XML string input', () => {
   })
 })
 
+describe('validateColumnWidths integration via safeValidateEmailTemplate', () => {
+  it('flags a multi-column section whose percentage widths do not sum to 100%', () => {
+    const doc: RcmlDocument = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          attributes: { width: '600px' },
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                { tagName: 'rc-column', attributes: { width: '40%' }, children: [] },
+                { tagName: 'rc-column', attributes: { width: '40%' }, children: [] },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as RcmlDocument
+    const result = safeValidateEmailTemplate(doc)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some(
+        (e) => e.code === EmailTemplateErrorCodes.ATTR_INVALID_VALUE && e.message.includes('sum to')
+      )).toBe(true)
+    }
+  })
+
+  it('accepts a multi-column section whose percentage widths sum to 100%', () => {
+    const doc: RcmlDocument = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          attributes: { width: '600px' },
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                { tagName: 'rc-column', attributes: { width: '50%' }, children: [] },
+                { tagName: 'rc-column', attributes: { width: '50%' }, children: [] },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as RcmlDocument
+    const result = safeValidateEmailTemplate(doc)
+
+    if (!result.success) {
+      const columnSumErrors = result.errors.filter(
+        (e) => e.code === EmailTemplateErrorCodes.ATTR_INVALID_VALUE && e.message.includes('sum to')
+      )
+
+      expect(columnSumErrors).toHaveLength(0)
+    }
+  })
+})
+
 describe('EmailTemplateValidationError shape', () => {
   it('matches the expected error format', () => {
     const bad = { tagName: 'rcml' } as unknown as RcmlDocument

--- a/packages/rcml/src/email/validate-email-template.test.ts
+++ b/packages/rcml/src/email/validate-email-template.test.ts
@@ -328,6 +328,7 @@ describe('validateColumnWidths integration via safeValidateEmailTemplate', () =>
     const result = safeValidateEmailTemplate(doc)
 
     expect(result.success).toBe(false)
+
     if (!result.success) {
       expect(result.errors.some(
         (e) => e.code === EmailTemplateErrorCodes.ATTR_INVALID_VALUE && e.message.includes('sum to')

--- a/packages/rcml/src/email/validate-email-template.ts
+++ b/packages/rcml/src/email/validate-email-template.ts
@@ -5,17 +5,23 @@
  * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. All
  * heavy lifting is delegated to the internal helpers under `./validator/`.
  *
- * The validator merges three passes into one unified issue list:
+ * The validator merges four passes into one unified issue list:
  *   1. AJV structural check (see `./validator/ajv-validate.ts`).
  *   2. Zod per-attribute value check (see `./validator/attr-value-validate.ts`).
  *   3. ProseMirror content delegation (see `./validator/content-validate.ts`).
+ *   4. Cross-element column-width check (see `./validator/column-width-validate.ts`).
  *
  * Input may be either an `RcmlDocument` JSON AST or an RCML XML string; XML
  * is parsed first via {@link safeXmlToRcml}.
  */
 
 import type { RcmlDocument } from './rcml-types.js'
-import { validateAttrValues, validateContent, validateStructure } from './validator/index.js'
+import {
+  validateAttrValues,
+  validateColumnWidths,
+  validateContent,
+  validateStructure,
+} from './validator/index.js'
 import { RcmlXmlErrorCodes, safeXmlToRcml } from './xml-to-rcml.js'
 
 // ─── Error codes ─────────────────────────────────────────────────────────────
@@ -173,6 +179,7 @@ export function safeValidateEmailTemplate(input: RcmlDocument | string): SafeVal
   issues.push(...validateStructure(json))
   issues.push(...validateAttrValues(json))
   issues.push(...validateContent(json))
+  issues.push(...validateColumnWidths(json))
 
   if (issues.length > 0) {
     return { success: false, errors: issues }

--- a/packages/rcml/src/email/validator/column-width-validate.test.ts
+++ b/packages/rcml/src/email/validator/column-width-validate.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { validateColumnWidths } from './column-width-validate.js'
+
+const section = (columns: unknown[]) => ({
+  tagName: 'rc-section',
+  children: columns,
+})
+
+const col = (width?: string) => ({
+  tagName: 'rc-column',
+  attributes: width !== undefined ? { width } : {},
+  children: [],
+})
+
+const colNoAttrs = () => ({
+  tagName: 'rc-column',
+  children: [],
+})
+
+describe('validateColumnWidths — single-column sections', () => {
+  it('returns no issues for a single column with no width', () => {
+    expect(validateColumnWidths({ tagName: 'rcml', children: [section([colNoAttrs()])] })).toEqual(
+      [],
+    )
+  })
+
+  it('returns no issues for a single column with a pixel width', () => {
+    expect(
+      validateColumnWidths({ tagName: 'rcml', children: [section([col('200px')])] }),
+    ).toEqual([])
+  })
+})
+
+describe('validateColumnWidths — multi-column sections', () => {
+  it('returns no issues when two columns sum to 100%', () => {
+    expect(
+      validateColumnWidths({ tagName: 'rcml', children: [section([col('50%'), col('50%')])] }),
+    ).toEqual([])
+  })
+
+  it('returns no issues when three columns sum to 100%', () => {
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([col('33%'), col('33%'), col('34%')])],
+      }),
+    ).toEqual([])
+  })
+
+  it('flags a column with a pixel width in a multi-column section', () => {
+    const issues = validateColumnWidths({
+      tagName: 'rcml',
+      children: [section([col('80px'), col('50%')])],
+    })
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('ATTR_INVALID_VALUE')
+    expect(issues[0].path).toContain('width')
+    expect(issues[0].message).toContain('"80px"')
+  })
+
+  it('flags a column with no width attribute in a multi-column section', () => {
+    const issues = validateColumnWidths({
+      tagName: 'rcml',
+      children: [section([colNoAttrs(), col('50%')])],
+    })
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('ATTR_INVALID_VALUE')
+    expect(issues[0].message).toMatch(/must have a percentage width/)
+  })
+
+  it('flags two columns where neither has a width', () => {
+    const issues = validateColumnWidths({
+      tagName: 'rcml',
+      children: [section([colNoAttrs(), colNoAttrs()])],
+    })
+
+    expect(issues).toHaveLength(2)
+  })
+
+  it('flags widths that do not sum to 100%', () => {
+    const issues = validateColumnWidths({
+      tagName: 'rcml',
+      children: [section([col('40%'), col('40%')])],
+    })
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0].message).toMatch(/sum to 80%/)
+  })
+
+  it('allows floating-point rounding within ±0.5%', () => {
+    // 33.33% × 3 = 99.99% — should not produce an error
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([col('33.33%'), col('33.33%'), col('33.34%')])],
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('validateColumnWidths — nesting', () => {
+  it('validates sections nested inside rc-wrapper or rc-body', () => {
+    const doc = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [section([colNoAttrs(), colNoAttrs()])],
+        },
+      ],
+    }
+    const issues = validateColumnWidths(doc)
+
+    expect(issues.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/rcml/src/email/validator/column-width-validate.test.ts
+++ b/packages/rcml/src/email/validator/column-width-validate.test.ts
@@ -47,39 +47,34 @@ describe('validateColumnWidths — multi-column sections', () => {
     ).toEqual([])
   })
 
-  it('flags a column with a pixel width in a multi-column section', () => {
-    const issues = validateColumnWidths({
-      tagName: 'rcml',
-      children: [section([col('80px'), col('50%')])],
-    })
-
-    expect(issues).toHaveLength(1)
-    expect(issues[0].code).toBe('ATTR_INVALID_VALUE')
-    expect(issues[0].path).toContain('width')
-    expect(issues[0].message).toContain('"80px"')
+  it('returns no issues for a column with a pixel width in a multi-column section (schema allows it)', () => {
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([col('80px'), col('50%')])],
+      }),
+    ).toEqual([])
   })
 
-  it('flags a column with no width attribute in a multi-column section', () => {
-    const issues = validateColumnWidths({
-      tagName: 'rcml',
-      children: [section([colNoAttrs(), col('50%')])],
-    })
-
-    expect(issues).toHaveLength(1)
-    expect(issues[0].code).toBe('ATTR_INVALID_VALUE')
-    expect(issues[0].message).toMatch(/must have a percentage width/)
+  it('returns no issues when a column has no width attribute in a multi-column section (schema allows it)', () => {
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([colNoAttrs(), col('50%')])],
+      }),
+    ).toEqual([])
   })
 
-  it('flags two columns where neither has a width', () => {
-    const issues = validateColumnWidths({
-      tagName: 'rcml',
-      children: [section([colNoAttrs(), colNoAttrs()])],
-    })
-
-    expect(issues).toHaveLength(2)
+  it('returns no issues when no column has a width attribute (schema allows it)', () => {
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([colNoAttrs(), colNoAttrs()])],
+      }),
+    ).toEqual([])
   })
 
-  it('flags widths that do not sum to 100%', () => {
+  it('flags all-percentage widths that do not sum to 100%', () => {
     const issues = validateColumnWidths({
       tagName: 'rcml',
       children: [section([col('40%'), col('40%')])],
@@ -87,6 +82,15 @@ describe('validateColumnWidths — multi-column sections', () => {
 
     expect(issues).toHaveLength(1)
     expect(issues[0].message).toMatch(/sum to 80%/)
+  })
+
+  it('skips sum check when any column uses a non-percentage width', () => {
+    expect(
+      validateColumnWidths({
+        tagName: 'rcml',
+        children: [section([col('80px'), col('40%')])],
+      }),
+    ).toEqual([])
   })
 
   it('allows floating-point rounding within ±0.5%', () => {
@@ -108,7 +112,7 @@ describe('validateColumnWidths — nesting', () => {
         { tagName: 'rc-head', children: [] },
         {
           tagName: 'rc-body',
-          children: [section([colNoAttrs(), colNoAttrs()])],
+          children: [section([col('40%'), col('40%')])],
         },
       ],
     }

--- a/packages/rcml/src/email/validator/column-width-validate.ts
+++ b/packages/rcml/src/email/validator/column-width-validate.ts
@@ -1,0 +1,94 @@
+/**
+ * Internal: cross-element column-width validation.
+ *
+ * When an `rc-section` contains more than one `rc-column`, every column must
+ * carry a percentage `width` and all widths must sum to 100 %. This pass
+ * enforces that constraint. Single-column sections are left untouched (width
+ * is optional there).
+ */
+
+import {
+  EmailTemplateErrorCodes,
+  type EmailTemplateValidationIssue,
+} from '../validate-email-template.js'
+
+const PCT_RE = /^(\d+(?:\.\d+)?)%$/
+
+/**
+ * Walk `doc` and emit `ATTR_INVALID_VALUE` issues for any multi-column
+ * section whose column widths are not all valid percentages summing to 100 %.
+ *
+ * @param doc - Any value (expected to be an {@link import('../rcml-types.js').RcmlDocument}-shaped tree).
+ * @returns A list of `ATTR_INVALID_VALUE` issues (empty on success).
+ */
+export function validateColumnWidths(doc: unknown): EmailTemplateValidationIssue[] {
+  const issues: EmailTemplateValidationIssue[] = []
+
+  visitNode(doc, '', issues)
+
+  return issues
+}
+
+function visitNode(node: unknown, path: string, issues: EmailTemplateValidationIssue[]): void {
+  if (!isObj(node)) return
+
+  if (node.tagName === 'rc-section') {
+    const children: unknown[] = Array.isArray(node.children) ? node.children : []
+    const columns = children
+      .map((c, i) => ({ node: c, index: i }))
+      .filter(({ node: c }) => isObj(c) && c.tagName === 'rc-column')
+
+    if (columns.length > 1) {
+      let sum = 0
+      let hasError = false
+
+      for (const { node: col, index } of columns) {
+        const colPath = `${path}/children/${index}`
+        const width =
+          isObj(col) && isObj(col.attributes) ? (col.attributes.width as unknown) : undefined
+
+        if (typeof width !== 'string') {
+          issues.push({
+            path: `${colPath}/attributes/width`,
+            code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
+            message: 'Column in a multi-column section must have a percentage width (e.g. "50%").',
+          })
+          hasError = true
+          continue
+        }
+
+        const m = PCT_RE.exec(width)
+
+        if (!m) {
+          issues.push({
+            path: `${colPath}/attributes/width`,
+            code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
+            message: `Column width "${width}" must be a percentage in a multi-column section (e.g. "50%").`,
+          })
+          hasError = true
+          continue
+        }
+
+        sum += parseFloat(m[1])
+      }
+
+      if (!hasError && Math.abs(sum - 100) > 0.5) {
+        issues.push({
+          path: `${path}/children`,
+          code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
+          message: `Column widths in this section sum to ${sum}% but must sum to 100%.`,
+        })
+      }
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child: unknown, i: number) => {
+      visitNode(child, `${path}/children/${i}`, issues)
+    })
+  }
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}

--- a/packages/rcml/src/email/validator/column-width-validate.ts
+++ b/packages/rcml/src/email/validator/column-width-validate.ts
@@ -61,10 +61,12 @@ function visitNode(node: unknown, path: string, issues: EmailTemplateValidationI
       }
 
       if (allPercentage && Math.abs(sum - 100) > 0.5) {
+        const displaySum = parseFloat(sum.toFixed(2))
+
         issues.push({
           path: `${path}/children`,
           code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
-          message: `Column widths in this section sum to ${sum}% but must sum to 100%.`,
+          message: `Column widths in this section sum to ${displaySum}% but must sum to 100%.`,
         })
       }
     }

--- a/packages/rcml/src/email/validator/column-width-validate.ts
+++ b/packages/rcml/src/email/validator/column-width-validate.ts
@@ -1,10 +1,13 @@
 /**
  * Internal: cross-element column-width validation.
  *
- * When an `rc-section` contains more than one `rc-column`, every column must
- * carry a percentage `width` and all widths must sum to 100 %. This pass
- * enforces that constraint. Single-column sections are left untouched (width
- * is optional there).
+ * When an `rc-section` contains more than one `rc-column` and every column
+ * carries a percentage `width`, this pass checks that the widths sum to 100 %.
+ * Single-column sections are left untouched. Columns with a missing or
+ * non-percentage width (e.g. `200px`) are skipped — those values are
+ * individually valid per the published schema (`validator: V.PxOrPercentage`,
+ * width is optional for single-column). Only when all columns in a
+ * multi-column section are percentage-valued is the sum enforced.
  */
 
 import {
@@ -16,7 +19,9 @@ const PCT_RE = /^(\d+(?:\.\d+)?)%$/
 
 /**
  * Walk `doc` and emit `ATTR_INVALID_VALUE` issues for any multi-column
- * section whose column widths are not all valid percentages summing to 100 %.
+ * section where all columns carry percentage widths that do not sum to 100 %.
+ * Columns with absent or non-percentage widths are not flagged here — those
+ * are covered by the AJV structural pass and the per-attribute Zod pass.
  *
  * @param doc - Any value (expected to be an {@link import('../rcml-types.js').RcmlDocument}-shaped tree).
  * @returns A list of `ATTR_INVALID_VALUE` issues (empty on success).
@@ -40,39 +45,22 @@ function visitNode(node: unknown, path: string, issues: EmailTemplateValidationI
 
     if (columns.length > 1) {
       let sum = 0
-      let hasError = false
+      let allPercentage = true
 
-      for (const { node: col, index } of columns) {
-        const colPath = `${path}/children/${index}`
+      for (const { node: col } of columns) {
         const width =
           isObj(col) && isObj(col.attributes) ? (col.attributes.width as unknown) : undefined
-
-        if (typeof width !== 'string') {
-          issues.push({
-            path: `${colPath}/attributes/width`,
-            code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
-            message: 'Column in a multi-column section must have a percentage width (e.g. "50%").',
-          })
-          hasError = true
-          continue
-        }
-
-        const m = PCT_RE.exec(width)
+        const m = typeof width === 'string' ? PCT_RE.exec(width) : null
 
         if (!m) {
-          issues.push({
-            path: `${colPath}/attributes/width`,
-            code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,
-            message: `Column width "${width}" must be a percentage in a multi-column section (e.g. "50%").`,
-          })
-          hasError = true
-          continue
+          allPercentage = false
+          break
         }
 
         sum += parseFloat(m[1])
       }
 
-      if (!hasError && Math.abs(sum - 100) > 0.5) {
+      if (allPercentage && Math.abs(sum - 100) > 0.5) {
         issues.push({
           path: `${path}/children`,
           code: EmailTemplateErrorCodes.ATTR_INVALID_VALUE,

--- a/packages/rcml/src/email/validator/index.ts
+++ b/packages/rcml/src/email/validator/index.ts
@@ -13,4 +13,5 @@
 
 export { validateStructure } from './ajv-validate.js'
 export { validateAttrValues } from './attr-value-validate.js'
+export { validateColumnWidths } from './column-width-validate.js'
 export { validateContent } from './content-validate.js'


### PR DESCRIPTION
## Summary

- **feat(rcml)**: `applyTheme` now stamps `rc-class` defaults (`rcml-p-style`, `rcml-h1-style`, `rcml-label-style`, `rcml-logo-style`) onto unstyled `rc-text`, `rc-heading`, `rc-button`, and `rc-logo` body nodes so the renderer picks up font theme styles. Previously the font-style classes were defined in `<rc-attributes>` but never wired onto body elements.
- **feat(rcml)**: Add `validateColumnWidths` pass to `safeValidateEmailTemplate` — validates that `rc-column` widths within a row sum to 100%.
- **chore**: Add `republish:local` script to root `package.json` for re-publishing the same version to Verdaccio during local development (clears `@rulecom` storage subtree first).

## Test plan

- [ ] Run `pnpm nx affected -t eslint:lint vitest:test --base=develop` — all pass, no errors
- [ ] Run `pnpm republish:local` while Verdaccio is running — `@rulecom` packages publish successfully and the Verdaccio page shows an updated timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)