### PR TITLE
feat: createDefaultEmailCampaign and createDefaultSmsCampaign with docs

### DIFF
--- a/apps/docs/.vitepress/sidebar.ts
+++ b/apps/docs/.vitepress/sidebar.ts
@@ -118,6 +118,7 @@ export const guideSidebar: DefaultTheme.SidebarItem[] = [
       { text: 'Exports', link: '/packages/client/exports' },
       { text: 'Custom Field Schema', link: '/packages/client/custom-fields-schema' },
       { text: 'API Keys', link: '/packages/client/api-keys' },
+      { text: 'Account', link: '/packages/client/account' },
       { text: 'Error Handling', link: '/packages/client/error-handling' },
 
     ],

--- a/packages/client/docs/account.md
+++ b/packages/client/docs/account.md
@@ -1,0 +1,28 @@
+# Account
+
+The `client.account` namespace exposes account-level configuration for your Rule.io account, including sender details used when creating campaigns.
+
+## Sender details
+
+Use `getSenderDetails()` to fetch the account's email and SMS sender configuration.
+
+```typescript
+const details = await client.account.getSenderDetails();
+console.log(details.textMessageSenderName); // e.g. 'Acme Corp'
+console.log(details.linkInsteadOfStopWord); // true | false | undefined
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `accountId` | `number` | Account ID |
+| `name` | `string` | Sender display name for emails |
+| `email` | `string` | Sender email address |
+| `company` | `string` | Company name |
+| `textMessageSenderName` | `string` | The `From` field for outgoing SMS messages |
+| `linkInsteadOfStopWord` | `boolean?` | When `true`, SMS unsubscribe uses a link; when `false` or omitted, a stop-word is used |
+
+*→ [`AccountSenderDetails`](/api/client/src/interfaces/AccountSenderDetails)*
+
+## Next steps
+
+- `textMessageSenderName` is used automatically when creating a default SMS campaign — see [SMS Campaigns](./sms-campaigns).

--- a/packages/client/docs/email-campaigns.md
+++ b/packages/client/docs/email-campaigns.md
@@ -24,6 +24,25 @@ const campaignId = campaign.id!;
 
 *→ [`CreateEmailCampaignPayload`](/api/client/src/interfaces/CreateEmailCampaignPayload)*
 
+## Default campaign
+
+Use `createDefaultEmailCampaign()` to create a campaign with all required content in a single call. The method creates the campaign, message, and a branded email template in parallel, then links them together with a dynamic set. If any step fails, all already-created resources are automatically rolled back.
+
+```typescript
+import { resolvePreferredBrandStyle } from '@rulecom/sdk';
+
+const { id: brandStyleId } = await resolvePreferredBrandStyle(client);
+
+const result = await client.campaigns.createDefaultEmailCampaign({ brandStyleId });
+// result: { campaignId, messageId, templateId, dynamicSetId }
+```
+
+The template is built automatically from the brand style — logo, brand colours, and a placeholder content section. See [Brand Styles](./brand-styles) for how to look up the account's preferred brand style.
+
+An optional `name` and `sendoutType` (`'marketing'` or `'transactional'`) can be passed as well.
+
+*→ [`CreateDefaultEmailCampaignParams`](/api/client/src/interfaces/CreateDefaultEmailCampaignParams), [`CreateDefaultCampaignResult`](/api/client/src/interfaces/CreateDefaultCampaignResult)*
+
 ## Attaching email content
 
 After creating a campaign, attach a message, template, and dynamic set before scheduling. See [Email Messages](./email-messages) for the full walkthrough — the process is the same regardless of whether the dispatcher is a campaign or an automation.

--- a/packages/client/docs/email-campaigns.md
+++ b/packages/client/docs/email-campaigns.md
@@ -39,6 +39,29 @@ const result = await client.campaigns.createDefaultEmailCampaign({ brandStyleId 
 
 The template is built automatically from the brand style — logo, brand colours, and a placeholder content section. See [Brand Styles](./brand-styles) for how to look up the account's preferred brand style.
 
+Pass `message` and `template` to override the auto-generated defaults:
+
+```typescript
+const result = await client.campaigns.createDefaultEmailCampaign({
+  brandStyleId,
+  message: {
+    subject: 'Summer sale — 20% off everything',
+    preheader: 'Shop now before it ends',
+    fromName: 'Acme Store',
+  },
+  template: { name: 'Summer Sale 2025' },
+});
+```
+
+Supply a fully custom RCML document via `template.content` to skip the brand style fetch entirely:
+
+```typescript
+const result = await client.campaigns.createDefaultEmailCampaign({
+  brandStyleId,   // still required by type; not fetched when template.content is provided
+  template: { content: myRcmlDocument },
+});
+```
+
 An optional `name` and `sendoutType` (`'marketing'` or `'transactional'`) can be passed as well.
 
 *→ [`CreateDefaultEmailCampaignParams`](/api/client/src/interfaces/CreateDefaultEmailCampaignParams), [`CreateDefaultCampaignResult`](/api/client/src/interfaces/CreateDefaultCampaignResult)*

--- a/packages/client/docs/sms-campaigns.md
+++ b/packages/client/docs/sms-campaigns.md
@@ -33,6 +33,27 @@ const result = await client.campaigns.createDefaultSmsCampaign();
 
 Sender details are fetched from `client.account` automatically — no manual configuration is needed. See [Account](./account) for details on the sender configuration.
 
+Pass `message` and `template` to override the auto-generated defaults:
+
+```typescript
+const result = await client.campaigns.createDefaultSmsCampaign({
+  message: { subject: 'Hi [Subscriber:FirstName], your order shipped!' },
+  template: { name: 'Order Shipped SMS' },
+});
+```
+
+Supply a custom SMS document via `template.content` to use your own template structure:
+
+```typescript
+import { createSmsDocument } from '@rulecom/sdk';
+
+const result = await client.campaigns.createDefaultSmsCampaign({
+  template: {
+    content: createSmsDocument({ content: 'Your order [Order:Id] has shipped!' }),
+  },
+});
+```
+
 An optional `name` and `sendoutType` (`'marketing'` or `'transactional'`) can be passed as well.
 
 *→ [`CreateDefaultSmsCampaignParams`](/api/client/src/interfaces/CreateDefaultSmsCampaignParams), [`CreateDefaultCampaignResult`](/api/client/src/interfaces/CreateDefaultCampaignResult)*

--- a/packages/client/docs/sms-campaigns.md
+++ b/packages/client/docs/sms-campaigns.md
@@ -22,6 +22,21 @@ const campaignId = campaign.id!;
 
 *→ [`CreateSmsCampaignPayload`](/api/client/src/type-aliases/CreateSmsCampaignPayload)*
 
+## Default campaign
+
+Use `createDefaultSmsCampaign()` to create a campaign with all required content in a single call. The method fetches account sender details automatically, then creates the campaign, message, and an SMS template in parallel, and links them with a dynamic set. The unsubscribe style (link vs stop-word) is determined from the account's sender configuration. If any step fails, all already-created resources are automatically rolled back.
+
+```typescript
+const result = await client.campaigns.createDefaultSmsCampaign();
+// result: { campaignId, messageId, templateId, dynamicSetId }
+```
+
+Sender details are fetched from `client.account` automatically — no manual configuration is needed. See [Account](./account) for details on the sender configuration.
+
+An optional `name` and `sendoutType` (`'marketing'` or `'transactional'`) can be passed as well.
+
+*→ [`CreateDefaultSmsCampaignParams`](/api/client/src/interfaces/CreateDefaultSmsCampaignParams), [`CreateDefaultCampaignResult`](/api/client/src/interfaces/CreateDefaultCampaignResult)*
+
 ## Attaching SMS content
 
 After creating a campaign, attach a message, template, and dynamic set before scheduling. See [SMS Messages](./sms-messages) for the full walkthrough — the process is the same regardless of whether the dispatcher is a campaign or an automation.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -29,6 +29,7 @@ import { BaseResource } from './core/base-resource.js';
 import { HttpTransport } from './core/transport.js';
 import { resolveConfig, type ResolvedClientConfig, type RuleClientConfig } from './config.js';
 
+import { AccountClient } from './resources/account/account.client.js';
 import { AnalyticsClient } from './resources/analytics/analytics.client.js';
 import { ApiKeysClient } from './resources/api-keys/api-keys.client.js';
 import { AutomationsClient } from './resources/automations/automations.client.js';
@@ -116,6 +117,10 @@ export class RuleClient extends BaseResource {
   }
 
   // ── Namespaced API (lazy singletons) ───────────────────────────────────────
+
+  get account(): AccountClient {
+    return this.lazy('account', () => new AccountClient(this.transport));
+  }
 
   get subscribers(): SubscribersClient {
     return this.lazy(

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,6 +16,11 @@ export { AnalyticsMetrics, AnalyticsObjectTypes, AnalyticsMessageTypes } from '.
 export type * from './types.js';
 export * from './brand-style-to-theme.js';
 export { findTemplateOwner } from './find-template-owner.js';
+export {
+  resolvePreferredBrandStyle,
+  type ResolvePreferredBrandStyleResult,
+  type ResolvePreferredBrandStyleSource,
+} from './resolve-preferred-brand-style.js';
 export { formatDateForRule } from './utils/index.js';
 export type {
   TemplateOwner,

--- a/packages/client/src/resolve-preferred-brand-style.ts
+++ b/packages/client/src/resolve-preferred-brand-style.ts
@@ -15,7 +15,7 @@ import { RuleApiError } from './errors.js';
 import type { RuleClient } from './client.js';
 import type { BrandStyleListItem } from './resources/brand-styles/brand-styles.types.js';
 
-export type ResolvePreferredBrandStyleSource = 'default' | 'fallback';
+export type ResolvePreferredBrandStyleSource = 'default' | 'fallback' | 'explicit';
 
 export interface ResolvePreferredBrandStyleResult {
   /** ID of the resolved brand style. */
@@ -25,6 +25,7 @@ export interface ResolvePreferredBrandStyleResult {
   /**
    * How the style was selected.
    *
+   * `'explicit'` — a specific `brandStyleId` was passed to the function.
    * `'default'` — the style is flagged `isDefault` on the account.
    * `'fallback'` — no default was set; the first style in the list was used.
    */
@@ -64,7 +65,7 @@ export async function resolvePreferredBrandStyle(
       throw new RuleApiError(`Brand style ${brandStyleId} not found.`, 404);
     }
 
-    return { id: match.id, brandStyle: match, source: 'default' };
+    return { id: match.id, brandStyle: match, source: 'explicit' };
   }
 
   const defaultStyle = styles.find((s) => s.isDefault);

--- a/packages/client/src/resolve-preferred-brand-style.ts
+++ b/packages/client/src/resolve-preferred-brand-style.ts
@@ -59,17 +59,21 @@ export async function resolvePreferredBrandStyle(
 
   if (brandStyleId !== undefined) {
     const match = styles.find((s) => s.id === brandStyleId);
+
     if (!match) {
       throw new RuleApiError(`Brand style ${brandStyleId} not found.`, 404);
     }
+
     return { id: match.id, brandStyle: match, source: 'default' };
   }
 
   const defaultStyle = styles.find((s) => s.isDefault);
+
   if (defaultStyle) {
     return { id: defaultStyle.id, brandStyle: defaultStyle, source: 'default' };
   }
 
   const fallback = styles[0]!;
+
   return { id: fallback.id, brandStyle: fallback, source: 'fallback' };
 }

--- a/packages/client/src/resolve-preferred-brand-style.ts
+++ b/packages/client/src/resolve-preferred-brand-style.ts
@@ -1,0 +1,75 @@
+/**
+ * Resolve the preferred brand style for an account.
+ *
+ * Returns the brand style marked `isDefault` on the account, falling back to
+ * the first style in the list if no default is set. Throws if the account has
+ * no brand styles at all.
+ *
+ * Use this helper instead of hardcoding brand style IDs — a customer's
+ * preferred style can change.
+ *
+ * @public
+ */
+
+import { RuleApiError } from './errors.js';
+import type { RuleClient } from './client.js';
+import type { BrandStyleListItem } from './resources/brand-styles/brand-styles.types.js';
+
+export type ResolvePreferredBrandStyleSource = 'default' | 'fallback';
+
+export interface ResolvePreferredBrandStyleResult {
+  /** ID of the resolved brand style. */
+  id: number;
+  /** The resolved brand style list item. */
+  brandStyle: BrandStyleListItem;
+  /**
+   * How the style was selected.
+   *
+   * `'default'` — the style is flagged `isDefault` on the account.
+   * `'fallback'` — no default was set; the first style in the list was used.
+   */
+  source: ResolvePreferredBrandStyleSource;
+}
+
+/**
+ * Resolve the preferred brand style for an account.
+ *
+ * Fetches all brand styles and returns the one marked `isDefault`. If none is
+ * marked default, falls back to the first in the list. Throws if the account
+ * has no brand styles.
+ *
+ * @param client - A `RuleClient` instance.
+ * @param brandStyleId - Optional: if provided, look up and return this specific
+ *   brand style ID instead of auto-resolving the default.
+ *
+ * @example
+ * ```typescript
+ * const { id: brandStyleId } = await resolvePreferredBrandStyle(client);
+ * ```
+ */
+export async function resolvePreferredBrandStyle(
+  client: RuleClient,
+  brandStyleId?: number
+): Promise<ResolvePreferredBrandStyleResult> {
+  const styles = await client.brandStyles.list();
+
+  if (styles.length === 0) {
+    throw new RuleApiError('No brand styles found on this account.', 404);
+  }
+
+  if (brandStyleId !== undefined) {
+    const match = styles.find((s) => s.id === brandStyleId);
+    if (!match) {
+      throw new RuleApiError(`Brand style ${brandStyleId} not found.`, 404);
+    }
+    return { id: match.id, brandStyle: match, source: 'default' };
+  }
+
+  const defaultStyle = styles.find((s) => s.isDefault);
+  if (defaultStyle) {
+    return { id: defaultStyle.id, brandStyle: defaultStyle, source: 'default' };
+  }
+
+  const fallback = styles[0]!;
+  return { id: fallback.id, brandStyle: fallback, source: 'fallback' };
+}

--- a/packages/client/src/resources/account/account.client.test.ts
+++ b/packages/client/src/resources/account/account.client.test.ts
@@ -60,6 +60,7 @@ describe('AccountClient', () => {
 
     it('maps undefined link_instead_of_stop_word to undefined', async () => {
       const wire = { ...WIRE_SENDER };
+
       delete (wire as Partial<typeof WIRE_SENDER>).link_instead_of_stop_word;
       fetchMock.mockResolvedValueOnce(createMockResponse(wire));
       const client = createClient(fetchMock);

--- a/packages/client/src/resources/account/account.client.test.ts
+++ b/packages/client/src/resources/account/account.client.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createMockFetch,
+  createMockResponse,
+  createMockTransport,
+  type MockFetch,
+} from '../../core/mock-fetch.js';
+import { AccountClient } from './account.client.js';
+
+const WIRE_SENDER = {
+  status: 200,
+  account_id: 42,
+  name: 'Acme Sender',
+  email: 'sender@acme.com',
+  company: 'Acme Inc',
+  text_message_sender_name: 'Acme',
+  link_instead_of_stop_word: true,
+};
+
+function createClient(fetchMock: MockFetch): AccountClient {
+  return new AccountClient(createMockTransport(fetchMock));
+}
+
+describe('AccountClient', () => {
+  let fetchMock: MockFetch;
+
+  beforeEach(() => {
+    fetchMock = createMockFetch();
+  });
+
+  describe('getSenderDetails', () => {
+    it('GETs the v2 sender/details endpoint', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      const client = createClient(fetchMock);
+
+      await client.getSenderDetails();
+
+      const [url, init] = fetchMock.mock.calls[0]!;
+
+      expect(url).toBe('https://app.rule.io/api/v2/sender/details');
+      expect((init as RequestInit).method).toBe('GET');
+    });
+
+    it('maps wire snake_case to camelCase entity', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      const client = createClient(fetchMock);
+
+      const result = await client.getSenderDetails();
+
+      expect(result).toEqual({
+        accountId: 42,
+        name: 'Acme Sender',
+        email: 'sender@acme.com',
+        company: 'Acme Inc',
+        textMessageSenderName: 'Acme',
+        linkInsteadOfStopWord: true,
+      });
+    });
+
+    it('maps undefined link_instead_of_stop_word to undefined', async () => {
+      const wire = { ...WIRE_SENDER };
+      delete (wire as Partial<typeof WIRE_SENDER>).link_instead_of_stop_word;
+      fetchMock.mockResolvedValueOnce(createMockResponse(wire));
+      const client = createClient(fetchMock);
+
+      const result = await client.getSenderDetails();
+
+      expect(result.linkInsteadOfStopWord).toBeUndefined();
+    });
+  });
+});

--- a/packages/client/src/resources/account/account.client.ts
+++ b/packages/client/src/resources/account/account.client.ts
@@ -1,0 +1,55 @@
+/**
+ * Account namespace client for the `@rulecom/client` package.
+ *
+ * Wraps account-level configuration endpoints, including sender details
+ * used when building campaign messages and SMS templates.
+ */
+
+import { BaseResource } from '../../core/base-resource.js';
+import type {
+  AccountSenderDetails,
+  AccountSenderDetailsWire,
+} from './account.types.js';
+
+// ── Client ────────────────────────────────────────────────────────────────────
+
+export class AccountClient extends BaseResource {
+  /**
+   * Fetch account sender details.
+   *
+   * Returns the account-level email and SMS sender configuration. The SMS
+   * sender name (`textMessageSenderName`) is used as the `From` field when
+   * creating SMS campaigns.
+   *
+   * @returns The account sender details.
+   *
+   * @example
+   * ```typescript
+   * const details = await client.account.getSenderDetails();
+   * console.log(details.textMessageSenderName);
+   * ```
+   */
+  async getSenderDetails(): Promise<AccountSenderDetails> {
+    const wire = await this.transport.get<AccountSenderDetailsWire>('/sender/details', {
+      version: 'v2',
+    });
+
+    return mapSenderDetailsWireToEntity(wire);
+  }
+}
+
+// ── Wire ↔ entity mappers ─────────────────────────────────────────────────────
+
+/**
+ * @internal
+ */
+function mapSenderDetailsWireToEntity(wire: AccountSenderDetailsWire): AccountSenderDetails {
+  return {
+    accountId: wire.account_id,
+    name: wire.name,
+    email: wire.email,
+    company: wire.company,
+    textMessageSenderName: wire.text_message_sender_name,
+    linkInsteadOfStopWord: wire.link_instead_of_stop_word,
+  };
+}

--- a/packages/client/src/resources/account/account.types.ts
+++ b/packages/client/src/resources/account/account.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Account namespace types for the `@rulecom/client` package.
+ *
+ * The sender details endpoint returns account-level email and SMS sender
+ * configuration used when creating campaigns.
+ */
+
+import type { RuleApiResponse } from '../../shared.types.js';
+
+// ── Public SDK types ──────────────────────────────────────────────────────────
+
+/**
+ * Account sender details as returned by `GET /sender/details`.
+ *
+ * Contains the account-level email and SMS sender configuration.
+ */
+export interface AccountSenderDetails {
+  /** Account ID. */
+  accountId: number;
+  /** Sender display name for emails. */
+  name: string;
+  /** Sender email address. */
+  email: string;
+  /** Company name. */
+  company: string;
+  /** SMS sender name (the `From` field for text messages). */
+  textMessageSenderName: string;
+  /**
+   * Whether to use an unsubscribe link instead of a stop-word in SMS messages.
+   *
+   * When `true`, the default SMS template should include a link-based
+   * unsubscribe. When `false` or omitted, a stop-word is used instead.
+   */
+  linkInsteadOfStopWord?: boolean;
+}
+
+// ── Internal wire types ───────────────────────────────────────────────────────
+
+/**
+ * Wire-format sender details from `GET /sender/details`.
+ *
+ * The endpoint returns the object at the root level (not nested under `data`).
+ * @internal
+ */
+export interface AccountSenderDetailsWire extends RuleApiResponse {
+  account_id: number;
+  name: string;
+  email: string;
+  company: string;
+  text_message_sender_name: string;
+  link_instead_of_stop_word?: boolean;
+}

--- a/packages/client/src/resources/campaigns/campaigns.client.test.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.test.ts
@@ -476,6 +476,67 @@ describe('CampaignsClient', () => {
       expect(deletedUrls.some((u) => u.includes('/editor/message/10'))).toBe(true);
       expect(deletedUrls.some((u) => u.includes('/editor/campaign/100'))).toBe(true);
     });
+
+    it('message override replaces the default subject', async () => {
+      setupHappyPath();
+      const client = createClient(fetchMock);
+
+      await client.createDefaultEmailCampaign({
+        brandStyleId: 1,
+        message: { subject: 'Custom subject', preheader: 'Custom preheader' },
+      });
+
+      const messagePostCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string).includes('/editor/message') &&
+          (init as RequestInit).method === 'POST'
+      );
+      const body = JSON.parse((messagePostCall![1] as RequestInit).body as string);
+
+      expect(body.subject).toBe('Custom subject');
+      expect(body.pre_header).toBe('Custom preheader');
+    });
+
+    it('template.content override skips the brand style fetch', async () => {
+      // No brand style fetch — only 4 calls (campaign, message, template, dynamic set)
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_CAMPAIGN }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_MESSAGE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_TEMPLATE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_DYNAMIC_SET }));
+
+      const client = createClient(fetchMock);
+
+      await client.createDefaultEmailCampaign({
+        brandStyleId: 1,
+        template: { content: { tagName: 'rc-email', attributes: {}, head: { tagName: 'rc-head', attributes: {}, children: [] }, body: { tagName: 'rc-body', attributes: {}, children: [] } } },
+      });
+
+      const brandStyleFetched = fetchMock.mock.calls.some(([url]) =>
+        (url as string).includes('/brand-styles')
+      );
+
+      expect(brandStyleFetched).toBe(false);
+      expect(fetchMock.mock.calls).toHaveLength(4);
+    });
+
+    it('template.name override uses the custom name', async () => {
+      setupHappyPath();
+      const client = createClient(fetchMock);
+
+      await client.createDefaultEmailCampaign({
+        brandStyleId: 1,
+        template: { name: 'My Custom Template' },
+      });
+
+      const templatePostCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string).includes('/editor/template') &&
+          (init as RequestInit).method === 'POST'
+      );
+      const body = JSON.parse((templatePostCall![1] as RequestInit).body as string);
+
+      expect(body.name).toBe('My Custom Template');
+    });
   });
 
   describe('createDefaultSmsCampaign', () => {
@@ -561,6 +622,52 @@ describe('CampaignsClient', () => {
 
       expect(deletedUrls.some((u) => u.includes('/editor/template/21'))).toBe(true);
       expect(deletedUrls.some((u) => u.includes('/editor/campaign/200'))).toBe(true);
+    });
+
+    it('message.subject override replaces the default SMS body', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_MESSAGE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_DYNAMIC_SET }));
+
+      const client = createClient(fetchMock);
+
+      await client.createDefaultSmsCampaign({
+        message: { subject: 'Hi [Subscriber:FirstName], your order shipped!' },
+      });
+
+      const messagePostCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string).includes('/editor/message') &&
+          (init as RequestInit).method === 'POST'
+      );
+      const body = JSON.parse((messagePostCall![1] as RequestInit).body as string);
+
+      expect(body.subject).toBe('Hi [Subscriber:FirstName], your order shipped!');
+    });
+
+    it('template.name override uses the custom name', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_MESSAGE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_DYNAMIC_SET }));
+
+      const client = createClient(fetchMock);
+
+      await client.createDefaultSmsCampaign({
+        template: { name: 'Order Shipped SMS' },
+      });
+
+      const templatePostCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string).includes('/editor/template') &&
+          (init as RequestInit).method === 'POST'
+      );
+      const body = JSON.parse((templatePostCall![1] as RequestInit).body as string);
+
+      expect(body.name).toBe('Order Shipped SMS');
     });
   });
 });

--- a/packages/client/src/resources/campaigns/campaigns.client.test.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.test.ts
@@ -625,7 +625,7 @@ describe('CampaignsClient', () => {
     });
 
     it('message.subject override replaces the default SMS body', async () => {
-      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      // No sender mock — getSenderDetails is skipped when message.subject is provided
       fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
       fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_MESSAGE }));
       fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));

--- a/packages/client/src/resources/campaigns/campaigns.client.test.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.test.ts
@@ -525,6 +525,7 @@ describe('CampaignsClient', () => {
       fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_DYNAMIC_SET }));
 
       const client = createClient(fetchMock);
+
       await client.createDefaultSmsCampaign();
 
       const messagePostCall = fetchMock.mock.calls.find(
@@ -532,7 +533,9 @@ describe('CampaignsClient', () => {
           (url as string).includes('/editor/message') &&
           (init as RequestInit).method === 'POST'
       );
+
       const body = JSON.parse((messagePostCall![1] as RequestInit).body as string);
+
       expect(body.subject).not.toBe('Spring Newsletter');
       expect(typeof body.subject).toBe('string');
       expect(body.subject.length).toBeGreaterThan(0);

--- a/packages/client/src/resources/campaigns/campaigns.client.test.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.test.ts
@@ -401,4 +401,163 @@ describe('CampaignsClient', () => {
       expect(result.map((c) => c.id)).toEqual([100, 200]);
     });
   });
+
+  describe('createDefaultEmailCampaign', () => {
+    const WIRE_BRAND_STYLE_FULL = {
+      id: 1,
+      account_id: 1,
+      name: 'Default',
+      is_default: true,
+      description: null,
+      domain: null,
+      colours: [],
+      links: [],
+      fonts: [],
+      images: [],
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+    };
+    const WIRE_MESSAGE = { id: 10, subject: 'Spring Newsletter' };
+    const WIRE_TEMPLATE = { id: 20, name: 'Campaign 100 template', message_type: 'email', created_at: '2024-01-01', updated_at: '2024-01-01' };
+    const WIRE_DYNAMIC_SET = { id: 30, name: 'ds', active: false, position: 0, created_at: '2024-01-01', updated_at: '2024-01-01' };
+
+    function setupHappyPath(): void {
+      // 1. GET brand style by id
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_BRAND_STYLE_FULL }));
+      // 2. POST campaign
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_CAMPAIGN }));
+      // 3a. POST message (parallel)
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_MESSAGE }));
+      // 3b. POST template (parallel)
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_TEMPLATE }));
+      // 4. POST dynamic set
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_DYNAMIC_SET }));
+    }
+
+    it('returns IDs of all created resources on success', async () => {
+      setupHappyPath();
+      const client = createClient(fetchMock);
+
+      const result = await client.createDefaultEmailCampaign({ brandStyleId: 1 });
+
+      expect(result).toEqual({
+        campaignId: 100,
+        messageId: 10,
+        templateId: 20,
+        dynamicSetId: 30,
+      });
+    });
+
+    it('rolls back campaign and any created resources if template creation fails', async () => {
+      // 1. GET brand style by id
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_BRAND_STYLE_FULL }));
+      // 2. POST campaign — succeeds
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_CAMPAIGN }));
+      // 3a. POST message — succeeds
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_MESSAGE }));
+      // 3b. POST template — fails
+      fetchMock.mockResolvedValueOnce(createMockErrorResponse({}, 500));
+      // 4. DELETE message (rollback)
+      fetchMock.mockResolvedValueOnce(createMockResponse({}));
+      // 5. DELETE campaign (rollback)
+      fetchMock.mockResolvedValueOnce(createMockResponse({}));
+
+      const client = createClient(fetchMock);
+
+      await expect(
+        client.createDefaultEmailCampaign({ brandStyleId: 1 })
+      ).rejects.toBeInstanceOf(RuleApiError);
+
+      const deletedUrls = fetchMock.mock.calls
+        .filter(([, init]) => (init as RequestInit).method === 'DELETE')
+        .map(([url]) => url as string);
+
+      // Both the message and the campaign must be deleted
+      expect(deletedUrls.some((u) => u.includes('/editor/message/10'))).toBe(true);
+      expect(deletedUrls.some((u) => u.includes('/editor/campaign/100'))).toBe(true);
+    });
+  });
+
+  describe('createDefaultSmsCampaign', () => {
+    const WIRE_SENDER = {
+      status: 200,
+      account_id: 1,
+      name: 'Acme',
+      email: 'acme@example.com',
+      company: 'Acme Inc',
+      text_message_sender_name: 'Acme',
+      link_instead_of_stop_word: false,
+    };
+    const WIRE_SMS_CAMPAIGN = { ...WIRE_CAMPAIGN, id: 200 };
+    const WIRE_SMS_MESSAGE = { id: 11, subject: 'Your message here.\n[Subscriber:stop_word]' };
+    const WIRE_SMS_TEMPLATE = { id: 21, name: 'Campaign 200 SMS template', message_type: 'sms', created_at: '2024-01-01', updated_at: '2024-01-01' };
+    const WIRE_SMS_DYNAMIC_SET = { id: 31, name: 'ds', active: false, position: 0, created_at: '2024-01-01', updated_at: '2024-01-01' };
+
+    it('returns IDs of all created resources on success', async () => {
+      // 1. GET sender details
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      // 2. POST SMS campaign
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
+      // 3a. POST SMS message (parallel)
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_MESSAGE }));
+      // 3b. POST SMS template (parallel)
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));
+      // 4. POST dynamic set
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_DYNAMIC_SET }));
+
+      const client = createClient(fetchMock);
+
+      const result = await client.createDefaultSmsCampaign();
+
+      expect(result).toEqual({
+        campaignId: 200,
+        messageId: 11,
+        templateId: 21,
+        dynamicSetId: 31,
+      });
+    });
+
+    it('uses SMS body text (not campaign name) as the message subject', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_MESSAGE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_DYNAMIC_SET }));
+
+      const client = createClient(fetchMock);
+      await client.createDefaultSmsCampaign();
+
+      const messagePostCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string).includes('/editor/message') &&
+          (init as RequestInit).method === 'POST'
+      );
+      const body = JSON.parse((messagePostCall![1] as RequestInit).body as string);
+      expect(body.subject).not.toBe('Spring Newsletter');
+      expect(typeof body.subject).toBe('string');
+      expect(body.subject.length).toBeGreaterThan(0);
+    });
+
+    it('rolls back created resources when message creation fails', async () => {
+      fetchMock.mockResolvedValueOnce(createMockResponse(WIRE_SENDER));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_CAMPAIGN }));
+      // message fails, template succeeds
+      fetchMock.mockResolvedValueOnce(createMockErrorResponse({}, 500));
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_SMS_TEMPLATE }));
+      // rollbacks
+      fetchMock.mockResolvedValueOnce(createMockResponse({}));
+      fetchMock.mockResolvedValueOnce(createMockResponse({}));
+
+      const client = createClient(fetchMock);
+
+      await expect(client.createDefaultSmsCampaign()).rejects.toBeInstanceOf(RuleApiError);
+
+      const deletedUrls = fetchMock.mock.calls
+        .filter(([, init]) => (init as RequestInit).method === 'DELETE')
+        .map(([url]) => url as string);
+
+      expect(deletedUrls.some((u) => u.includes('/editor/template/21'))).toBe(true);
+      expect(deletedUrls.some((u) => u.includes('/editor/campaign/200'))).toBe(true);
+    });
+  });
 });

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -635,13 +635,19 @@ export class CampaignsClient extends BaseResource {
     const templates = this.lazy('templates', () => new TemplatesClient(this.transport));
     const dynamicSets = this.lazy('dynamicSets', () => new DynamicSetsClient(this.transport));
 
-    const brandStyle = await brandStyles.get(params.brandStyleId);
+    const { content: templateContentOverride, ...templateMetaOverrides } = params.template ?? {};
 
-    if (!brandStyle) {
-      throw new RuleApiError(`Brand style ${params.brandStyleId} not found.`, 404);
+    let templateContent = templateContentOverride;
+
+    if (!templateContent) {
+      const brandStyle = await brandStyles.get(params.brandStyleId);
+
+      if (!brandStyle) {
+        throw new RuleApiError(`Brand style ${params.brandStyleId} not found.`, 404);
+      }
+
+      templateContent = buildDefaultBrandedTemplate(brandStyle);
     }
-
-    const templateContent = buildDefaultBrandedTemplate(brandStyle);
 
     const createdResources: { type: 'campaign' | 'message' | 'template'; id: number }[] = [];
 
@@ -662,9 +668,11 @@ export class CampaignsClient extends BaseResource {
       const [messageResult, templateResult] = await Promise.allSettled([
         messages.createEmailCampaignMessage(campaignId, {
           subject: campaign.name,
+          ...params.message,
         }),
         templates.createEmailTemplate({
           name: `Campaign ${campaignId} template`,
+          ...templateMetaOverrides,
           content: templateContent,
         }),
       ]);
@@ -750,7 +758,9 @@ export class CampaignsClient extends BaseResource {
 
     const senderDetails = await account.getSenderDetails();
 
-    const smsContent = buildDefaultSmsContent(senderDetails.linkInsteadOfStopWord ?? false);
+    const { content: templateContentOverride, ...templateMetaOverrides } = params.template ?? {};
+    const defaultSmsBody = buildDefaultSmsContent(senderDetails.linkInsteadOfStopWord ?? false);
+    const smsBody = params.message?.subject ?? defaultSmsBody;
 
     const createdResources: { type: 'campaign' | 'message' | 'template'; id: number }[] = [];
 
@@ -770,11 +780,13 @@ export class CampaignsClient extends BaseResource {
 
       const [messageResult, templateResult] = await Promise.allSettled([
         messages.createSmsCampaignMessage(campaignId, {
-          subject: smsContent,
+          subject: smsBody,
+          ...params.message,
         }),
         templates.createSmsTemplate({
           name: `Campaign ${campaignId} SMS template`,
-          content: createSmsDocument({ content: smsContent }),
+          ...templateMetaOverrides,
+          content: templateContentOverride ?? createSmsDocument({ content: smsBody }),
         }),
       ]);
 

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -659,7 +659,7 @@ export class CampaignsClient extends BaseResource {
 
       createdResources.push({ type: 'campaign', id: campaignId });
 
-      const [message, template] = await Promise.all([
+      const [messageResult, templateResult] = await Promise.allSettled([
         messages.createEmailCampaignMessage(campaignId, {
           subject: campaign.name,
         }),
@@ -669,6 +669,23 @@ export class CampaignsClient extends BaseResource {
         }),
       ]);
 
+      if (messageResult.status === 'fulfilled' && messageResult.value.id) {
+        createdResources.push({ type: 'message', id: messageResult.value.id });
+      }
+      if (templateResult.status === 'fulfilled' && templateResult.value.id) {
+        createdResources.push({ type: 'template', id: templateResult.value.id });
+      }
+
+      if (messageResult.status === 'rejected') {
+        throw messageResult.reason;
+      }
+      if (templateResult.status === 'rejected') {
+        throw templateResult.reason;
+      }
+
+      const message = messageResult.value;
+      const template = templateResult.value;
+
       if (!message.id) {
         throw new RuleApiError('Failed to create message — no ID returned.', 500);
       }
@@ -676,9 +693,6 @@ export class CampaignsClient extends BaseResource {
       if (!template.id) {
         throw new RuleApiError('Failed to create template — no ID returned.', 500);
       }
-
-      createdResources.push({ type: 'message', id: message.id });
-      createdResources.push({ type: 'template', id: template.id });
 
       const dynamicSet = await dynamicSets.create({
         messageId: message.id,
@@ -752,15 +766,32 @@ export class CampaignsClient extends BaseResource {
 
       createdResources.push({ type: 'campaign', id: campaignId });
 
-      const [message, template] = await Promise.all([
+      const [messageResult, templateResult] = await Promise.allSettled([
         messages.createSmsCampaignMessage(campaignId, {
-          subject: campaign.name,
+          subject: smsContent,
         }),
         templates.createSmsTemplate({
           name: `Campaign ${campaignId} SMS template`,
           content: createSmsDocument({ content: smsContent }),
         }),
       ]);
+
+      if (messageResult.status === 'fulfilled' && messageResult.value.id) {
+        createdResources.push({ type: 'message', id: messageResult.value.id });
+      }
+      if (templateResult.status === 'fulfilled' && templateResult.value.id) {
+        createdResources.push({ type: 'template', id: templateResult.value.id });
+      }
+
+      if (messageResult.status === 'rejected') {
+        throw messageResult.reason;
+      }
+      if (templateResult.status === 'rejected') {
+        throw templateResult.reason;
+      }
+
+      const message = messageResult.value;
+      const template = templateResult.value;
 
       if (!message.id) {
         throw new RuleApiError('Failed to create message — no ID returned.', 500);
@@ -769,9 +800,6 @@ export class CampaignsClient extends BaseResource {
       if (!template.id) {
         throw new RuleApiError('Failed to create template — no ID returned.', 500);
       }
-
-      createdResources.push({ type: 'message', id: message.id });
-      createdResources.push({ type: 'template', id: template.id });
 
       const dynamicSet = await dynamicSets.create({
         messageId: message.id,
@@ -871,7 +899,7 @@ function mapMessageTypeToWire(type: CampaignMessageType): number {
 }
 
 /**
- * Build the default SMS body content string in SMS RFM format.
+ * Build the default SMS body content string in RCML format.
  *
  * Mirrors the frontend's `InitialSmsTemplateRcmlBuilder`: appends either a
  * link-based unsubscribe (`linkInsteadOfStopWord = true`) or a stop-word

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -15,9 +15,17 @@
  * ({@link renameCampaign}, {@link setCampaignSendoutType}, etc.).
  */
 
+import { createSmsDocument } from '@rulecom/rcml';
+
 import { RuleApiError, RuleClientError } from '../../errors.js';
 import { BaseResource } from '../../core/base-resource.js';
 import { buildQueryString } from '../../core/query-string.js';
+import { buildDefaultBrandedTemplate } from '../../default-branded-template.js';
+import { BrandStylesClient } from '../brand-styles/brand-styles.client.js';
+import { DynamicSetsClient } from '../dynamic-sets/dynamic-sets.client.js';
+import { MessagesClient } from '../messages/messages.client.js';
+import { TemplatesClient } from '../templates/templates.client.js';
+import { AccountClient } from '../account/account.client.js';
 import type {
   Campaign,
   CampaignListResponse,
@@ -28,6 +36,9 @@ import type {
   CampaignSendoutType,
   CampaignStatus,
   CampaignWire,
+  CreateDefaultCampaignResult,
+  CreateDefaultEmailCampaignParams,
+  CreateDefaultSmsCampaignParams,
   CreateEmailCampaignPayload,
   CreateSmsCampaignPayload,
   ListCampaignsParams,
@@ -592,6 +603,215 @@ export class CampaignsClient extends BaseResource {
 
     return results;
   }
+
+  /**
+   * Create a complete email campaign with all its dependencies in one call.
+   *
+   * Executes the full creation sequence:
+   * 1. Create the campaign.
+   * 2. In parallel: create the message (using the campaign name as subject)
+   *    and create the email template (built from the given brand style).
+   * 3. Create the default dynamic set linking the message to the template.
+   *
+   * If any step fails, all previously created resources are deleted
+   * automatically before the error is rethrown.
+   *
+   * @param params - Brand style ID and optional campaign name and sendout type.
+   * @returns IDs of all created resources.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.campaigns.createDefaultEmailCampaign({
+   *   brandStyleId: 42,
+   * });
+   * console.log(result.campaignId, result.messageId, result.templateId, result.dynamicSetId);
+   * ```
+   */
+  async createDefaultEmailCampaign(
+    params: CreateDefaultEmailCampaignParams
+  ): Promise<CreateDefaultCampaignResult> {
+    const brandStyles = this.lazy('brandStyles', () => new BrandStylesClient(this.transport));
+    const messages = this.lazy('messages', () => new MessagesClient(this.transport));
+    const templates = this.lazy('templates', () => new TemplatesClient(this.transport));
+    const dynamicSets = this.lazy('dynamicSets', () => new DynamicSetsClient(this.transport));
+
+    const brandStyle = await brandStyles.get(params.brandStyleId);
+
+    if (!brandStyle) {
+      throw new RuleApiError(`Brand style ${params.brandStyleId} not found.`, 404);
+    }
+
+    const templateContent = buildDefaultBrandedTemplate(brandStyle);
+
+    const createdResources: { type: 'campaign' | 'message' | 'template'; id: number }[] = [];
+
+    try {
+      const campaign = await this.createEmailCampaign({
+        name: params.name,
+        sendoutType: params.sendoutType ?? 'marketing',
+      });
+
+      if (!campaign.id) {
+        throw new RuleApiError('Failed to create campaign — no ID returned.', 500);
+      }
+
+      const campaignId = campaign.id;
+
+      createdResources.push({ type: 'campaign', id: campaignId });
+
+      const [message, template] = await Promise.all([
+        messages.createEmailCampaignMessage(campaignId, {
+          subject: campaign.name,
+        }),
+        templates.createEmailTemplate({
+          name: `Campaign ${campaignId} template`,
+          content: templateContent,
+        }),
+      ]);
+
+      if (!message.id) {
+        throw new RuleApiError('Failed to create message — no ID returned.', 500);
+      }
+
+      if (!template.id) {
+        throw new RuleApiError('Failed to create template — no ID returned.', 500);
+      }
+
+      createdResources.push({ type: 'message', id: message.id });
+      createdResources.push({ type: 'template', id: template.id });
+
+      const dynamicSet = await dynamicSets.create({
+        messageId: message.id,
+        templateId: template.id,
+      });
+
+      if (!dynamicSet.id) {
+        throw new RuleApiError('Failed to create dynamic set — no ID returned.', 500);
+      }
+
+      return {
+        campaignId,
+        messageId: message.id,
+        templateId: template.id,
+        dynamicSetId: dynamicSet.id,
+      };
+    } catch (error) {
+      await this._cleanupResources(createdResources, { messages, templates });
+      throw error;
+    }
+  }
+
+  /**
+   * Create a complete SMS campaign with all its dependencies in one call.
+   *
+   * Executes the full creation sequence:
+   * 1. Fetch account sender details (for the SMS sender name and unsubscribe
+   *    behavior).
+   * 2. Create the campaign.
+   * 3. In parallel: create the SMS message and create the SMS template (built
+   *    from the account sender details).
+   * 4. Create the default dynamic set linking the message to the template.
+   *
+   * If any step fails, all previously created resources are deleted
+   * automatically before the error is rethrown.
+   *
+   * @param params - Optional campaign name and sendout type.
+   * @returns IDs of all created resources.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.campaigns.createDefaultSmsCampaign();
+   * console.log(result.campaignId, result.messageId, result.templateId, result.dynamicSetId);
+   * ```
+   */
+  async createDefaultSmsCampaign(
+    params: CreateDefaultSmsCampaignParams = {}
+  ): Promise<CreateDefaultCampaignResult> {
+    const account = this.lazy('account', () => new AccountClient(this.transport));
+    const messages = this.lazy('messages', () => new MessagesClient(this.transport));
+    const templates = this.lazy('templates', () => new TemplatesClient(this.transport));
+    const dynamicSets = this.lazy('dynamicSets', () => new DynamicSetsClient(this.transport));
+
+    const senderDetails = await account.getSenderDetails();
+
+    const smsContent = buildDefaultSmsContent(senderDetails.linkInsteadOfStopWord ?? false);
+
+    const createdResources: { type: 'campaign' | 'message' | 'template'; id: number }[] = [];
+
+    try {
+      const campaign = await this.createSmsCampaign({
+        name: params.name,
+        sendoutType: params.sendoutType ?? 'marketing',
+      });
+
+      if (!campaign.id) {
+        throw new RuleApiError('Failed to create campaign — no ID returned.', 500);
+      }
+
+      const campaignId = campaign.id;
+
+      createdResources.push({ type: 'campaign', id: campaignId });
+
+      const [message, template] = await Promise.all([
+        messages.createSmsCampaignMessage(campaignId, {
+          subject: campaign.name,
+        }),
+        templates.createSmsTemplate({
+          name: `Campaign ${campaignId} SMS template`,
+          content: createSmsDocument({ content: smsContent }),
+        }),
+      ]);
+
+      if (!message.id) {
+        throw new RuleApiError('Failed to create message — no ID returned.', 500);
+      }
+
+      if (!template.id) {
+        throw new RuleApiError('Failed to create template — no ID returned.', 500);
+      }
+
+      createdResources.push({ type: 'message', id: message.id });
+      createdResources.push({ type: 'template', id: template.id });
+
+      const dynamicSet = await dynamicSets.create({
+        messageId: message.id,
+        templateId: template.id,
+      });
+
+      if (!dynamicSet.id) {
+        throw new RuleApiError('Failed to create dynamic set — no ID returned.', 500);
+      }
+
+      return {
+        campaignId,
+        messageId: message.id,
+        templateId: template.id,
+        dynamicSetId: dynamicSet.id,
+      };
+    } catch (error) {
+      await this._cleanupResources(createdResources, { messages, templates });
+      throw error;
+    }
+  }
+
+  private async _cleanupResources(
+    resources: { type: 'campaign' | 'message' | 'template'; id: number }[],
+    clients: { messages: MessagesClient; templates: TemplatesClient }
+  ): Promise<void> {
+    for (const resource of resources.reverse()) {
+      try {
+        if (resource.type === 'campaign') {
+          await this.delete(resource.id);
+        } else if (resource.type === 'message') {
+          await clients.messages.delete(resource.id);
+        } else {
+          await clients.templates.delete(resource.id);
+        }
+      } catch {
+        // Ignore cleanup errors — best-effort only.
+      }
+    }
+  }
 }
 
 // ── Wire ↔ entity mappers ─────────────────────────────────────────────────────
@@ -648,4 +868,22 @@ function mapSendoutTypeToWire(type: CampaignSendoutType): '1' | '2' {
  */
 function mapMessageTypeToWire(type: CampaignMessageType): number {
   return type === 'email' ? 1 : 2;
+}
+
+/**
+ * Build the default SMS body content string in SMS RFM format.
+ *
+ * Mirrors the frontend's `InitialSmsTemplateRcmlBuilder`: appends either a
+ * link-based unsubscribe (`linkInsteadOfStopWord = true`) or a stop-word
+ * (`linkInsteadOfStopWord = false`) after the placeholder message text.
+ * @internal
+ */
+function buildDefaultSmsContent(linkInsteadOfStopWord: boolean): string {
+  const body = 'Your message here.\n';
+
+  if (linkInsteadOfStopWord) {
+    return `${body}[Subscriber:unsubscribe_text] [Link:Unsubscribe]`;
+  }
+
+  return `${body}[Subscriber:stop_word]`;
 }

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -672,6 +672,7 @@ export class CampaignsClient extends BaseResource {
       if (messageResult.status === 'fulfilled' && messageResult.value.id) {
         createdResources.push({ type: 'message', id: messageResult.value.id });
       }
+
       if (templateResult.status === 'fulfilled' && templateResult.value.id) {
         createdResources.push({ type: 'template', id: templateResult.value.id });
       }
@@ -679,6 +680,7 @@ export class CampaignsClient extends BaseResource {
       if (messageResult.status === 'rejected') {
         throw messageResult.reason;
       }
+
       if (templateResult.status === 'rejected') {
         throw templateResult.reason;
       }
@@ -779,6 +781,7 @@ export class CampaignsClient extends BaseResource {
       if (messageResult.status === 'fulfilled' && messageResult.value.id) {
         createdResources.push({ type: 'message', id: messageResult.value.id });
       }
+
       if (templateResult.status === 'fulfilled' && templateResult.value.id) {
         createdResources.push({ type: 'template', id: templateResult.value.id });
       }
@@ -786,6 +789,7 @@ export class CampaignsClient extends BaseResource {
       if (messageResult.status === 'rejected') {
         throw messageResult.reason;
       }
+
       if (templateResult.status === 'rejected') {
         throw templateResult.reason;
       }

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -667,8 +667,8 @@ export class CampaignsClient extends BaseResource {
 
       const [messageResult, templateResult] = await Promise.allSettled([
         messages.createEmailCampaignMessage(campaignId, {
-          subject: campaign.name,
           ...params.message,
+          subject: params.message?.subject ?? campaign.name,
         }),
         templates.createEmailTemplate({
           name: `Campaign ${campaignId} template`,
@@ -729,11 +729,12 @@ export class CampaignsClient extends BaseResource {
    * Create a complete SMS campaign with all its dependencies in one call.
    *
    * Executes the full creation sequence:
-   * 1. Fetch account sender details (for the SMS sender name and unsubscribe
-   *    behavior).
+   * 1. Fetch account sender details when needed (to determine the unsubscribe
+   *    footer style for the default SMS body). Skipped when both
+   *    `message.subject` and `template.content` are provided.
    * 2. Create the campaign.
    * 3. In parallel: create the SMS message and create the SMS template (built
-   *    from the account sender details).
+   *    from the resolved SMS body text).
    * 4. Create the default dynamic set linking the message to the template.
    *
    * If any step fails, all previously created resources are deleted
@@ -756,11 +757,17 @@ export class CampaignsClient extends BaseResource {
     const templates = this.lazy('templates', () => new TemplatesClient(this.transport));
     const dynamicSets = this.lazy('dynamicSets', () => new DynamicSetsClient(this.transport));
 
-    const senderDetails = await account.getSenderDetails();
-
     const { content: templateContentOverride, ...templateMetaOverrides } = params.template ?? {};
-    const defaultSmsBody = buildDefaultSmsContent(senderDetails.linkInsteadOfStopWord ?? false);
-    const smsBody = params.message?.subject ?? defaultSmsBody;
+
+    let smsBody: string;
+
+    if (params.message?.subject === undefined) {
+      const senderDetails = await account.getSenderDetails();
+
+      smsBody = buildDefaultSmsContent(senderDetails.linkInsteadOfStopWord ?? false);
+    } else {
+      smsBody = params.message.subject;
+    }
 
     const createdResources: { type: 'campaign' | 'message' | 'template'; id: number }[] = [];
 
@@ -780,8 +787,8 @@ export class CampaignsClient extends BaseResource {
 
       const [messageResult, templateResult] = await Promise.allSettled([
         messages.createSmsCampaignMessage(campaignId, {
-          subject: smsBody,
           ...params.message,
+          subject: params.message?.subject ?? smsBody,
         }),
         templates.createSmsTemplate({
           name: `Campaign ${campaignId} SMS template`,
@@ -915,7 +922,7 @@ function mapMessageTypeToWire(type: CampaignMessageType): number {
 }
 
 /**
- * Build the default SMS body content string in RCML format.
+ * Build the default SMS body content string in SMS RFM format.
  *
  * Mirrors the frontend's `InitialSmsTemplateRcmlBuilder`: appends either a
  * link-based unsubscribe (`linkInsteadOfStopWord = true`) or a stop-word

--- a/packages/client/src/resources/campaigns/campaigns.types.ts
+++ b/packages/client/src/resources/campaigns/campaigns.types.ts
@@ -383,6 +383,83 @@ export interface ScheduleCampaignPayload {
   datetime?: string;
 }
 
+// ── Default campaign creation result ─────────────────────────────────────────
+
+/**
+ * Result from `CampaignsClient.createDefaultEmailCampaign` or
+ * `CampaignsClient.createDefaultSmsCampaign`.
+ *
+ * Contains the IDs of all resources created during the campaign setup
+ * sequence: campaign → message → template → dynamic set.
+ *
+ * @example
+ * ```typescript
+ * const result = await client.campaigns.createDefaultEmailCampaign({
+ *   brandStyleId: 42,
+ * });
+ * console.log(result.campaignId, result.messageId, result.templateId, result.dynamicSetId);
+ * ```
+ */
+export interface CreateDefaultCampaignResult {
+  /** The created campaign ID. */
+  campaignId: number;
+  /** The created message ID. */
+  messageId: number;
+  /** The created template ID. */
+  templateId: number;
+  /** The created dynamic set ID linking the message to the template. */
+  dynamicSetId: number;
+}
+
+/**
+ * Options for `CampaignsClient.createDefaultEmailCampaign`.
+ *
+ * Creates a complete email campaign with all its dependencies in one call:
+ * campaign → message → template (built from brand style) → dynamic set.
+ *
+ * @example
+ * ```typescript
+ * const result = await client.campaigns.createDefaultEmailCampaign({
+ *   brandStyleId: 42,
+ * });
+ * ```
+ */
+export interface CreateDefaultEmailCampaignParams {
+  /**
+   * Brand style ID used to build the default email template.
+   *
+   * The SDK fetches the brand style and auto-generates an editor-compatible
+   * RCML template with a logo, placeholder content section, and footer.
+   */
+  brandStyleId: number;
+  /**
+   * Initial campaign name. Defaults to a generated name when omitted.
+   */
+  name?: string;
+  /** Sendout type. Defaults to `'marketing'`. */
+  sendoutType?: CampaignSendoutType;
+}
+
+/**
+ * Options for `CampaignsClient.createDefaultSmsCampaign`.
+ *
+ * Creates a complete SMS campaign with all its dependencies in one call:
+ * campaign → message → template (built from account sender details) → dynamic set.
+ *
+ * @example
+ * ```typescript
+ * const result = await client.campaigns.createDefaultSmsCampaign();
+ * ```
+ */
+export interface CreateDefaultSmsCampaignParams {
+  /**
+   * Initial campaign name. Defaults to a generated name when omitted.
+   */
+  name?: string;
+  /** Sendout type. Defaults to `'marketing'`. */
+  sendoutType?: CampaignSendoutType;
+}
+
 // ── Internal wire types ───────────────────────────────────────────────────────
 
 /**

--- a/packages/client/src/resources/campaigns/campaigns.types.ts
+++ b/packages/client/src/resources/campaigns/campaigns.types.ts
@@ -474,7 +474,7 @@ export interface CreateDefaultEmailCampaignParams {
  * Options for `CampaignsClient.createDefaultSmsCampaign`.
  *
  * Creates a complete SMS campaign with all its dependencies in one call:
- * campaign → message → template (built from account sender details) → dynamic set.
+ * campaign → message → template → dynamic set.
  *
  * @example
  * ```typescript
@@ -492,23 +492,23 @@ export interface CreateDefaultSmsCampaignParams {
    * Optional overrides for the auto-created SMS message.
    *
    * Any field provided here replaces the default. `subject` (the SMS body
-   * text) defaults to a placeholder built from the account's sender
-   * configuration (including the appropriate unsubscribe footer).
+   * text) defaults to a placeholder with an unsubscribe footer; the footer
+   * style (link vs stop-word) is determined from the account's sender
+   * configuration, fetched automatically when `subject` is omitted.
    */
   message?: Partial<CreateSmsCampaignMessagePayload>;
   /**
    * Optional overrides for the auto-created SMS template.
    *
-   * Provide `content` to supply a custom SMS document — this skips the
-   * account sender details fetch for template building. Provide `name` to
-   * override the auto-generated template name.
+   * Provide `name` to override the auto-generated template name. Provide
+   * `content` to supply a custom SMS document.
    */
   template?: {
     /** Template name. Defaults to `'Campaign ${id} SMS template'`. */
     name?: string;
     /**
-     * Custom SMS document. When omitted the SDK auto-generates a template
-     * from the account's sender configuration.
+     * Custom SMS document. When omitted the SDK wraps the resolved SMS body
+     * text in a default SMS document.
      */
     content?: SmsDocument;
   };

--- a/packages/client/src/resources/campaigns/campaigns.types.ts
+++ b/packages/client/src/resources/campaigns/campaigns.types.ts
@@ -12,7 +12,13 @@
  * structure stays the same but the content changes (e.g. recurring newsletters).
  */
 
+import type { RcmlDocument, SmsDocument } from '@rulecom/rcml';
+
 import type { PagePaginationParams, RuleApiResponse } from '../../shared.types.js';
+import type {
+  CreateEmailCampaignMessagePayload,
+  CreateSmsCampaignMessagePayload,
+} from '../messages/messages.types.js';
 
 // ── Public SDK types ──────────────────────────────────────────────────────────
 
@@ -430,6 +436,7 @@ export interface CreateDefaultEmailCampaignParams {
    *
    * The SDK fetches the brand style and auto-generates an editor-compatible
    * RCML template with a logo, placeholder content section, and footer.
+   * Not fetched when `template.content` is provided.
    */
   brandStyleId: number;
   /**
@@ -438,6 +445,29 @@ export interface CreateDefaultEmailCampaignParams {
   name?: string;
   /** Sendout type. Defaults to `'marketing'`. */
   sendoutType?: CampaignSendoutType;
+  /**
+   * Optional overrides for the auto-created email message.
+   *
+   * Any field provided here replaces the default. `subject` defaults to the
+   * campaign name when omitted.
+   */
+  message?: Partial<CreateEmailCampaignMessagePayload>;
+  /**
+   * Optional overrides for the auto-created email template.
+   *
+   * Provide `content` to supply a custom RCML document — this skips the brand
+   * style fetch entirely. Provide `name` to override the auto-generated
+   * template name.
+   */
+  template?: {
+    /** Template name. Defaults to `'Campaign ${id} template'`. */
+    name?: string;
+    /**
+     * Custom RCML document. When omitted the SDK auto-generates a branded
+     * template from `brandStyleId`.
+     */
+    content?: RcmlDocument;
+  };
 }
 
 /**
@@ -458,6 +488,30 @@ export interface CreateDefaultSmsCampaignParams {
   name?: string;
   /** Sendout type. Defaults to `'marketing'`. */
   sendoutType?: CampaignSendoutType;
+  /**
+   * Optional overrides for the auto-created SMS message.
+   *
+   * Any field provided here replaces the default. `subject` (the SMS body
+   * text) defaults to a placeholder built from the account's sender
+   * configuration (including the appropriate unsubscribe footer).
+   */
+  message?: Partial<CreateSmsCampaignMessagePayload>;
+  /**
+   * Optional overrides for the auto-created SMS template.
+   *
+   * Provide `content` to supply a custom SMS document — this skips the
+   * account sender details fetch for template building. Provide `name` to
+   * override the auto-generated template name.
+   */
+  template?: {
+    /** Template name. Defaults to `'Campaign ${id} SMS template'`. */
+    name?: string;
+    /**
+     * Custom SMS document. When omitted the SDK auto-generates a template
+     * from the account's sender configuration.
+     */
+    content?: SmsDocument;
+  };
 }
 
 // ── Internal wire types ───────────────────────────────────────────────────────

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -130,6 +130,9 @@ export type {
   CampaignRecipients,
   CampaignSendoutType,
   CampaignStatus,
+  CreateDefaultCampaignResult,
+  CreateDefaultEmailCampaignParams,
+  CreateDefaultSmsCampaignParams,
   CreateEmailCampaignPayload,
   CreateSmsCampaignPayload,
   ListCampaignsParams,
@@ -169,6 +172,11 @@ export type {
   CreateApiKeyPayload,
   UpdateApiKeyPayload,
 } from './resources/api-keys/api-keys.types.js';
+
+// ── Account ───────────────────────────────────────────────────────────────────
+export type {
+  AccountSenderDetails,
+} from './resources/account/account.types.js';
 
 // ── Exports ──────────────────────────────────────────────────────────────────
 export type {


### PR DESCRIPTION
## Summary

- Add `createDefaultEmailCampaign()` and `createDefaultSmsCampaign()` orchestration methods to the campaigns client — each creates a campaign, message, template, and dynamic set in a single call with automatic rollback on failure
- Add `client.account.getSenderDetails()` — fetches email/SMS sender config; used internally by the SMS default campaign method to determine unsubscribe style
- Add `packages/client/docs/account.md` documenting the account namespace
- Document both `createDefault*` methods in `email-campaigns.md` and `sms-campaigns.md`
- Wire `account.md` into the sidebar

## Test plan

- [ ] Review orchestration logic and rollback behaviour in the implementation commit
- [ ] Check that the account page renders correctly in VitePress
- [ ] Verify cross-references between account, sms-campaigns, and email-campaigns pages are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)