### PR TITLE
feat: rename npm scope from @rulecom to @rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,24 +56,24 @@ jobs:
           fail=0
           for pkg in packages/*/package.json; do
             name=$(jq -r '.name' "$pkg")
-            # Per-package allowlist of non-@rulecom/* runtime deps. Adding
+            # Per-package allowlist of non-@rule/* runtime deps. Adding
             # an entry here means we accept that the dep ships in the
             # published tarball and counts toward each consumer's install
             # footprint.
             case "$name" in
-              "@rulecom/rcml")
+              "@rule/rcml")
                 # sanitize-url: URL sanitisation used in RCML elements; ajv:
                 # JSON-schema validator; prosemirror-model: doc nodes;
                 # remark-* / unified / vfile / mdast-*: markdown→RCML pipeline;
                 # fast-xml-parser: RCML XML round-trip; zod: runtime schema.
                 allowed='["@braintree/sanitize-url","@types/mdast","@types/unist","ajv","fast-xml-parser","mdast-util-directive","prosemirror-model","remark-directive","remark-parse","unified","vfile","zod"]'
                 ;;
-              "@rulecom/client")
+              "@rule/client")
                 # sanitize-url: URL sanitisation used when constructing API requests.
                 allowed='["@braintree/sanitize-url"]'
                 ;;
-              "@rulecom/template-engine")
-                # No external runtime deps — only @rulecom/rcml (internal).
+              "@rule/template-engine")
+                # No external runtime deps — only @rule/rcml (internal).
                 allowed='[]'
                 ;;
               *)
@@ -83,7 +83,7 @@ jobs:
             bad=$(jq --argjson allowed "$allowed" -r '
               (.dependencies // {})
               | to_entries
-              | map(select(.key | startswith("@rulecom/") | not))
+              | map(select(.key | startswith("@rule/") | not))
               | map(select(.key as $k | ($allowed | index($k)) | not))
               | .[].key
             ' "$pkg")

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -8,7 +8,7 @@ uplinks:
     maxage: 60m
 
 packages:
-  '@rulecom/*':
+  '@rule/*':
     access: $all
     publish: $all
     unpublish: $all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### 🚀 Features
 
-- **client:** refactor subscriber tag API and add @rulecom/client docs ([b302c59](https://github.com/rulecom/rule-io-sdk/commit/b302c59))
+- **client:** refactor subscriber tag API and add @rule/client docs ([b302c59](https://github.com/rulecom/rule-io-sdk/commit/b302c59))
 - **client:** add getByCustomIdentifier() subscriber lookup method ([e1c6d41](https://github.com/rulecom/rule-io-sdk/commit/e1c6d41))
 - **client:** add tag automation methods, syncSegments option, and docs ([851a97d](https://github.com/rulecom/rule-io-sdk/commit/851a97d))
 - **client:** refactor messages namespace with dispatcher-specific types and OpenAPI wire fixes ([4c160f1](https://github.com/rulecom/rule-io-sdk/commit/4c160f1))
@@ -54,7 +54,7 @@
 - **client:** refactor custom-field namespace with full paginated list family ([2c6e0db](https://github.com/rulecom/rule-io-sdk/commit/2c6e0db))
 - **client:** expose AnalyticsMetrics, AnalyticsObjectTypes, AnalyticsMessageTypes constants ([189c6a2](https://github.com/rulecom/rule-io-sdk/commit/189c6a2))
 - **client:** accept SubscriberIdentifier in getSubscriberTags ([796f33a](https://github.com/rulecom/rule-io-sdk/commit/796f33a))
-- **client:** refactor subscriber tag API and add @rulecom/client docs ([#149](https://github.com/rulecom/rule-io-sdk/pull/149))
+- **client:** refactor subscriber tag API and add @rule/client docs ([#149](https://github.com/rulecom/rule-io-sdk/pull/149))
 
 ### 🩹 Fixes
 
@@ -195,4 +195,4 @@
 
 First public beta of the Rule.io TypeScript SDK.
 
-Published packages: `@rulecom/client`, `@rulecom/rcml`, `@rulecom/sdk`.
+Published packages: `@rule/client`, `@rule/rcml`, `@rule/sdk`.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Nx monorepo for the Rule.io TypeScript SDK. Detailed usage docs live in [`packag
 
 | Package | Purpose | Status |
 |---|---|---|
-| [`@rulecom/rcml`](packages/rcml) | RCML email-template builders, types, and validators | **Released** |
-| [`@rulecom/client`](packages/client) | HTTP wrapper around the Rule.io v2/v3 API | **Released** |
-| [`@rulecom/sdk`](packages/sdk) | Meta-package re-exporting `@rulecom/rcml` + `@rulecom/client` | **Released** |
-| [`@rulecom/template-engine`](packages/template-engine) | XML template engine powering vendor email templates | Under development |
-| [`@rulecom/vendor`](packages/vendor) | Shared vendor-preset infrastructure | Under development |
-| [`@rulecom/vendor-shopify`](packages/vendor-shopify) | Shopify preset — e-commerce automation flows | Under development |
-| [`@rulecom/vendor-bookzen`](packages/vendor-bookzen) | Bookzen preset — hospitality automation flows | Under development |
-| [`@rulecom/vendor-samfora`](packages/vendor-samfora) | Samfora preset — Swedish donation flows | Under development |
+| [`@rule/rcml`](packages/rcml) | RCML email-template builders, types, and validators | **Released** |
+| [`@rule/client`](packages/client) | HTTP wrapper around the Rule.io v2/v3 API | **Released** |
+| [`@rule/sdk`](packages/sdk) | Meta-package re-exporting `@rule/rcml` + `@rule/client` | **Released** |
+| [`@rule/template-engine`](packages/template-engine) | XML template engine powering vendor email templates | Under development |
+| [`@rule/vendor`](packages/vendor) | Shared vendor-preset infrastructure | Under development |
+| [`@rule/vendor-shopify`](packages/vendor-shopify) | Shopify preset — e-commerce automation flows | Under development |
+| [`@rule/vendor-bookzen`](packages/vendor-bookzen) | Bookzen preset — hospitality automation flows | Under development |
+| [`@rule/vendor-samfora`](packages/vendor-samfora) | Samfora preset — Swedish donation flows | Under development |
 
 ---
 
@@ -23,20 +23,20 @@ Most consumers install **one** package — npm pulls in everything else as trans
 
 | If you want to… | Install | Notes |
 |---|---|---|
-| Call the Rule.io HTTP API | `@rulecom/client` | The 90% case. Brings in `@rulecom/rcml` automatically. |
-| Compose custom RCML templates from primitives | `@rulecom/rcml` | Low-level builders only — pair with `@rulecom/client` to send. |
-| Try everything in one install (prototypes, demos) | `@rulecom/sdk` | Meta-package re-exporting the libraries above. |
+| Call the Rule.io HTTP API | `@rule/client` | The 90% case. Brings in `@rule/rcml` automatically. |
+| Compose custom RCML templates from primitives | `@rule/rcml` | Low-level builders only — pair with `@rule/client` to send. |
+| Try everything in one install (prototypes, demos) | `@rule/sdk` | Meta-package re-exporting the libraries above. |
 
 ### Examples
 
 Just calling the API:
 
 ```bash
-npm install @rulecom/client
+npm install @rule/client
 ```
 
 ```ts
-import { RuleClient } from '@rulecom/client';
+import { RuleClient } from '@rule/client';
 
 const client = new RuleClient({ apiKey: process.env.RULE_API_KEY! });
 await client.addSubscriberTagsV3('user@example.com', { tags: ['welcome'] });
@@ -45,14 +45,14 @@ await client.addSubscriberTagsV3('user@example.com', { tags: ['welcome'] });
 Kitchen sink for prototyping:
 
 ```bash
-npm install @rulecom/sdk
+npm install @rule/sdk
 ```
 
 ```ts
-import { RuleClient, createBrandTemplate } from '@rulecom/sdk';
+import { RuleClient, createBrandTemplate } from '@rule/sdk';
 ```
 
-> `@rulecom/template-engine` is an infrastructure package — it almost never appears in a consumer's `package.json`. It arrives as a transitive dependency of the vendor preset packages (not yet released).
+> `@rule/template-engine` is an infrastructure package — it almost never appears in a consumer's `package.json`. It arrives as a transitive dependency of the vendor preset packages (not yet released).
 
 ---
 
@@ -165,7 +165,7 @@ Scope your commits when a change is package-specific: `fix(client): …`, `feat(
 
 ### npm dist-tags
 
-- Beta releases publish under the **`beta`** dist-tag → `npm install @rulecom/client@beta`
+- Beta releases publish under the **`beta`** dist-tag → `npm install @rule/client@beta`
 - Stable releases publish under **`latest`**
 
 ### What gets published

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -7,7 +7,7 @@ const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), '../src');
 
 export default defineConfig({
   title: 'Rule.io SDK',
-  description: 'Documentation for @rulecom/client, @rulecom/rcml, and @rulecom/sdk',
+  description: 'Documentation for @rule/client, @rule/rcml, and @rule/sdk',
   srcDir: 'src',
   base: (process.env['DOCS_BASE'] ?? '/rule-io-sdk/') as `/${string}/`,
 

--- a/apps/docs/.vitepress/sidebar.ts
+++ b/apps/docs/.vitepress/sidebar.ts
@@ -3,9 +3,9 @@ import { join } from 'node:path';
 import type { DefaultTheme } from 'vitepress';
 
 const API_PACKAGES: { dir: string; label: string }[] = [
-  { dir: 'client/src', label: '@rulecom/client' },
-  { dir: 'rcml/src', label: '@rulecom/rcml' },
-  { dir: 'sdk/src', label: '@rulecom/sdk' },
+  { dir: 'client/src', label: '@rule/client' },
+  { dir: 'rcml/src', label: '@rule/rcml' },
+  { dir: 'sdk/src', label: '@rule/sdk' },
 ];
 
 const CATEGORIES: { dir: string; label: string }[] = [
@@ -56,14 +56,21 @@ export const guideSidebar: DefaultTheme.SidebarItem[] = [
     ],
   },
   {
-    text: '@rulecom/sdk',
+    text: 'Migration',
+    collapsed: false,
+    items: [
+      { text: '@rulecom → @rule', link: '/guide/migration' },
+    ],
+  },
+  {
+    text: '@rule/sdk',
     collapsed: false,
     items: [
       { text: 'Overview', link: '/packages/sdk/' },
     ],
   },
   {
-    text: '@rulecom/client',
+    text: '@rule/client',
     collapsed: false,
     items: [
       { text: 'Overview', link: '/packages/client/' },
@@ -124,7 +131,7 @@ export const guideSidebar: DefaultTheme.SidebarItem[] = [
     ],
   },
   {
-    text: '@rulecom/rcml',
+    text: '@rule/rcml',
     collapsed: false,
     items: [
       { text: 'Overview', link: '/packages/rcml/' },

--- a/apps/docs/src/guide/getting-started.md
+++ b/apps/docs/src/guide/getting-started.md
@@ -3,10 +3,10 @@
 ## Installation
 
 ```bash
-npm install @rulecom/sdk
+npm install @rule/sdk
 ```
 
-`@rulecom/sdk` is the recommended entry point. It re-exports everything from `@rulecom/client` and `@rulecom/rcml` so you only need one install.
+`@rule/sdk` is the recommended entry point. It re-exports everything from `@rule/client` and `@rule/rcml` so you only need one install.
 
 ## Authentication
 
@@ -15,7 +15,7 @@ Get your API key from [Rule.io Settings → API](https://app.rule.io/v5/#/app/se
 ## Quick Start
 
 ```typescript
-import { RuleClient } from '@rulecom/sdk';
+import { RuleClient } from '@rule/sdk';
 
 const client = new RuleClient({ apiKey: process.env.RULE_API_KEY! });
 
@@ -54,7 +54,7 @@ Throws `RuleClientError` if the API key is missing, or `RuleApiError` with statu
 ## Error Handling
 
 ```typescript
-import { RuleApiError, RuleClientError } from '@rulecom/sdk';
+import { RuleApiError, RuleClientError } from '@rule/sdk';
 
 try {
   await client.createSubscriberV3({ email: 'user@example.com' });

--- a/apps/docs/src/guide/migration.md
+++ b/apps/docs/src/guide/migration.md
@@ -1,0 +1,43 @@
+# Migrating to @rule
+
+All Rule.io SDK packages have been renamed from the `@rulecom` scope to `@rule`. The API is unchanged — only the package names and import paths need to be updated.
+
+## Install the new packages
+
+Replace your existing `@rulecom` packages with the `@rule` equivalents.
+
+If you use the meta-package:
+
+```bash
+npm uninstall @rulecom/sdk
+npm install @rule/sdk
+```
+
+If you use individual packages:
+
+```bash
+npm uninstall @rulecom/client @rulecom/rcml
+npm install @rule/client @rule/rcml
+```
+
+## Update your imports
+
+Find and replace all `@rulecom/` occurrences in your source files with `@rule/`.
+
+```typescript
+// Before
+import { RuleClient } from '@rulecom/sdk';
+import { RuleApiError } from '@rulecom/client';
+import { xmlToRcml } from '@rulecom/rcml';
+
+// After
+import { RuleClient } from '@rule/sdk';
+import { RuleApiError } from '@rule/client';
+import { xmlToRcml } from '@rule/rcml';
+```
+
+## Compatibility
+
+The `@rulecom/*` packages on npm are deprecated and will no longer receive updates. All new releases are published exclusively under `@rule/*`.
+
+If you are setting up a new project, see [Getting Started](/guide/getting-started).

--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: Rule.io SDK
-  tagline: '@rulecom/client · @rulecom/rcml · @rulecom/sdk'
+  tagline: '@rule/client · @rule/rcml · @rule/sdk'
   actions:
     - theme: brand
       text: Get Started

--- a/package-lock.json
+++ b/package-lock.json
@@ -3963,35 +3963,35 @@
         "win32"
       ]
     },
-    "node_modules/@rulecom/client": {
+    "node_modules/@rule/client": {
       "resolved": "packages/client",
       "link": true
     },
-    "node_modules/@rulecom/rcml": {
+    "node_modules/@rule/rcml": {
       "resolved": "packages/rcml",
       "link": true
     },
-    "node_modules/@rulecom/sdk": {
+    "node_modules/@rule/sdk": {
       "resolved": "packages/sdk",
       "link": true
     },
-    "node_modules/@rulecom/template-engine": {
+    "node_modules/@rule/template-engine": {
       "resolved": "packages/template-engine",
       "link": true
     },
-    "node_modules/@rulecom/vendor": {
+    "node_modules/@rule/vendor": {
       "resolved": "packages/vendor",
       "link": true
     },
-    "node_modules/@rulecom/vendor-bookzen": {
+    "node_modules/@rule/vendor-bookzen": {
       "resolved": "packages/vendor-bookzen",
       "link": true
     },
-    "node_modules/@rulecom/vendor-samfora": {
+    "node_modules/@rule/vendor-samfora": {
       "resolved": "packages/vendor-samfora",
       "link": true
     },
-    "node_modules/@rulecom/vendor-shopify": {
+    "node_modules/@rule/vendor-shopify": {
       "resolved": "packages/vendor-shopify",
       "link": true
     },
@@ -15264,18 +15264,18 @@
       }
     },
     "packages/cli": {
-      "name": "@rulecom/cli",
+      "name": "@rule/cli",
       "version": "0.3.0",
       "extraneous": true,
       "license": "MIT",
       "dependencies": {
-        "@rulecom/client": "0.3.0",
-        "@rulecom/core": "0.3.0",
-        "@rulecom/rcml": "0.3.0",
-        "@rulecom/vendor": "0.3.0",
-        "@rulecom/vendor-bookzen": "0.3.0",
-        "@rulecom/vendor-samfora": "0.3.0",
-        "@rulecom/vendor-shopify": "0.3.0",
+        "@rule/client": "0.3.0",
+        "@rule/core": "0.3.0",
+        "@rule/rcml": "0.3.0",
+        "@rule/vendor": "0.3.0",
+        "@rule/vendor-bookzen": "0.3.0",
+        "@rule/vendor-samfora": "0.3.0",
+        "@rule/vendor-shopify": "0.3.0",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -15286,19 +15286,19 @@
       }
     },
     "packages/client": {
-      "name": "@rulecom/client",
+      "name": "@rule/client",
       "version": "0.4.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
-        "@rulecom/rcml": "0.4.0-beta.7"
+        "@rule/rcml": "0.4.0-beta.7"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/core": {
-      "name": "@rulecom/core",
+      "name": "@rule/core",
       "version": "0.3.0",
       "extraneous": true,
       "license": "MIT",
@@ -15307,7 +15307,7 @@
       }
     },
     "packages/rcml": {
-      "name": "@rulecom/rcml",
+      "name": "@rule/rcml",
       "version": "0.4.0-beta.7",
       "license": "MIT",
       "dependencies": {
@@ -15368,30 +15368,30 @@
       }
     },
     "packages/sdk": {
-      "name": "@rulecom/sdk",
+      "name": "@rule/sdk",
       "version": "0.4.0-beta.7",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/client": "0.4.0-beta.7",
-        "@rulecom/rcml": "0.4.0-beta.7"
+        "@rule/client": "0.4.0-beta.7",
+        "@rule/rcml": "0.4.0-beta.7"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/template-engine": {
-      "name": "@rulecom/template-engine",
+      "name": "@rule/template-engine",
       "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "*"
+        "@rule/rcml": "*"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/templates": {
-      "name": "@rulecom/templates",
+      "name": "@rule/templates",
       "version": "0.6.0",
       "extraneous": true,
       "license": "MIT",
@@ -15400,51 +15400,51 @@
       }
     },
     "packages/vendor": {
-      "name": "@rulecom/vendor",
+      "name": "@rule/vendor",
       "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "*"
+        "@rule/rcml": "*"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/vendor-bookzen": {
-      "name": "@rulecom/vendor-bookzen",
+      "name": "@rule/vendor-bookzen",
       "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/client": "*",
-        "@rulecom/rcml": "*",
-        "@rulecom/template-engine": "*",
-        "@rulecom/vendor": "*"
+        "@rule/client": "*",
+        "@rule/rcml": "*",
+        "@rule/template-engine": "*",
+        "@rule/vendor": "*"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/vendor-samfora": {
-      "name": "@rulecom/vendor-samfora",
+      "name": "@rule/vendor-samfora",
       "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "*",
-        "@rulecom/template-engine": "*",
-        "@rulecom/vendor": "*"
+        "@rule/rcml": "*",
+        "@rule/template-engine": "*",
+        "@rule/vendor": "*"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/vendor-shopify": {
-      "name": "@rulecom/vendor-shopify",
+      "name": "@rule/vendor-shopify",
       "version": "0.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@rulecom/rcml": "*",
-        "@rulecom/template-engine": "*",
-        "@rulecom/vendor": "*"
+        "@rule/rcml": "*",
+        "@rule/template-engine": "*",
+        "@rule/vendor": "*"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rule-io-sdk",
   "version": "0.4.0-beta.0",
   "private": true,
-  "description": "Rule.io SDK monorepo \u2014 publishable packages under @rulecom/*",
+  "description": "Rule.io SDK monorepo \u2014 publishable packages under @rule/*",
   "workspaces": [
     "packages/*"
   ],
@@ -17,7 +17,7 @@
     "release": "nx release",
     "local-registry": "nx run rule-io-sdk:local-registry",
     "publish:local": "nx run-many -t build && nx release publish --registry http://localhost:4873",
-    "republish:local": "rm -rf tmp/local-registry/storage/@rulecom && npm run publish:local",
+    "republish:local": "rm -rf tmp/local-registry/storage/@rule && npm run publish:local",
     "daemon:restart": "nx daemon --stop && nx daemon --start",
     "docs:generate": "nx run docs:generate",
     "docs:check": "nx run docs:check",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -39,7 +39,7 @@
 - **client:** refactor messages namespace with dispatcher-specific types and OpenAPI wire fixes ([4c160f1](https://github.com/rulecom/rule-io-sdk/commit/4c160f1))
 - **client:** add tag automation methods, syncSegments option, and docs ([851a97d](https://github.com/rulecom/rule-io-sdk/commit/851a97d))
 - **client:** add getByCustomIdentifier() subscriber lookup method ([e1c6d41](https://github.com/rulecom/rule-io-sdk/commit/e1c6d41))
-- **client:** refactor subscriber tag API and add @rulecom/client docs ([b302c59](https://github.com/rulecom/rule-io-sdk/commit/b302c59))
+- **client:** refactor subscriber tag API and add @rule/client docs ([b302c59](https://github.com/rulecom/rule-io-sdk/commit/b302c59))
 
 ### 🩹 Fixes
 
@@ -126,7 +126,7 @@ This was a version bump only for client to align it with other projects, there w
 
 ### Initial Beta Release
 
-First public beta of `@rulecom/client` — a TypeScript HTTP client for the Rule.io email marketing API.
+First public beta of `@rule/client` — a TypeScript HTTP client for the Rule.io email marketing API.
 
 #### Features
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,9 +1,9 @@
-# @rulecom/client
+# @rule/client
 
 HTTP API client for the Rule.io email-marketing platform. Wraps the v2 and v3 endpoints for subscribers, automations, messages, templates, campaigns, exports, analytics, brand styles, and API keys.
 
 ```ts
-import { RuleClient } from '@rulecom/client';
+import { RuleClient } from '@rule/client';
 
 const client = new RuleClient({ apiKey: process.env.RULE_API_KEY! });
 
@@ -15,6 +15,6 @@ await client.subscribers.create({
 
 ## Composes with
 
-- [`@rulecom/rcml`](../rcml/README.md) — build email templates that the client sends via `client.createAutomationEmail()` / `client.createCampaignEmail()`.
+- [`@rule/rcml`](../rcml/README.md) — build email templates that the client sends via `client.createAutomationEmail()` / `client.createCampaignEmail()`.
 
-See the [main `@rulecom/sdk` README](../sdk/README.md) for end-to-end usage.
+See the [main `@rule/sdk` README](../sdk/README.md) for end-to-end usage.

--- a/packages/client/docs/analytics.md
+++ b/packages/client/docs/analytics.md
@@ -22,7 +22,7 @@ Dates are required. The time portion is stripped automatically — `'2025-01-01T
 To drill into a specific campaign (or multiple campaigns), provide `objectType`, `objectIds`, and the `metrics` you want. Use the `AnalyticsObjectTypes` and `AnalyticsMetrics` constants for autocomplete:
 
 ```typescript
-import { AnalyticsMetrics, AnalyticsObjectTypes } from '@rulecom/client';
+import { AnalyticsMetrics, AnalyticsObjectTypes } from '@rule/client';
 
 const result = await client.analytics.get({
   dateFrom: '2025-01-01',
@@ -46,7 +46,7 @@ When `objectType` is provided, both `objectIds` and `metrics` must be non-empty 
 ## Getting metrics for automations
 
 ```typescript
-import { AnalyticsMetrics, AnalyticsObjectTypes } from '@rulecom/client';
+import { AnalyticsMetrics, AnalyticsObjectTypes } from '@rule/client';
 
 const result = await client.analytics.get({
   dateFrom: '2025-01-01',
@@ -62,7 +62,7 @@ const result = await client.analytics.get({
 Narrow results to a specific channel:
 
 ```typescript
-import { AnalyticsMessageTypes } from '@rulecom/client';
+import { AnalyticsMessageTypes } from '@rule/client';
 
 const result = await client.analytics.get({
   dateFrom: '2025-01-01',

--- a/packages/client/docs/async-operations.md
+++ b/packages/client/docs/async-operations.md
@@ -1,6 +1,6 @@
 # Asynchronous Operations
 
-Some methods in `@rulecom/client` return immediately once Rule.io has accepted the request. The actual work — tagging subscribers, blocking contacts, sending bulk updates — happens in the background on Rule.io's side.
+Some methods in `@rule/client` return immediately once Rule.io has accepted the request. The actual work — tagging subscribers, blocking contacts, sending bulk updates — happens in the background on Rule.io's side.
 
 These methods are:
 

--- a/packages/client/docs/brand-styles.md
+++ b/packages/client/docs/brand-styles.md
@@ -6,10 +6,10 @@ You can manage brand styles through the API or in the Rule.io UI under **Setting
 
 ## Finding the account's default brand style
 
-Use `resolvePreferredBrandStyle()` from `@rulecom/sdk` — it returns the style flagged `isDefault` on the account, falling back to the first in the list if none is marked default. Do not hardcode brand style IDs; a customer's preferred style can change:
+Use `resolvePreferredBrandStyle()` from `@rule/sdk` — it returns the style flagged `isDefault` on the account, falling back to the first in the list if none is marked default. Do not hardcode brand style IDs; a customer's preferred style can change:
 
 ```typescript
-import { resolvePreferredBrandStyle } from '@rulecom/sdk';
+import { resolvePreferredBrandStyle } from '@rule/sdk';
 
 const { id: brandStyleId, brandStyle, source } =
   await resolvePreferredBrandStyle(client);
@@ -112,5 +112,5 @@ await client.brandStyles.delete(brandStyleId);
 
 ## Next steps
 
-- Pass `brandStyleId` to the RCML template builders: [@rulecom/rcml documentation](/packages/rcml/)
+- Pass `brandStyleId` to the RCML template builders: [@rule/rcml documentation](/packages/rcml/)
 - Build a complete campaign email: [Email Campaigns](./email-campaigns)

--- a/packages/client/docs/custom-fields.md
+++ b/packages/client/docs/custom-fields.md
@@ -288,4 +288,4 @@ await client.subscribers.deleteCustomFieldDataByGroup(subscriberId, 169233); // 
 
 - Write custom fields alongside subscriber upsert: [Syncing Subscribers](./syncing-subscribers)
 - Assign and remove tags: [Organizing with Tags](./organizing-with-tags)
-- Use custom fields in email templates: [@rulecom/rcml](/packages/rcml/)
+- Use custom fields in email templates: [@rule/rcml](/packages/rcml/)

--- a/packages/client/docs/email-campaigns.md
+++ b/packages/client/docs/email-campaigns.md
@@ -29,7 +29,7 @@ const campaignId = campaign.id!;
 Use `createDefaultEmailCampaign()` to create a campaign with all required content in a single call. The method creates the campaign, message, and a branded email template in parallel, then links them together with a dynamic set. If any step fails, all already-created resources are automatically rolled back.
 
 ```typescript
-import { resolvePreferredBrandStyle } from '@rulecom/sdk';
+import { resolvePreferredBrandStyle } from '@rule/sdk';
 
 const { id: brandStyleId } = await resolvePreferredBrandStyle(client);
 

--- a/packages/client/docs/email-templates.md
+++ b/packages/client/docs/email-templates.md
@@ -9,7 +9,7 @@ A template holds the email body written in [RCML](/packages/rcml/). Templates ar
 Use `createEmailTemplate()` to create a new email template. The template's RCML document defines the visual structure and content of the email.
 
 ```typescript
-import { buildRcmlDocument } from '@rulecom/rcml';
+import { buildRcmlDocument } from '@rule/rcml';
 
 const rcml = buildRcmlDocument({ /* ... your template ... */ });
 
@@ -24,7 +24,7 @@ Template names must be unique within the account. When creating templates progra
 
 *→ [`CreateEmailTemplatePayload`](/api/client/src/interfaces/CreateEmailTemplatePayload)*
 
-See the [@rulecom/rcml documentation](/packages/rcml/) for how to build the RCML document.
+See the [@rule/rcml documentation](/packages/rcml/) for how to build the RCML document.
 
 ## Fetching a template
 
@@ -122,4 +122,4 @@ for await (const page of client.templates.iterateTemplatesPages({ pagination: { 
 ## Next steps
 
 - Link the template to a message: [Dynamic Sets](./dynamic-sets)
-- Build RCML templates: [@rulecom/rcml documentation](/packages/rcml/)
+- Build RCML templates: [@rule/rcml documentation](/packages/rcml/)

--- a/packages/client/docs/error-handling.md
+++ b/packages/client/docs/error-handling.md
@@ -5,7 +5,7 @@ The client uses two error classes and a consistent `null`-for-404 pattern. Under
 ## The two error classes
 
 ```typescript
-import { RuleApiError, RuleClientError } from '@rulecom/client';
+import { RuleApiError, RuleClientError } from '@rule/client';
 ```
 
 ### `RuleApiError`

--- a/packages/client/docs/index.md
+++ b/packages/client/docs/index.md
@@ -1,19 +1,19 @@
-# @rulecom/client
+# @rule/client
 
-`@rulecom/client` is the HTTP API client for the [Rule.io](https://rule.io) marketing platform. It covers the full Rule.io API surface: subscriber management, audience segmentation, email and SMS campaigns and automations, templates, analytics, and more.
+`@rule/client` is the HTTP API client for the [Rule.io](https://rule.io) marketing platform. It covers the full Rule.io API surface: subscriber management, audience segmentation, email and SMS campaigns and automations, templates, analytics, and more.
 
-> **Most users should install `@rulecom/sdk` instead.** It re-exports everything from this package and adds the RCML template builders and high-level helpers on top.
+> **Most users should install `@rule/sdk` instead.** It re-exports everything from this package and adds the RCML template builders and high-level helpers on top.
 
 ## Installation
 
 ```bash
-npm install @rulecom/client
+npm install @rule/client
 ```
 
 ## Connecting to Rule.io
 
 ```typescript
-import { RuleClient } from '@rulecom/client';
+import { RuleClient } from '@rule/client';
 
 const client = new RuleClient({ apiKey: process.env['RULE_API_KEY']! });
 ```
@@ -46,7 +46,7 @@ You can also pass the API key as a plain string: `new RuleClient(apiKey)`.
 Two error classes are exported from this package:
 
 ```typescript
-import { RuleApiError, RuleClientError } from '@rulecom/client';
+import { RuleApiError, RuleClientError } from '@rule/client';
 ```
 
 - **`RuleApiError`** — the Rule.io API returned a non-2xx response. Provides `.statusCode`, `.isAuthError()`, `.isValidationError()`, and `.validationErrors`.

--- a/packages/client/docs/sms-campaigns.md
+++ b/packages/client/docs/sms-campaigns.md
@@ -45,7 +45,7 @@ const result = await client.campaigns.createDefaultSmsCampaign({
 Supply a custom SMS document via `template.content` to use your own template structure:
 
 ```typescript
-import { createSmsDocument } from '@rulecom/sdk';
+import { createSmsDocument } from '@rule/sdk';
 
 const result = await client.campaigns.createDefaultSmsCampaign({
   template: {

--- a/packages/client/docs/sms-templates.md
+++ b/packages/client/docs/sms-templates.md
@@ -1,13 +1,13 @@
 # SMS Templates
 
-A template holds the SMS body as an [`SmsDocument`](/packages/rcml/sms/concepts/sms-document) from `@rulecom/rcml`. Templates are independent objects — they are not linked to a message at creation time. The link is made later, via a dynamic set. This means the same template can be reused across multiple messages.
+A template holds the SMS body as an [`SmsDocument`](/packages/rcml/sms/concepts/sms-document) from `@rule/rcml`. Templates are independent objects — they are not linked to a message at creation time. The link is made later, via a dynamic set. This means the same template can be reused across multiple messages.
 
 ## Creating a template
 
 Use `createSmsTemplate()` to create a new SMS template. The template's `SmsDocument` defines the message body, including any `::placeholder{…}` directives or `:link[…]{…}` link marks.
 
 ```typescript
-import { createSmsDocument } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
 
 const sms = createSmsDocument({
   content: 'Hi ::placeholder{type="Subscriber" original="[Subscriber:FirstName]" name="First name"}, your order has shipped!',
@@ -24,7 +24,7 @@ Template names must be unique within the account. When creating templates progra
 
 *→ [`CreateSmsTemplatePayload`](/api/client/src/interfaces/CreateSmsTemplatePayload)*
 
-See the [@rulecom/rcml SMS documentation](/packages/rcml/sms/) for how to author SMS templates — including the `sms` builder namespace for composing `SmsContentJson` programmatically and the SMS RFM source format reference.
+See the [@rule/rcml SMS documentation](/packages/rcml/sms/) for how to author SMS templates — including the `sms` builder namespace for composing `SmsContentJson` programmatically and the SMS RFM source format reference.
 
 ## Fetching a template
 
@@ -47,7 +47,7 @@ if (!template) {
 Use `updateSmsTemplate()` to change a template's name or `SmsDocument` content. Pass only the fields you want to change — omitted fields are left as-is.
 
 ```typescript
-import { createSmsDocument } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
 
 const updatedSms = createSmsDocument({ content: 'Updated SMS body…' });
 
@@ -130,4 +130,4 @@ for await (const page of client.templates.iterateTemplatesPages({ pagination: { 
 ## Next steps
 
 - Link the template to a message: [Dynamic Sets](./dynamic-sets)
-- Author SMS templates: [@rulecom/rcml SMS documentation](/packages/rcml/sms/)
+- Author SMS templates: [@rule/rcml SMS documentation](/packages/rcml/sms/)

--- a/packages/client/docs/webhooks.md
+++ b/packages/client/docs/webhooks.md
@@ -3,7 +3,7 @@
 Rule.io can POST a JSON body to a URL of your choosing whenever certain
 events happen in your account — a transaction is sent, a campaign is
 opened, a subscriber bounces, an import finishes. The
-`@rulecom/client` package provides typed event shapes plus a parser
+`@rule/client` package provides typed event shapes plus a parser
 (`parseWebhookEvent`) that turns the raw body into a discriminated
 union you can `switch` on.
 
@@ -30,7 +30,7 @@ Mount a route that reads the request body and hands it to
 union — narrow with `switch (event.type)`:
 
 ```typescript
-import { parseWebhookEvent } from '@rulecom/client';
+import { parseWebhookEvent } from '@rule/client';
 
 app.post('/webhooks/rule', (req, res) => {
   const event = parseWebhookEvent(req.body);
@@ -276,7 +276,7 @@ Rule.io — one for "added to tag" and one for "removed from tag" —
 and call `markTagDirection` on each route to commit the type:
 
 ```typescript
-import { parseWebhookEvent, markTagDirection } from '@rulecom/client';
+import { parseWebhookEvent, markTagDirection } from '@rule/client';
 
 app.post('/webhooks/rule/tag-added', (req, res) => {
   const parsed = parseWebhookEvent(req.body);

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rulecom/client",
+  "name": "@rule/client",
   "version": "0.4.0-beta.7",
   "description": "HTTP API client for the Rule.io email marketing platform.",
   "type": "module",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.2",
-    "@rulecom/rcml": "0.4.0-beta.7"
+    "@rule/rcml": "0.4.0-beta.7"
   },
   "engines": {
     "node": ">=20"

--- a/packages/client/src/brand-style-to-theme.test.ts
+++ b/packages/client/src/brand-style-to-theme.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for {@link emailThemeFromBrandStyle} — the `@rulecom/client` bridge
+ * Tests for {@link emailThemeFromBrandStyle} — the `@rule/client` bridge
  * that converts a Rule.io brand-style API response directly into an
  * {@link EmailTheme}.
  */
@@ -11,7 +11,7 @@ import {
   EmailThemeFontStyleType,
   EmailThemeImageType,
   applyTheme,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 import { emailThemeFromBrandStyle, resolveBrandTheme } from './brand-style-to-theme.js';
 import { RuleClientError } from './errors.js';

--- a/packages/client/src/brand-style-to-theme.ts
+++ b/packages/client/src/brand-style-to-theme.ts
@@ -16,7 +16,7 @@ import {
   EmailThemeFontStyleType,
   EmailThemeImageType,
   createEmailTheme,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 import type {
   EmailThemeColor,
   EmailThemeFont,
@@ -24,7 +24,7 @@ import type {
   EmailThemeImage,
   EmailThemeSocialLink,
   EmailThemeSocialLinkType,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 import { RuleClientError } from './errors.js';
 import { sanitizeUrl } from '@braintree/sanitize-url';

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -20,7 +20,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RuleApiError } from './errors.js';
 import { RuleClientError } from './errors.js';
-import type { RcmlDocument } from '@rulecom/rcml';
+import type { RcmlDocument } from '@rule/rcml';
 
 import {
   createMock204Response,

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -17,7 +17,7 @@ export const RULE_API_V3_BASE_URL = 'https://app.rule.io/api/v3';
  * @example
  * ```typescript
  * // Prefer vendor-specific tags:
- * import { SHOPIFY_TAGS } from '@rulecom/sdk';
+ * import { SHOPIFY_TAGS } from '@rule/sdk';
  * await client.syncSubscriber({
  *   email: 'customer@example.com',
  *   tags: [SHOPIFY_TAGS.orderCompleted],

--- a/packages/client/src/default-branded-template.ts
+++ b/packages/client/src/default-branded-template.ts
@@ -17,8 +17,8 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { applyTheme } from '@rulecom/rcml';
-import type { RcmlBodyChild, RcmlDocument, RcmlHead } from '@rulecom/rcml';
+import { applyTheme } from '@rule/rcml';
+import type { RcmlBodyChild, RcmlDocument, RcmlHead } from '@rule/rcml';
 
 import { emailThemeFromBrandStyle } from './brand-style-to-theme.js';
 import type { BrandStyle } from './types.js';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,8 +3,8 @@
  *
  * Wraps the v2 and v3 endpoints of the Rule.io email-marketing API. Use this
  * package to create subscribers, manage automations, send campaign emails,
- * and read analytics. Composes with `@rulecom/rcml` to build templates and
- * with the `@rulecom/vendor-*` preset packages for platform-specific flows.
+ * and read analytics. Composes with `@rule/rcml` to build templates and
+ * with the `@rule/vendor-*` preset packages for platform-specific flows.
  */
 
 export { RuleClient } from './client.js';

--- a/packages/client/src/orchestration.types.ts
+++ b/packages/client/src/orchestration.types.ts
@@ -7,7 +7,7 @@
  * consumers in a follow-up change.
  */
 
-import type { RcmlDocument, RcmlSection, RcmlLoop, RcmlSwitch } from '@rulecom/rcml';
+import type { RcmlDocument, RcmlSection, RcmlLoop, RcmlSwitch } from '@rule/rcml';
 
 import type { AutomationSendoutType } from './resources/automations/automations.types.js';
 import type {

--- a/packages/client/src/resources/account/account.client.ts
+++ b/packages/client/src/resources/account/account.client.ts
@@ -1,5 +1,5 @@
 /**
- * Account namespace client for the `@rulecom/client` package.
+ * Account namespace client for the `@rule/client` package.
  *
  * Wraps account-level configuration endpoints, including sender details
  * used when building campaign messages and SMS templates.

--- a/packages/client/src/resources/account/account.types.ts
+++ b/packages/client/src/resources/account/account.types.ts
@@ -1,5 +1,5 @@
 /**
- * Account namespace types for the `@rulecom/client` package.
+ * Account namespace types for the `@rule/client` package.
  *
  * The sender details endpoint returns account-level email and SMS sender
  * configuration used when creating campaigns.

--- a/packages/client/src/resources/automations/automations.client.ts
+++ b/packages/client/src/resources/automations/automations.client.ts
@@ -1,5 +1,5 @@
 /**
- * Automations namespace client for the `@rulecom/client` package.
+ * Automations namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/automail` endpoints. The "Automail" terminology used
  * by the underlying API is hidden — consumers see only "Automation".

--- a/packages/client/src/resources/automations/automations.types.ts
+++ b/packages/client/src/resources/automations/automations.types.ts
@@ -1,5 +1,5 @@
 /**
- * Automation types for the `@rulecom/client` automations namespace.
+ * Automation types for the `@rule/client` automations namespace.
  *
  * An automation is a trigger-based email that fires automatically when a
  * subscriber enters a tag or a segment. Unlike campaigns (one-time sends),

--- a/packages/client/src/resources/brand-styles/brand-styles.client.ts
+++ b/packages/client/src/resources/brand-styles/brand-styles.client.ts
@@ -1,5 +1,5 @@
 /**
- * Brand-styles namespace client for the `@rulecom/client` package.
+ * Brand-styles namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/brand-styles` endpoints — list, get, create (from-domain
  * or manual), update (PATCH), and delete.

--- a/packages/client/src/resources/brand-styles/brand-styles.types.ts
+++ b/packages/client/src/resources/brand-styles/brand-styles.types.ts
@@ -1,5 +1,5 @@
 /**
- * Brand-style types for the `@rulecom/client` brand-styles namespace.
+ * Brand-style types for the `@rule/client` brand-styles namespace.
  *
  * A brand style captures your visual identity — logo, colours, fonts, and
  * social links. The RCML template builders use brand styles to produce

--- a/packages/client/src/resources/campaigns/campaigns.client.ts
+++ b/packages/client/src/resources/campaigns/campaigns.client.ts
@@ -1,5 +1,5 @@
 /**
- * Campaigns namespace client for the `@rulecom/client` package.
+ * Campaigns namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/campaign` endpoints, including the auxiliary
  * `/copy` and `/schedule` actions.
@@ -15,7 +15,7 @@
  * ({@link renameCampaign}, {@link setCampaignSendoutType}, etc.).
  */
 
-import { createSmsDocument } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
 
 import { RuleApiError, RuleClientError } from '../../errors.js';
 import { BaseResource } from '../../core/base-resource.js';

--- a/packages/client/src/resources/campaigns/campaigns.types.ts
+++ b/packages/client/src/resources/campaigns/campaigns.types.ts
@@ -1,5 +1,5 @@
 /**
- * Campaign types for the `@rulecom/client` campaigns namespace.
+ * Campaign types for the `@rule/client` campaigns namespace.
  *
  * A campaign is a one-time or scheduled email blast sent to a defined set of
  * recipients. The lifecycle is:
@@ -12,7 +12,7 @@
  * structure stays the same but the content changes (e.g. recurring newsletters).
  */
 
-import type { RcmlDocument, SmsDocument } from '@rulecom/rcml';
+import type { RcmlDocument, SmsDocument } from '@rule/rcml';
 
 import type { PagePaginationParams, RuleApiResponse } from '../../shared.types.js';
 import type {

--- a/packages/client/src/resources/custom-field/custom-field.client.ts
+++ b/packages/client/src/resources/custom-field/custom-field.client.ts
@@ -1,5 +1,5 @@
 /**
- * Custom field schema client for the `@rulecom/client` package.
+ * Custom field schema client for the `@rule/client` package.
  *
  * Wraps the v2 `/customizations` endpoints for managing custom field group
  * schemas — creating groups and fields, listing them, and fetching a single

--- a/packages/client/src/resources/custom-field/custom-field.types.ts
+++ b/packages/client/src/resources/custom-field/custom-field.types.ts
@@ -1,5 +1,5 @@
 /**
- * Custom field schema types for the `@rulecom/client` customField namespace.
+ * Custom field schema types for the `@rule/client` customField namespace.
  *
  * These types wrap the v2 `/customizations` endpoints which manage the
  * structure of custom field groups and their fields. For reading and writing

--- a/packages/client/src/resources/dynamic-sets/dynamic-sets.client.ts
+++ b/packages/client/src/resources/dynamic-sets/dynamic-sets.client.ts
@@ -1,5 +1,5 @@
 /**
- * Dynamic-sets namespace client for the `@rulecom/client` package.
+ * Dynamic-sets namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/dynamic-set` endpoints. A dynamic set connects a
  * template to a message. A message can have multiple dynamic sets — one per

--- a/packages/client/src/resources/dynamic-sets/dynamic-sets.types.ts
+++ b/packages/client/src/resources/dynamic-sets/dynamic-sets.types.ts
@@ -1,5 +1,5 @@
 /**
- * Dynamic-set types for the `@rulecom/client` dynamic-sets namespace.
+ * Dynamic-set types for the `@rule/client` dynamic-sets namespace.
  *
  * A dynamic set connects a template to a message. It sits in the middle of
  * the email chain:

--- a/packages/client/src/resources/messages/messages.client.ts
+++ b/packages/client/src/resources/messages/messages.client.ts
@@ -1,5 +1,5 @@
 /**
- * Messages namespace client for the `@rulecom/client` package.
+ * Messages namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/message` endpoints. A message belongs to a single
  * dispatcher (campaign or automation) and holds the subject, sender settings,

--- a/packages/client/src/resources/messages/messages.types.ts
+++ b/packages/client/src/resources/messages/messages.types.ts
@@ -1,5 +1,5 @@
 /**
- * Message types for the `@rulecom/client` messages namespace.
+ * Message types for the `@rule/client` messages namespace.
  *
  * The Rule.io API models an email as three connected layers:
  *

--- a/packages/client/src/resources/recipients/recipients.client.ts
+++ b/packages/client/src/resources/recipients/recipients.client.ts
@@ -1,5 +1,5 @@
 /**
- * Recipients namespace client for the `@rulecom/client` package.
+ * Recipients namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/recipients/*` endpoints which return lightweight lists
  * of segments, tags, and subscribers for use when setting up recipient targeting

--- a/packages/client/src/resources/recipients/recipients.types.ts
+++ b/packages/client/src/resources/recipients/recipients.types.ts
@@ -1,5 +1,5 @@
 /**
- * Recipients types for the `@rulecom/client` recipients namespace.
+ * Recipients types for the `@rule/client` recipients namespace.
  *
  * These endpoints return lightweight lists of segments, tags, and subscribers
  * for use when setting up campaign or automation recipient targeting. They are

--- a/packages/client/src/resources/subscribers/subscribers.types.ts
+++ b/packages/client/src/resources/subscribers/subscribers.types.ts
@@ -1,5 +1,5 @@
 /**
- * Subscriber types for the `@rulecom/client` subscribers namespace.
+ * Subscriber types for the `@rule/client` subscribers namespace.
  */
 
 import type { RuleApiResponse, PagePaginationParams } from '../../shared.types.js';

--- a/packages/client/src/resources/tags/tags.client.ts
+++ b/packages/client/src/resources/tags/tags.client.ts
@@ -1,5 +1,5 @@
 /**
- * Tags namespace client for the `@rulecom/client` package.
+ * Tags namespace client for the `@rule/client` package.
  *
  * Wraps the v2 `/tags` endpoints — there is no v3 equivalent.
  *

--- a/packages/client/src/resources/tags/tags.types.ts
+++ b/packages/client/src/resources/tags/tags.types.ts
@@ -1,9 +1,9 @@
 /**
- * Tag types for the `@rulecom/client` tags namespace.
+ * Tag types for the `@rule/client` tags namespace.
  *
  * Tags wrap the v2 `/tags` API — there is no v3 equivalent.
  *
- * Note: The `RuleTag` symbol exported from `@rulecom/client` refers to
+ * Note: The `RuleTag` symbol exported from `@rule/client` refers to
  * deprecated well-known tag string literals, not this entity type.
  */
 

--- a/packages/client/src/resources/templates/templates.client.test.ts
+++ b/packages/client/src/resources/templates/templates.client.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { RuleApiError } from '../../errors.js';
-import type { RcmlDocument } from '@rulecom/rcml';
+import type { RcmlDocument } from '@rule/rcml';
 
 import {
   createMockErrorResponse,

--- a/packages/client/src/resources/templates/templates.client.ts
+++ b/packages/client/src/resources/templates/templates.client.ts
@@ -1,5 +1,5 @@
 /**
- * Templates namespace client for the `@rulecom/client` package.
+ * Templates namespace client for the `@rule/client` package.
  *
  * Wraps the v3 `/editor/template` endpoints. Templates hold RCML email bodies
  * and are linked to messages via dynamic sets — they are not associated
@@ -41,7 +41,7 @@ export class TemplatesClient extends BaseResource {
    *
    * @example
    * ```typescript
-   * import { buildRcmlDocument } from '@rulecom/rcml';
+   * import { buildRcmlDocument } from '@rule/rcml';
    *
    * const template = await client.templates.createEmailTemplate({
    *   name: 'Welcome email — v1',
@@ -124,7 +124,7 @@ export class TemplatesClient extends BaseResource {
    * Create an SMS template.
    *
    * Construct the `content` document with `createSmsDocument` from
-   * `@rulecom/rcml`. Templates are not linked to a message at creation time —
+   * `@rule/rcml`. Templates are not linked to a message at creation time —
    * use a dynamic set to connect a template to a message after both have been
    * created.
    *
@@ -133,7 +133,7 @@ export class TemplatesClient extends BaseResource {
    *
    * @example
    * ```typescript
-   * import { createSmsDocument } from '@rulecom/rcml';
+   * import { createSmsDocument } from '@rule/rcml';
    *
    * const template = await client.templates.createSmsTemplate({
    *   name: 'Order shipped SMS',
@@ -164,7 +164,7 @@ export class TemplatesClient extends BaseResource {
    *
    * @example
    * ```typescript
-   * import { createSmsDocument } from '@rulecom/rcml';
+   * import { createSmsDocument } from '@rule/rcml';
    *
    * await client.templates.updateSmsTemplate(templateId, {
    *   content: createSmsDocument({ content: 'Your order has shipped — updated!' }),

--- a/packages/client/src/resources/templates/templates.types.ts
+++ b/packages/client/src/resources/templates/templates.types.ts
@@ -1,5 +1,5 @@
 /**
- * Template types for the `@rulecom/client` templates namespace.
+ * Template types for the `@rule/client` templates namespace.
  *
  * A template holds the RCML email body. It belongs to a message via a
  * dynamic set:
@@ -15,7 +15,7 @@
  * by creating additional dynamic sets.
  */
 
-import type { RcmlDocument, SmsDocument } from '@rulecom/rcml';
+import type { RcmlDocument, SmsDocument } from '@rule/rcml';
 
 import type { PagePaginationParams, RuleApiResponse } from '../../shared.types.js';
 
@@ -111,7 +111,7 @@ export type SmsTemplate = Template;
  *
  * @example
  * ```typescript
- * import { buildRcmlDocument } from '@rulecom/rcml';
+ * import { buildRcmlDocument } from '@rule/rcml';
  *
  * const template = await client.templates.createEmailTemplate({
  *   name: 'Welcome email — v1',
@@ -136,11 +136,11 @@ export interface CreateEmailTemplatePayload {
  * Payload for `TemplatesClient.createSmsTemplate`.
  *
  * The message type is fixed to `'text_message'` by the method. Construct the
- * `content` document with `createSmsDocument` from `@rulecom/rcml`.
+ * `content` document with `createSmsDocument` from `@rule/rcml`.
  *
  * @example
  * ```typescript
- * import { createSmsDocument } from '@rulecom/rcml';
+ * import { createSmsDocument } from '@rule/rcml';
  *
  * const template = await client.templates.createSmsTemplate({
  *   name: 'Order shipped SMS',
@@ -189,7 +189,7 @@ export interface UpdateEmailTemplatePayload {
  *
  * @example
  * ```typescript
- * import { createSmsDocument } from '@rulecom/rcml';
+ * import { createSmsDocument } from '@rule/rcml';
  *
  * await client.templates.updateSmsTemplate(templateId, {
  *   content: createSmsDocument({ content: 'Your order has shipped — updated!' }),

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,10 +1,10 @@
 /**
- * Public type barrel for `@rulecom/client`.
+ * Public type barrel for `@rule/client`.
  *
  * Every type previously declared in this file lives next to its namespace
  * client (under `resources/<namespace>/<namespace>.types.ts`); this barrel
  * re-exports them all under their original names so `import type { ... }
- * from '@rulecom/client'` keeps working unchanged for downstream consumers.
+ * from '@rule/client'` keeps working unchanged for downstream consumers.
  *
  * The `RuleTag` v2 entity historically defined here is now exported as
  * `RuleTagEntity` to avoid colliding with the `RuleTag` string-literal union

--- a/packages/client/src/webhooks/mark-tag.ts
+++ b/packages/client/src/webhooks/mark-tag.ts
@@ -29,7 +29,7 @@ import type {
  *
  * @example
  * ```typescript
- * import { parseWebhookEvent, markTagDirection } from '@rulecom/client';
+ * import { parseWebhookEvent, markTagDirection } from '@rule/client';
  *
  * app.post('/webhooks/rule/tag-added', (req, res) => {
  *   const parsed = parseWebhookEvent(req.body);

--- a/packages/client/src/webhooks/parse.ts
+++ b/packages/client/src/webhooks/parse.ts
@@ -138,7 +138,7 @@ function toImportSummary(raw: Record<string, unknown>): WebhookImportSummary {
  *
  * @example
  * ```typescript
- * import { parseWebhookEvent } from '@rulecom/client';
+ * import { parseWebhookEvent } from '@rule/client';
  *
  * app.post('/webhooks/rule', (req, res) => {
  *   const event = parseWebhookEvent(req.body);

--- a/packages/rcml/CHANGELOG.md
+++ b/packages/rcml/CHANGELOG.md
@@ -97,7 +97,7 @@ This was a version bump only for rcml to align it with other projects, there wer
 
 ### Initial Beta Release
 
-First public beta of `@rulecom/rcml` — RCML (Rule Campaign Markup Language) builders, validators, and converters.
+First public beta of `@rule/rcml` — RCML (Rule Campaign Markup Language) builders, validators, and converters.
 
 #### Features
 

--- a/packages/rcml/README.md
+++ b/packages/rcml/README.md
@@ -1,12 +1,12 @@
-# @rulecom/rcml
+# @rule/rcml
 
-RCML (Rule Campaign Markup Language) template builders and type definitions. Use this package to compose email templates that you can send through the Rule.io API via `@rulecom/client` (or one of the vendor presets).
+RCML (Rule Campaign Markup Language) template builders and type definitions. Use this package to compose email templates that you can send through the Rule.io API via `@rule/client` (or one of the vendor presets).
 
 ```ts
 import {
   createRCMLDocument,
   createBrandTemplate,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 ```
 
 ## What's included
@@ -16,4 +16,4 @@ import {
 - **Types**: full RCML structural type hierarchy (`RCMLDocument`, `RCMLSection`, `RCMLProseMirrorDoc`, etc.)
 - **Automation config schema**: `AutomationConfigV2`, `TemplateConfigV2`, `getAutomationByIdV2`, `getAutomationByTriggerV2`
 
-See the [main `@rulecom/sdk` README](../sdk/README.md) for end-to-end usage examples.
+See the [main `@rule/sdk` README](../sdk/README.md) for end-to-end usage examples.

--- a/packages/rcml/docs/email/building-programmatically.md
+++ b/packages/rcml/docs/email/building-programmatically.md
@@ -1,6 +1,6 @@
 # Building programmatically
 
-The `@rulecom/rcml` package exports a set of typed factory functions that build an
+The `@rule/rcml` package exports a set of typed factory functions that build an
 `RcmlDocument` JSON AST bottom-up. Each factory validates its inputs immediately and
 throws `RcmlElementBuildError` if something is wrong — errors surface at the call site,
 not at render time.
@@ -24,7 +24,7 @@ import {
   createSpacerElement,
   createPreviewElement,
   createTextContent,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 // 1. Head — preheader text shown in inbox previews
 const head = createHeadElement({
@@ -66,7 +66,7 @@ ProseMirror JSON document. The easiest way to produce one is `createTextContent(
 which accepts an Email RFM string — a compact markdown dialect designed for email copy.
 
 ```typescript
-import { createTextContent } from '@rulecom/rcml';
+import { createTextContent } from '@rule/rcml';
 
 // Plain text
 createTextContent('Hello world')
@@ -92,7 +92,7 @@ import {
   createInlineContent,
   createTextNode,
   createPlaceholderNode,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 const content = createInlineContent([
   createTextNode('Hi '),
@@ -136,7 +136,7 @@ import {
   EmailThemeImageType,
   EmailThemeFontStyleType,
   EmailThemeSocialLinkType,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 const theme = createEmailTheme({
   // Link to the Rule brand profile that owns this template.
@@ -186,7 +186,7 @@ after the template is created.
 are filled with defaults:
 
 ```typescript
-import { getTheme } from '@rulecom/rcml';
+import { getTheme } from '@rule/rcml';
 
 const theme = getTheme(themedDoc);
 console.log(theme.colors); // [{ type: 'Primary', hex: '#05CC87' }, ...]
@@ -201,7 +201,7 @@ and writing it back.
 text elements is serialised back to Email RFM, making the output easy to read and diff.
 
 ```typescript
-import { rcmlToXml } from '@rulecom/rcml';
+import { rcmlToXml } from '@rule/rcml';
 
 const xml = rcmlToXml(themedDoc, { prettyPrint: true });
 console.log(xml);
@@ -217,7 +217,7 @@ Common uses:
 If a template is stored as XML, convert it back to JSON and validate before use:
 
 ```typescript
-import { safeXmlToRcml, safeValidateEmailTemplate } from '@rulecom/rcml';
+import { safeXmlToRcml, safeValidateEmailTemplate } from '@rule/rcml';
 
 const parsed = safeXmlToRcml(xmlString);
 if (!parsed.success) {

--- a/packages/rcml/docs/email/building-with-llm.md
+++ b/packages/rcml/docs/email/building-with-llm.md
@@ -12,12 +12,12 @@ alignment, social blocks, placeholders, merge fields, custom fonts, or the full 
 attributes each element accepts.
 
 Pasting this documentation into a system prompt solves that, but at the cost of a large
-token budget on every call. `@rulecom/rcml` exports three purpose-built, machine-readable
+token budget on every call. `@rule/rcml` exports three purpose-built, machine-readable
 spec constants that describe the schema concisely. Each is a plain object — serialize it
 to JSON and include it in the system prompt once, at the start of a session.
 
 ```typescript
-import { rcmlSpec, emailRfmSpec, placeholderSpec } from '@rulecom/rcml';
+import { rcmlSpec, emailRfmSpec, placeholderSpec } from '@rule/rcml';
 
 const systemPrompt = `
 You generate RCML email templates.
@@ -93,7 +93,7 @@ Example of what LLM-generated XML looks like:
 Convert and validate before submitting:
 
 ```typescript
-import { safeXmlToRcml, safeValidateEmailTemplate } from '@rulecom/rcml';
+import { safeXmlToRcml, safeValidateEmailTemplate } from '@rule/rcml';
 
 // 1. LLM produces XML
 const xmlString = await llm.generate(prompt);
@@ -127,7 +127,7 @@ Pass `emailRfmSpec` anyway so the LLM understands how content nodes are shaped.
 Validate before using regardless of format:
 
 ```typescript
-import { safeValidateEmailTemplate } from '@rulecom/rcml';
+import { safeValidateEmailTemplate } from '@rule/rcml';
 
 const doc = JSON.parse(await llm.generate(jsonPrompt));
 const result = safeValidateEmailTemplate(doc);
@@ -146,7 +146,7 @@ if (result.success) {
 - Letting users edit a template in XML before it is re-submitted.
 
 ```typescript
-import { rcmlToXml } from '@rulecom/rcml';
+import { rcmlToXml } from '@rule/rcml';
 
 const xml = rcmlToXml(validated.data, { prettyPrint: true });
 // display, store, or return xml to the user

--- a/packages/rcml/docs/email/concepts/basic/rich-text-content.md
+++ b/packages/rcml/docs/email/concepts/basic/rich-text-content.md
@@ -7,7 +7,7 @@ ProseMirror is also the editor's internal document model. Storing content as Pro
 Produce content using two functions:
 
 ```typescript
-import { emailRfmToJson, emailInlineRfmToJson } from '@rulecom/rcml';
+import { emailRfmToJson, emailInlineRfmToJson } from '@rule/rcml';
 
 const doc   = emailRfmToJson('Hello :font[world]{font-weight="bold"}');  // rc-text, rc-heading
 const label = emailInlineRfmToJson('Buy now');                           // rc-button

--- a/packages/rcml/docs/email/content/block-nodes/doc.md
+++ b/packages/rcml/docs/email/content/block-nodes/doc.md
@@ -47,7 +47,7 @@ A `doc` with multiple paragraphs:
 The `doc` node is the implicit wrapper for all Email RFM content. It is never written directly — the Email RFM parser and the `emailRfmToJson` / `emailInlineRfmToJson` functions always return a `doc` node as the top-level result.
 
 ```typescript
-import { emailRfmToJson } from '@rulecom/rcml';
+import { emailRfmToJson } from '@rule/rcml';
 
 const doc = emailRfmToJson('Hello world');
 // { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello world' }] }] }

--- a/packages/rcml/docs/email/content/flavors.md
+++ b/packages/rcml/docs/email/content/flavors.md
@@ -86,7 +86,7 @@ Parsed and validated by `emailInlineRfmToJson()`.
 ## API
 
 ```typescript
-import { emailRfmToJson, emailInlineRfmToJson } from '@rulecom/rcml';
+import { emailRfmToJson, emailInlineRfmToJson } from '@rule/rcml';
 
 // Full Email RFM → doc node (rc-text, rc-heading)
 const doc = emailRfmToJson('Hello :font[world]{font-weight="bold"}');

--- a/packages/rcml/docs/email/content/inline-nodes/placeholder.md
+++ b/packages/rcml/docs/email/content/inline-nodes/placeholder.md
@@ -261,10 +261,10 @@ The bracket tokens that appear in `original` can also be used directly as plain 
 - In `rc-raw` HTML content: `<p>[Subscriber:email]</p>`
 - In any RCML attribute that the backend renderer post-processes at send time
 
-The complete machine-readable token reference is available as `placeholderSpec` from `@rulecom/rcml`:
+The complete machine-readable token reference is available as `placeholderSpec` from `@rule/rcml`:
 
 ```typescript
-import { placeholderSpec } from '@rulecom/rcml';
+import { placeholderSpec } from '@rule/rcml';
 
 // All supported token types
 Object.keys(placeholderSpec.tokens)

--- a/packages/rcml/docs/email/rcml/body/content/rc-button.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-button.md
@@ -82,10 +82,10 @@ None. Content is an inline rich-text label set via the `content` field. See [Con
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createButtonElement } from '@rulecom/rcml';
+import { createButtonElement } from '@rule/rcml';
 
 createButtonElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/body/content/rc-divider.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-divider.md
@@ -49,10 +49,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createDividerElement } from '@rulecom/rcml';
+import { createDividerElement } from '@rule/rcml';
 
 createDividerElement({
   attrs: { 'border-color': '#dddddd', 'border-width': '1px', padding: '32px 0' },

--- a/packages/rcml/docs/email/rcml/body/content/rc-heading.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-heading.md
@@ -63,10 +63,10 @@ None. Content is a rich-text document set via the `content` field. See [Content 
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createHeadingElement } from '@rulecom/rcml';
+import { createHeadingElement } from '@rule/rcml';
 
 createHeadingElement({
   attrs: { color: '#1a1a2e', 'font-size': '32px', 'font-weight': '700' },

--- a/packages/rcml/docs/email/rcml/body/content/rc-image.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-image.md
@@ -65,10 +65,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createImageElement } from '@rulecom/rcml';
+import { createImageElement } from '@rule/rcml';
 
 createImageElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/body/content/rc-logo.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-logo.md
@@ -66,10 +66,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createLogoElement } from '@rulecom/rcml';
+import { createLogoElement } from '@rule/rcml';
 
 createLogoElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/body/content/rc-raw.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-raw.md
@@ -31,10 +31,10 @@ None. Content is a raw HTML string set via the `content` field.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createRawElement } from '@rulecom/rcml';
+import { createRawElement } from '@rule/rcml';
 
 createRawElement({ content: '<!--[if mso]><table><tr><td><![endif]-->' })
 ```

--- a/packages/rcml/docs/email/rcml/body/content/rc-social-element.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-social-element.md
@@ -67,10 +67,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createSocialChildElement } from '@rulecom/rcml';
+import { createSocialChildElement } from '@rule/rcml';
 
 createSocialChildElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/body/content/rc-social.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-social.md
@@ -71,10 +71,10 @@ Social media links container. Holds `<rc-social-element>` children representing 
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createSocialElement, createSocialChildElement } from '@rulecom/rcml';
+import { createSocialElement, createSocialChildElement } from '@rule/rcml';
 
 createSocialElement({
   attrs: { mode: 'horizontal', align: 'center' },

--- a/packages/rcml/docs/email/rcml/body/content/rc-spacer.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-spacer.md
@@ -41,10 +41,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createSpacerElement } from '@rulecom/rcml';
+import { createSpacerElement } from '@rule/rcml';
 
 createSpacerElement({ attrs: { height: '48px' } })
 ```

--- a/packages/rcml/docs/email/rcml/body/content/rc-text.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-text.md
@@ -62,10 +62,10 @@ None. Content is a rich-text document set via the `content` field. See [Content 
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createTextElement } from '@rulecom/rcml';
+import { createTextElement } from '@rule/rcml';
 
 createTextElement({
   attrs: { color: '#333333', 'font-size': '16px' },

--- a/packages/rcml/docs/email/rcml/body/content/rc-video.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-video.md
@@ -66,10 +66,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createVideoElement } from '@rulecom/rcml';
+import { createVideoElement } from '@rule/rcml';
 
 createVideoElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/body/control-flow/rc-case.md
+++ b/packages/rcml/docs/email/rcml/body/control-flow/rc-case.md
@@ -49,10 +49,10 @@ A single conditional branch inside an `<rc-switch>`. Rendered when its condition
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createCaseElement, createSectionElement } from '@rulecom/rcml';
+import { createCaseElement, createSectionElement } from '@rule/rcml';
 
 createCaseElement({
   attrs: { 'case-type': 'tag', 'case-property': '456', 'case-condition': 'eq', 'case-value': 'true' },

--- a/packages/rcml/docs/email/rcml/body/control-flow/rc-loop.md
+++ b/packages/rcml/docs/email/rcml/body/control-flow/rc-loop.md
@@ -47,10 +47,10 @@ Repeating section driven by a data feed. Renders its child `<rc-section>` once p
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createLoopElement, createSectionElement } from '@rulecom/rcml';
+import { createLoopElement, createSectionElement } from '@rule/rcml';
 
 createLoopElement({
   attrs: { 'loop-type': 'news-feed', 'loop-value': '42', 'loop-max-iterations': '5' },

--- a/packages/rcml/docs/email/rcml/body/control-flow/rc-switch.md
+++ b/packages/rcml/docs/email/rcml/body/control-flow/rc-switch.md
@@ -57,10 +57,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createSwitchElement, createCaseElement, createSectionElement } from '@rulecom/rcml';
+import { createSwitchElement, createCaseElement, createSectionElement } from '@rule/rcml';
 
 createSwitchElement({
   children: [

--- a/packages/rcml/docs/email/rcml/body/layout/rc-column.md
+++ b/packages/rcml/docs/email/rcml/body/layout/rc-column.md
@@ -62,10 +62,10 @@ Any content element: [`<rc-text>`](../content/rc-text.md), [`<rc-heading>`](../c
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createColumnElement, createTextElement } from '@rulecom/rcml';
+import { createColumnElement, createTextElement } from '@rule/rcml';
 
 createColumnElement({
   attrs: { padding: '0 16px', width: '50%' },

--- a/packages/rcml/docs/email/rcml/body/layout/rc-group.md
+++ b/packages/rcml/docs/email/rcml/body/layout/rc-group.md
@@ -39,10 +39,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createGroupElement, createColumnElement } from '@rulecom/rcml';
+import { createGroupElement, createColumnElement } from '@rule/rcml';
 
 createGroupElement({
   children: [

--- a/packages/rcml/docs/email/rcml/body/layout/rc-section.md
+++ b/packages/rcml/docs/email/rcml/body/layout/rc-section.md
@@ -70,10 +70,10 @@ Full-width horizontal band that holds one or more columns. The primary layout ro
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createSectionElement, createColumnElement } from '@rulecom/rcml';
+import { createSectionElement, createColumnElement } from '@rule/rcml';
 
 createSectionElement({
   attrs: { 'background-color': '#ffffff', padding: '40px 0' },

--- a/packages/rcml/docs/email/rcml/body/layout/rc-wrapper.md
+++ b/packages/rcml/docs/email/rcml/body/layout/rc-wrapper.md
@@ -65,10 +65,10 @@ Groups multiple sections under a shared background image or colour. Use for hero
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createWrapperElement, createSectionElement } from '@rulecom/rcml';
+import { createWrapperElement, createSectionElement } from '@rule/rcml';
 
 createWrapperElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/head/rc-attributes.md
+++ b/packages/rcml/docs/email/rcml/head/rc-attributes.md
@@ -47,10 +47,10 @@ Children carry only attributes — no `children` or `content` of their own. They
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createAttributesElement, createBodyElement } from '@rulecom/rcml';
+import { createAttributesElement, createBodyElement } from '@rule/rcml';
 
 createAttributesElement({
   children: [

--- a/packages/rcml/docs/email/rcml/head/rc-brand-style.md
+++ b/packages/rcml/docs/email/rcml/head/rc-brand-style.md
@@ -33,10 +33,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createBrandStyleElement } from '@rulecom/rcml';
+import { createBrandStyleElement } from '@rule/rcml';
 
 createBrandStyleElement({ attrs: { id: '42' } })
 ```

--- a/packages/rcml/docs/email/rcml/head/rc-class.md
+++ b/packages/rcml/docs/email/rcml/head/rc-class.md
@@ -54,10 +54,10 @@ None.
 
 ### Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createClassElement } from '@rulecom/rcml';
+import { createClassElement } from '@rule/rcml';
 
 createClassElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/head/rc-font.md
+++ b/packages/rcml/docs/email/rcml/head/rc-font.md
@@ -37,10 +37,10 @@ None.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createFontElement } from '@rulecom/rcml';
+import { createFontElement } from '@rule/rcml';
 
 createFontElement({
   attrs: {

--- a/packages/rcml/docs/email/rcml/head/rc-plain-text.md
+++ b/packages/rcml/docs/email/rcml/head/rc-plain-text.md
@@ -31,10 +31,10 @@ None. Content is plain text set via the `content` field.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createPlainTextElement } from '@rulecom/rcml';
+import { createPlainTextElement } from '@rule/rcml';
 
 createPlainTextElement({ content: 'Hi — see the full offer at example.com/sale.' })
 ```

--- a/packages/rcml/docs/email/rcml/head/rc-preview.md
+++ b/packages/rcml/docs/email/rcml/head/rc-preview.md
@@ -31,10 +31,10 @@ None. Content is plain text set via the `content` field.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createPreviewElement } from '@rulecom/rcml';
+import { createPreviewElement } from '@rule/rcml';
 
 createPreviewElement({ content: 'See inside for 20% off' })
 ```

--- a/packages/rcml/docs/email/rcml/index.md
+++ b/packages/rcml/docs/email/rcml/index.md
@@ -94,7 +94,7 @@ Attributes map directly to XML attributes. Child elements nest normally. Rich-te
 
 ## Building with factory functions
 
-The `@rulecom/rcml` package exports a factory function for every element:
+The `@rule/rcml` package exports a factory function for every element:
 
 ```typescript
 import {
@@ -104,7 +104,7 @@ import {
   createSectionElement,
   createColumnElement,
   createTextElement,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 
 const template = createRcmlDocumentElement({
   head: createHeadElement({ children: [] }),
@@ -136,7 +136,7 @@ const template = createRcmlDocumentElement({
 RCML JSON can also be generated directly by a language model. Pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context in your prompt — it contains the complete element schema with all tag names, allowed attributes, constraints, and parent-child relationships.
 
 ```typescript
-import { rcmlSpec } from '@rulecom/rcml';
+import { rcmlSpec } from '@rule/rcml';
 
 // Include rcmlSpec in your AI prompt context
 // The model can then produce valid RCML JSON directly

--- a/packages/rcml/docs/email/rcml/root/rc-body.md
+++ b/packages/rcml/docs/email/rcml/root/rc-body.md
@@ -47,10 +47,10 @@
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createBodyElement, createSectionElement } from '@rulecom/rcml';
+import { createBodyElement, createSectionElement } from '@rule/rcml';
 
 const body = createBodyElement({
   attrs: { 'background-color': '#f5f5f5', width: '600px' },

--- a/packages/rcml/docs/email/rcml/root/rc-head.md
+++ b/packages/rcml/docs/email/rcml/root/rc-head.md
@@ -46,10 +46,10 @@ All children are optional.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createHeadElement, createBrandStyleElement, createPreviewElement } from '@rulecom/rcml';
+import { createHeadElement, createBrandStyleElement, createPreviewElement } from '@rule/rcml';
 
 const head = createHeadElement({
   children: [

--- a/packages/rcml/docs/email/rcml/root/rcml.md
+++ b/packages/rcml/docs/email/rcml/root/rcml.md
@@ -40,10 +40,10 @@ None — this is the root element.
 
 ## Building
 
-Templates can be built using factory functions from `@rulecom/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
+Templates can be built using factory functions from `@rule/rcml`, or the JSON structure above can be generated directly by an AI model — pass [`rcmlSpec`](/api/rcml/src/variables/rcmlSpec) as context when prompting.
 
 ```typescript
-import { createRcmlDocumentElement, createHeadElement, createBodyElement } from '@rulecom/rcml';
+import { createRcmlDocumentElement, createHeadElement, createBodyElement } from '@rule/rcml';
 
 const template = createRcmlDocumentElement({
   head: createHeadElement({ children: [] }),

--- a/packages/rcml/docs/email/validation.md
+++ b/packages/rcml/docs/email/validation.md
@@ -20,7 +20,7 @@ immediate exception. Use `safeValidateEmailTemplate` when you need to inspect or
 the issue list.
 
 ```typescript
-import { validateEmailTemplate, safeValidateEmailTemplate } from '@rulecom/rcml';
+import { validateEmailTemplate, safeValidateEmailTemplate } from '@rule/rcml';
 
 // Throwing variant
 const doc = validateEmailTemplate(xmlString);
@@ -91,7 +91,7 @@ All codes are also available as the `EmailTemplateErrorCodes` constant so you ca
 without string literals:
 
 ```typescript
-import { EmailTemplateErrorCodes, safeValidateEmailTemplate } from '@rulecom/rcml';
+import { EmailTemplateErrorCodes, safeValidateEmailTemplate } from '@rule/rcml';
 
 const result = safeValidateEmailTemplate(doc);
 if (!result.success) {

--- a/packages/rcml/docs/index.md
+++ b/packages/rcml/docs/index.md
@@ -1,6 +1,6 @@
-# @rulecom/rcml
+# @rule/rcml
 
-`@rulecom/rcml` is the RCML (Rule Campaign Markup Language) library. It provides the
+`@rule/rcml` is the RCML (Rule Campaign Markup Language) library. It provides the
 types, element factories, theme utilities, format converters, and validation functions
 needed to build email and SMS templates that the Rule platform can render and send.
 
@@ -33,7 +33,7 @@ import {
   createTextElement, createHeadingElement, createButtonElement,
   createImageElement, createSpacerElement,
   createPreviewElement,
-} from '@rulecom/rcml';
+} from '@rule/rcml';
 ```
 
 See [Building programmatically](/packages/rcml/email/building-programmatically) for a
@@ -47,7 +47,7 @@ common entry point — it accepts an Email RFM markdown string and returns the P
 document expected by the element factories.
 
 ```typescript
-import { createTextContent, createInlineContent, createTextNode, createPlaceholderNode } from '@rulecom/rcml';
+import { createTextContent, createInlineContent, createTextNode, createPlaceholderNode } from '@rule/rcml';
 
 const content = createTextContent('Hi ::subscriber.first_name::, **your order** is confirmed.');
 ```
@@ -66,7 +66,7 @@ editor — it writes the brand-style reference, color defaults, font styles, and
 social-link URLs into `rc-head` in the exact structure the editor expects.
 
 ```typescript
-import { createEmailTheme, applyTheme, EmailThemeColorType } from '@rulecom/rcml';
+import { createEmailTheme, applyTheme, EmailThemeColorType } from '@rule/rcml';
 
 const theme = createEmailTheme({
   brandStyleId: 10457,
@@ -109,7 +109,7 @@ system prompts: `rcmlSpec`, `emailRfmSpec`, and `placeholderSpec`. Each is a pla
 JSON-serializable object.
 
 ```typescript
-import { rcmlSpec, emailRfmSpec, placeholderSpec } from '@rulecom/rcml';
+import { rcmlSpec, emailRfmSpec, placeholderSpec } from '@rule/rcml';
 // JSON.stringify and include in an LLM system prompt
 ```
 
@@ -123,7 +123,7 @@ template is a single `rc-sms` element whose body is written in **SMS RFM**
 (SMS Rule Flavor Markdown). Dynamic values use the `::placeholder{…}` directive.
 
 ```typescript
-import { createSmsDocument } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
 
 const doc = createSmsDocument({
   content: 'Hi ::placeholder{type="Subscriber" original="[Subscriber:FirstName]" name="First name"}! Your order has shipped.',
@@ -133,7 +133,7 @@ const doc = createSmsDocument({
 Three machine-readable spec constants for SMS LLM generation:
 
 ```typescript
-import { smsSpec, smsRfmSpec, smsPlaceholderSpec } from '@rulecom/rcml';
+import { smsSpec, smsRfmSpec, smsPlaceholderSpec } from '@rule/rcml';
 ```
 
 See [SMS](/packages/rcml/sms/) for the full SMS module documentation.

--- a/packages/rcml/docs/sms/building-programmatically.md
+++ b/packages/rcml/docs/sms/building-programmatically.md
@@ -1,6 +1,6 @@
 # Building programmatically
 
-The `@rulecom/rcml` package provides everything needed to construct, validate,
+The `@rule/rcml` package provides everything needed to construct, validate,
 and convert SMS templates in code: a document factory, a typed `sms` builder
 namespace, format converters between SMS RFM and JSON, and helpers for the XML
 representation.
@@ -28,7 +28,7 @@ of the `sms` builder functions described below.
 `content` and it returns a fully-formed `SmsDocument`:
 
 ```typescript
-import { createSmsDocument } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
 
 const doc = createSmsDocument({
   content:
@@ -61,7 +61,7 @@ see [XML format](#xml-format).
 `jsonToSmsRfm()` converts it back:
 
 ```typescript
-import { smsRfmToJson, jsonToSmsRfm } from '@rulecom/rcml';
+import { smsRfmToJson, jsonToSmsRfm } from '@rule/rcml';
 
 // SMS RFM → JSON. Use the ::placeholder{…} directive for dynamic values.
 const json = smsRfmToJson(
@@ -119,7 +119,7 @@ assembled document at the boundary.
 A small worked example:
 
 ```typescript
-import { sms, createSmsDocument } from '@rulecom/rcml';
+import { sms, createSmsDocument } from '@rule/rcml';
 
 const content = sms.createContent({
   paragraphs: [
@@ -446,8 +446,8 @@ useful when the JSON tree comes from somewhere other than the builders or the
 parser — for example, an editor save or a stored draft:
 
 ```typescript
-import { createSmsDocument } from '@rulecom/rcml';
-import type { SmsContentJson } from '@rulecom/rcml';
+import { createSmsDocument } from '@rule/rcml';
+import type { SmsContentJson } from '@rule/rcml';
 
 const content: SmsContentJson = loadDraftFromStorage(); // your code
 const doc = createSmsDocument({ content });
@@ -463,7 +463,7 @@ body of `<rc-sms>` is just an SMS RFM string, and the conversion is exact in
 both directions:
 
 ```typescript
-import { createSmsDocument, smsToXml, xmlToSms } from '@rulecom/rcml';
+import { createSmsDocument, smsToXml, xmlToSms } from '@rule/rcml';
 
 const doc = createSmsDocument({
   content:
@@ -499,7 +499,7 @@ user-provided input), use `safeXmlToSms` to parse and then
 `safeValidateSmsDocument` to validate before using the result:
 
 ```typescript
-import { safeXmlToSms, safeValidateSmsDocument } from '@rulecom/rcml';
+import { safeXmlToSms, safeValidateSmsDocument } from '@rule/rcml';
 
 // 1. Parse XML → SmsDocument
 const parsed = safeXmlToSms(xmlString);
@@ -526,7 +526,7 @@ A complete order-shipped SMS built with builders only — three paragraphs, two
 placeholders, one link mark, one hardbreak, one system-link placeholder:
 
 ```typescript
-import { sms, createSmsDocument } from '@rulecom/rcml';
+import { sms, createSmsDocument } from '@rule/rcml';
 
 const content = sms.createContent({
   paragraphs: [

--- a/packages/rcml/docs/sms/building-with-llm.md
+++ b/packages/rcml/docs/sms/building-with-llm.md
@@ -1,7 +1,7 @@
 # Building with LLM
 
 LLMs can generate SMS templates as SMS RFM strings or as `SmsContentJson` JSON. The
-`@rulecom/rcml` package exports three machine-readable spec constants that describe the
+`@rule/rcml` package exports three machine-readable spec constants that describe the
 complete SMS schema concisely. Serialize them to JSON and include them in a system
 prompt once, at the start of a session.
 
@@ -12,7 +12,7 @@ that does not match the `SmsContentJson` shape. The three spec objects give the 
 everything it needs to produce correct output:
 
 ```typescript
-import { smsSpec, smsRfmSpec, smsPlaceholderSpec } from '@rulecom/rcml';
+import { smsSpec, smsRfmSpec, smsPlaceholderSpec } from '@rule/rcml';
 
 const systemPrompt = `
 You generate Rule.io SMS templates as SMS RFM strings.
@@ -54,7 +54,7 @@ parameter descriptions, allowed values, and examples.
 `smsSpec.tags['rc-sms']` describes the one allowed element:
 
 ```typescript
-import { smsSpec } from '@rulecom/rcml';
+import { smsSpec } from '@rule/rcml';
 
 smsSpec.tags['rc-sms']
 // {
@@ -75,7 +75,7 @@ const flavor = smsRfmSpec.flavors[contentType];
 block and inline content, and which marks may be applied:
 
 ```typescript
-import { smsRfmSpec } from '@rulecom/rcml';
+import { smsRfmSpec } from '@rule/rcml';
 
 smsRfmSpec.flavors['sms-rfm-content']
 // {
@@ -107,7 +107,7 @@ in `SmsContentJson` — make sure the LLM emits `true`/`false`, not the strings
 `smsPlaceholderSpec.tokens` contains one entry per token type valid in SMS:
 
 ```typescript
-import { smsPlaceholderSpec } from '@rulecom/rcml';
+import { smsPlaceholderSpec } from '@rule/rcml';
 
 Object.keys(smsPlaceholderSpec.tokens)
 // → ['CustomField', 'Subscriber', 'User', 'Date', 'RemoteContent', 'Link']
@@ -132,7 +132,7 @@ SMS RFM is the easiest output format for an LLM to produce correctly. Ask the mo
 output the message body as a single SMS RFM string, then parse and validate:
 
 ```typescript
-import { smsRfmToJson, createSmsDocument, safeValidateSmsDocument } from '@rulecom/rcml';
+import { smsRfmToJson, createSmsDocument, safeValidateSmsDocument } from '@rule/rcml';
 
 // 1. LLM produces an SMS RFM string
 const rfmString = await llm.generate(systemPrompt + '\n\nGenerate a shipping confirmation.');
@@ -159,7 +159,7 @@ If the message requires linked text (text with `href`, `track`, and `shorten`), 
 the LLM to output `SmsContentJson` directly and validate with `safeParseSmsJson`:
 
 ```typescript
-import { safeParseSmsJson, createSmsDocument } from '@rulecom/rcml';
+import { safeParseSmsJson, createSmsDocument } from '@rule/rcml';
 
 // LLM produces a SmsContentJson object
 const rawJson = JSON.parse(await llm.generate(jsonPrompt));

--- a/packages/rcml/docs/sms/content/nodes/placeholder.md
+++ b/packages/rcml/docs/sms/content/nodes/placeholder.md
@@ -351,7 +351,7 @@ message body; use the link mark form when you want trackable linked text.
 The complete token reference is available as `smsPlaceholderSpec`:
 
 ```typescript
-import { smsPlaceholderSpec } from '@rulecom/rcml';
+import { smsPlaceholderSpec } from '@rule/rcml';
 
 // All SMS-valid token types
 Object.keys(smsPlaceholderSpec.tokens)

--- a/packages/rcml/docs/sms/index.md
+++ b/packages/rcml/docs/sms/index.md
@@ -23,7 +23,7 @@ A minimal example in both formats:
 ```
 
 ```typescript
-import type { SmsDocument } from '@rulecom/rcml';
+import type { SmsDocument } from '@rule/rcml';
 
 const doc: SmsDocument = {
   tagName: 'rc-sms',

--- a/packages/rcml/docs/sms/validation.md
+++ b/packages/rcml/docs/sms/validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-`@rulecom/rcml` provides three distinct validation entry points for SMS templates, each
+`@rule/rcml` provides three distinct validation entry points for SMS templates, each
 targeting a different stage of the document lifecycle:
 
 - **Document validation** — validate a complete `SmsDocument` before submitting to Rule.
@@ -23,7 +23,7 @@ submit.
 | `safeValidateSmsDocument` | Returns `{ success: false, errors }` |
 
 ```typescript
-import { validateSmsDocument, safeValidateSmsDocument } from '@rulecom/rcml';
+import { validateSmsDocument, safeValidateSmsDocument } from '@rule/rcml';
 
 // Throwing variant — use when invalid input is a programming error
 const doc = validateSmsDocument(candidate);
@@ -57,7 +57,7 @@ get the full issue list in a single call.
 All codes are available on the `SmsDocumentErrorCodes` constant:
 
 ```typescript
-import { SmsDocumentErrorCodes, safeValidateSmsDocument } from '@rulecom/rcml';
+import { SmsDocumentErrorCodes, safeValidateSmsDocument } from '@rule/rcml';
 
 const result = safeValidateSmsDocument(doc);
 if (!result.success) {
@@ -82,7 +82,7 @@ embedding it in a document.
 | `safeParseSmsJson` | Returns `{ success: false, errors }` |
 
 ```typescript
-import { validateSmsJson, safeParseSmsJson } from '@rulecom/rcml';
+import { validateSmsJson, safeParseSmsJson } from '@rule/rcml';
 
 // Throwing variant
 const content = validateSmsJson(rawJson);
@@ -146,7 +146,7 @@ Thrown by `xmlToSms` when XML parsing or `rc-sms` root validation fails. Use
 `safeXmlToSms` for the non-throwing variant:
 
 ```typescript
-import { safeXmlToSms, SmsXmlErrorCodes } from '@rulecom/rcml';
+import { safeXmlToSms, SmsXmlErrorCodes } from '@rule/rcml';
 
 const result = safeXmlToSms(xmlString);
 if (!result.success) {
@@ -169,7 +169,7 @@ if (!result.success) {
 The full recommended pattern when importing a document from an untrusted source:
 
 ```typescript
-import { safeXmlToSms, safeValidateSmsDocument } from '@rulecom/rcml';
+import { safeXmlToSms, safeValidateSmsDocument } from '@rule/rcml';
 
 async function importSmsTemplate(xmlString: string) {
   // Step 1: parse XML

--- a/packages/rcml/package.json
+++ b/packages/rcml/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rulecom/rcml",
+  "name": "@rule/rcml",
   "version": "0.4.0-beta.7",
   "description": "RCML email template builders and type definitions for the Rule.io SDK.",
   "type": "module",

--- a/packages/rcml/src/email/email-namespace.ts
+++ b/packages/rcml/src/email/email-namespace.ts
@@ -23,7 +23,7 @@ import {
  *
  * @example
  * ```ts
- * import { email } from '@rulecom/rcml';
+ * import { email } from '@rule/rcml';
  *
  * const fieldAtom = email.createCustomField({
  *   group: 'Order', name: 'Total', id: 13,

--- a/packages/rcml/src/email/email-rfm-spec.ts
+++ b/packages/rcml/src/email/email-rfm-spec.ts
@@ -75,7 +75,7 @@ export interface EmailRfmFlavorSpec {
   marks: string[]
 }
 
-/** Top-level machine-readable RFM specification exported from @rulecom/rcml. */
+/** Top-level machine-readable RFM specification exported from @rule/rcml. */
 export interface EmailRfmSpec {
   /** Spec format version. */
   version: string
@@ -440,7 +440,7 @@ function buildEmailRfmSpec(): EmailRfmSpec {
  *
  * @example
  * ```ts
- * import { emailRfmSpec } from '@rulecom/rcml'
+ * import { emailRfmSpec } from '@rule/rcml'
  *
  * // Which block nodes are valid inside an rc-text?
  * emailRfmSpec.flavors['rcml-content'].blockNodes

--- a/packages/rcml/src/email/email-rfm-to-json.ts
+++ b/packages/rcml/src/email/email-rfm-to-json.ts
@@ -2,7 +2,7 @@
  * Public API: Email RFM markdown → RCML content JSON conversion.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. The
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. The
  * parse/transform/convert pipeline lives under `./content/`.
  */
 

--- a/packages/rcml/src/email/json-to-email-rfm.ts
+++ b/packages/rcml/src/email/json-to-email-rfm.ts
@@ -2,7 +2,7 @@
  * Public API: RCML content JSON → Email RFM markdown conversion.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. The
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. The
  * block/inline/mark serializers live under `./content/serializer/`.
  */
 

--- a/packages/rcml/src/email/placeholder-spec.ts
+++ b/packages/rcml/src/email/placeholder-spec.ts
@@ -79,7 +79,7 @@ export interface PlaceholderTokenSpec {
   nestable?: boolean
 }
 
-/** Top-level machine-readable placeholder specification exported from @rulecom/rcml. */
+/** Top-level machine-readable placeholder specification exported from @rule/rcml. */
 export interface PlaceholderSpec {
   /** Spec format version. */
   version: string
@@ -311,7 +311,7 @@ const TOKENS: Record<string, PlaceholderTokenSpec> = {
  *
  * @example
  * ```ts
- * import { placeholderSpec } from '@rulecom/rcml'
+ * import { placeholderSpec } from '@rule/rcml'
  *
  * // All token type names
  * Object.keys(placeholderSpec.tokens)

--- a/packages/rcml/src/email/rcml-spec.ts
+++ b/packages/rcml/src/email/rcml-spec.ts
@@ -59,7 +59,7 @@ export interface RcmlPublicTagSpec {
   attributes: Record<string, RcmlPublicAttrSpec>
 }
 
-/** Top-level machine-readable RCML specification exported from @rulecom/rcml. */
+/** Top-level machine-readable RCML specification exported from @rule/rcml. */
 export interface RcmlSpec {
   /** Spec format version — incremented when the shape of this object changes. */
   version: string
@@ -171,7 +171,7 @@ function buildRcmlSpec(): RcmlSpec {
  *
  * @example
  * ```ts
- * import { rcmlSpec } from '@rulecom/rcml'
+ * import { rcmlSpec } from '@rule/rcml'
  *
  * // Enumerate all supported tags
  * Object.keys(rcmlSpec.tags)

--- a/packages/rcml/src/email/rcml-to-xml.ts
+++ b/packages/rcml/src/email/rcml-to-xml.ts
@@ -2,7 +2,7 @@
  * Public API: `RcmlDocument` JSON AST → RCML XML string conversion.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. All
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. All
  * implementation details live in `./xml/serialize-helpers.ts`.
  */
 

--- a/packages/rcml/src/email/theme/utils.ts
+++ b/packages/rcml/src/email/theme/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Internal helpers shared across the theme submodule. Nothing here is
- * part of the public `@rulecom/rcml` surface.
+ * part of the public `@rule/rcml` surface.
  *
  * @internal
  */

--- a/packages/rcml/src/email/validate-email-template.ts
+++ b/packages/rcml/src/email/validate-email-template.ts
@@ -2,7 +2,7 @@
  * Public API: RCML email-template validator.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. All
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. All
  * heavy lifting is delegated to the internal helpers under `./validator/`.
  *
  * The validator merges four passes into one unified issue list:

--- a/packages/rcml/src/email/validate-rcml-json.ts
+++ b/packages/rcml/src/email/validate-rcml-json.ts
@@ -3,7 +3,7 @@
  * typed node/mark tree model.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. The
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. The
  * AJV validator and visitor helpers live under `./content/json-validator/`.
  */
 

--- a/packages/rcml/src/email/xml-to-rcml.ts
+++ b/packages/rcml/src/email/xml-to-rcml.ts
@@ -2,7 +2,7 @@
  * Public API: RCML XML → `RcmlDocument` JSON-AST conversion.
  *
  * This file contains **only public exports**. Every symbol here is part of
- * the `@rulecom/rcml` contract and is marked `@public` in its JSDoc. All
+ * the `@rule/rcml` contract and is marked `@public` in its JSDoc. All
  * implementation details live in `./xml/parse-helpers.ts`.
  *
  * Text inside `<rc-text>`, `<rc-heading>`, and `<rc-button>` is treated as

--- a/packages/rcml/src/index.ts
+++ b/packages/rcml/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @rulecom/rcml — canonical RCML surface: schema, element factories, types,
+ * @rule/rcml — canonical RCML surface: schema, element factories, types,
  * validators, and RFM/XML converters. Email functionality lives under
  * `./email/` and SMS functionality under `./sms/`.
  */

--- a/packages/rcml/src/sms/builders/sms-namespace.ts
+++ b/packages/rcml/src/sms/builders/sms-namespace.ts
@@ -29,7 +29,7 @@ import {
  *
  * @example
  * ```ts
- * import { sms, createSmsDocument } from '@rulecom/rcml';
+ * import { sms, createSmsDocument } from '@rule/rcml';
  *
  * const content = sms.createContent({
  *   paragraphs: [

--- a/packages/rcml/src/sms/create-sms-document.ts
+++ b/packages/rcml/src/sms/create-sms-document.ts
@@ -38,7 +38,7 @@ export interface CreateSmsDocumentOptions {
  *
  * @example
  * ```typescript
- * import { createSmsDocument } from '@rulecom/rcml';
+ * import { createSmsDocument } from '@rule/rcml';
  *
  * // From an SMS RFM string
  * const doc = createSmsDocument({

--- a/packages/rcml/src/sms/sms-placeholder-spec.ts
+++ b/packages/rcml/src/sms/sms-placeholder-spec.ts
@@ -39,7 +39,7 @@ export type SmsPlaceholderTokenType = (typeof SMS_TOKEN_TYPES)[number]
  *
  * @example
  * ```ts
- * import { smsPlaceholderSpec } from '@rulecom/rcml'
+ * import { smsPlaceholderSpec } from '@rule/rcml'
  *
  * // All SMS-valid token type names
  * Object.keys(smsPlaceholderSpec.tokens)
@@ -50,7 +50,7 @@ export type SmsPlaceholderTokenType = (typeof SMS_TOKEN_TYPES)[number]
  * // → ['Optin', 'Unsubscribe', 'WebBrowser', 'ShareLink', 'Signup']
  *
  * // Cross-reference with smsRfmSpec:
- * import { smsRfmSpec } from '@rulecom/rcml'
+ * import { smsRfmSpec } from '@rule/rcml'
  * smsRfmSpec.nodes['placeholder'].attrs?.['type'].allowedValues
  * // → same list as Object.keys(smsPlaceholderSpec.tokens)
  * ```

--- a/packages/rcml/src/sms/sms-rfm-spec.ts
+++ b/packages/rcml/src/sms/sms-rfm-spec.ts
@@ -66,7 +66,7 @@ export interface SmsRfmFlavorSpec {
 }
 
 /**
- * Top-level machine-readable SMS RFM specification exported from `@rulecom/rcml`.
+ * Top-level machine-readable SMS RFM specification exported from `@rule/rcml`.
  *
  * @public
  */
@@ -228,7 +228,7 @@ function buildSmsRfmSpec(): SmsRfmSpec {
  *
  * @example
  * ```ts
- * import { smsRfmSpec, smsPlaceholderSpec } from '@rulecom/rcml'
+ * import { smsRfmSpec, smsPlaceholderSpec } from '@rule/rcml'
  *
  * // Which inline nodes are valid in SMS content?
  * smsRfmSpec.flavors['sms-rfm-content'].inlineNodes

--- a/packages/rcml/src/sms/sms-spec.ts
+++ b/packages/rcml/src/sms/sms-spec.ts
@@ -36,7 +36,7 @@ export interface SmsPublicTagSpec {
 }
 
 /**
- * Top-level machine-readable SMS specification exported from `@rulecom/rcml`.
+ * Top-level machine-readable SMS specification exported from `@rule/rcml`.
  *
  * @public
  */
@@ -54,7 +54,7 @@ export interface SmsSpec {
  *
  * @example
  * ```ts
- * import { smsSpec, smsRfmSpec } from '@rulecom/rcml'
+ * import { smsSpec, smsRfmSpec } from '@rule/rcml'
  *
  * // The only SMS tag
  * Object.keys(smsSpec.tags)  // → ['rc-sms']

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -46,7 +46,7 @@ This was a version bump only for sdk to align it with other projects, there were
 
 ### Initial Beta Release
 
-First public beta of `@rulecom/sdk` — convenience meta-package re-exporting
+First public beta of `@rule/sdk` — convenience meta-package re-exporting
 the full Rule.io TypeScript SDK under a single entry point.
 
-Re-exports everything from `@rulecom/client` and `@rulecom/rcml`.
+Re-exports everything from `@rule/client` and `@rule/rcml`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# @rulecom/sdk
+# @rule/sdk
 
 The official TypeScript SDK for the [Rule.io](https://rule.io) email marketing API. Build and send email campaigns, set up tag-triggered automations, manage subscribers, and compose RCML templates — all from code.
 
@@ -7,13 +7,13 @@ The official TypeScript SDK for the [Rule.io](https://rule.io) email marketing A
 ## Installation
 
 ```bash
-npm install @rulecom/sdk
+npm install @rule/sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { RuleClient } from '@rulecom/sdk';
+import { RuleClient } from '@rule/sdk';
 
 const client = new RuleClient({ apiKey: process.env.RULE_API_KEY! });
 

--- a/packages/sdk/docs/index.md
+++ b/packages/sdk/docs/index.md
@@ -1,18 +1,18 @@
-# @rulecom/sdk
+# @rule/sdk
 
-`@rulecom/sdk` is the meta-package umbrella for the Rule.io SDK. Install this one package to get the full API client and all RCML template builders.
+`@rule/sdk` is the meta-package umbrella for the Rule.io SDK. Install this one package to get the full API client and all RCML template builders.
 
 ```bash
-npm install @rulecom/sdk
+npm install @rule/sdk
 ```
 
 ## What's included
 
 | Export | Source | Purpose |
 |---|---|---|
-| `RuleClient`, `RuleApiError`, `RuleClientError` | `@rulecom/client` | HTTP API client and error types |
-| `createRCMLDocument`, `createBrandTemplate`, … | `@rulecom/rcml` | RCML element and brand-style builders |
+| `RuleClient`, `RuleApiError`, `RuleClientError` | `@rule/client` | HTTP API client and error types |
+| `createRCMLDocument`, `createBrandTemplate`, … | `@rule/rcml` | RCML element and brand-style builders |
 ## Where to go next
 
-- **[@rulecom/client →](/packages/client/)** — HTTP API client: subscribers, campaigns, automations, brand styles, and all other endpoints
-- **[@rulecom/rcml →](/packages/rcml/)** — RCML template builders: compose email templates at any level of abstraction
+- **[@rule/client →](/packages/client/)** — HTTP API client: subscribers, campaigns, automations, brand styles, and all other endpoints
+- **[@rule/rcml →](/packages/rcml/)** — RCML template builders: compose email templates at any level of abstraction

--- a/packages/sdk/docs/sending-emails.md
+++ b/packages/sdk/docs/sending-emails.md
@@ -34,7 +34,7 @@ console.log(result.automationId, result.templateId);
 Both helpers accept either `brandStyleId` (auto-builds a branded template) or `template` (your own `RcmlDocument`). You can also pass custom `sections` to replace the default placeholder content when using `brandStyleId`:
 
 ```typescript
-import { createBrandTemplate, createContentSection, createBrandHeading, createTextNode } from '@rulecom/sdk';
+import { createBrandTemplate, createContentSection, createBrandHeading, createTextNode } from '@rule/sdk';
 
 const template = createBrandTemplate({
   brandStyle: myBrand,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@rulecom/sdk",
+  "name": "@rule/sdk",
   "version": "0.4.0-beta.7",
-  "description": "TypeScript SDK for Rule.io email marketing API with RCML template builders — meta-package re-exporting @rulecom/rcml and @rulecom/client.",
+  "description": "TypeScript SDK for Rule.io email marketing API with RCML template builders — meta-package re-exporting @rule/rcml and @rule/client.",
   "type": "module",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -32,8 +32,8 @@
     "directory": "packages/sdk"
   },
   "dependencies": {
-    "@rulecom/rcml": "0.4.0-beta.7",
-    "@rulecom/client": "0.4.0-beta.7"
+    "@rule/rcml": "0.4.0-beta.7",
+    "@rule/client": "0.4.0-beta.7"
   },
   "engines": {
     "node": ">=20"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * @rulecom/sdk — meta-package re-exporting the Rule.io TypeScript SDK.
+ * @rule/sdk — meta-package re-exporting the Rule.io TypeScript SDK.
  *
  * This package is an umbrella over:
- * - `@rulecom/rcml`   — RCML email template builders and types
- * - `@rulecom/client` — HTTP API wrapper for the Rule.io endpoints
+ * - `@rule/rcml`   — RCML email template builders and types
+ * - `@rule/client` — HTTP API wrapper for the Rule.io endpoints
  *
- * Vendor presets (`@rulecom/vendor-shopify`, `@rulecom/vendor-bookzen`,
- * `@rulecom/vendor-samfora`) are under active development and will be
+ * Vendor presets (`@rule/vendor-shopify`, `@rule/vendor-bookzen`,
+ * `@rule/vendor-samfora`) are under active development and will be
  * included in a future release.
  *
  * For smaller install footprints, import from the split packages directly.
@@ -14,5 +14,5 @@
  * @packageDocumentation
  */
 
-export * from '@rulecom/rcml';
-export * from '@rulecom/client';
+export * from '@rule/rcml';
+export * from '@rule/client';

--- a/packages/template-engine/README.md
+++ b/packages/template-engine/README.md
@@ -1,6 +1,6 @@
-# @rulecom/template-engine
+# @rule/template-engine
 
-Minimal, XML-native template engine that powers the ready-made email templates in the vendor packages (`@rulecom/vendor-shopify`, etc.). Pure, synchronous, no JS runtime inside templates, no filesystem access from the compiler itself.
+Minimal, XML-native template engine that powers the ready-made email templates in the vendor packages (`@rule/vendor-shopify`, etc.). Pure, synchronous, no JS runtime inside templates, no filesystem access from the compiler itself.
 
 ```ts
 import {
@@ -10,7 +10,7 @@ import {
   createEmailTemplate,
   customField,
   loopValue,
-} from '@rulecom/template-engine'
+} from '@rule/template-engine'
 ```
 
 This README is the entry-point **for template authors** — it explains the layers, the file pattern, and the authoring flow. For the low-level API surface, see the JSDoc on each export.
@@ -21,7 +21,7 @@ This README is the entry-point **for template authors** — it explains the laye
 
 A ready-made email template spans three packages:
 
-- **`@rulecom/template-engine`** (this package) — XML compiler, runtime loaders, and email template factory.
+- **`@rule/template-engine`** (this package) — XML compiler, runtime loaders, and email template factory.
   - `compileTemplate({ template, copy, context, serializer? })` → `{ xml }`.
   - `loadTemplate(import.meta.url, './foo.xml')` → XML source string.
   - `loadCopy<T>(import.meta.url, './foo.json')` → parsed JSON, typed as `T`.
@@ -29,8 +29,8 @@ A ready-made email template spans three packages:
   - Types: `EmailTemplate<TCopy, TContext>`, `EmailTemplateRenderArgs<TCopy, TContext>`.
   - Typed refs: `customField(group, name, id?)`, `loopValue(key)`; types `CustomFieldRef`, `LoopValueRef`, `TemplateRef`. Serializer surface: `TemplateRefSerializer`, `defaultTemplateRefSerializer`, `serializeRef`, `isTemplateRef`.
   - Errors: `TemplateCompileError`.
-- **`@rulecom/rcml`** — RCML element factories, validators, converters, and theme API.
-- **Vendor packages** (e.g. `@rulecom/vendor-shopify`) — one folder per template, each with four files.
+- **`@rule/rcml`** — RCML element factories, validators, converters, and theme API.
+- **Vendor packages** (e.g. `@rule/vendor-shopify`) — one folder per template, each with four files.
 
 ---
 
@@ -117,7 +117,7 @@ import {
   type EmailTemplateRenderArgs,
   type CustomFieldRef,
   type LoopValueRef,
-} from '@rulecom/template-engine'
+} from '@rule/template-engine'
 
 /**
  * Typed data the XML consumes. Structural presence is the contract:
@@ -182,8 +182,8 @@ Net effect: the caller-facing context is the **minimum data the template actuall
 ## Consuming a template
 
 ```ts
-import { createAbandonedCartTemplate } from '@rulecom/vendor-shopify'
-import { customField, loopValue } from '@rulecom/template-engine'
+import { createAbandonedCartTemplate } from '@rule/vendor-shopify'
+import { customField, loopValue } from '@rule/template-engine'
 
 const template = createAbandonedCartTemplate()
 
@@ -200,12 +200,12 @@ const doc = template.render({
     },
     footer: { fontSize: '10px', textColor: '#666666' },
   },
-  theme,                              // EmailTheme from @rulecom/core
+  theme,                              // EmailTheme from @rule/core
   copy: { ctaButton: 'Check out' },   // optional partial override
 })
 ```
 
-`doc` is an `RcmlDocument` — send it through `@rulecom/client` to create a campaign or automation email in Rule.io.
+`doc` is an `RcmlDocument` — send it through `@rule/client` to create a campaign or automation email in Rule.io.
 
 ---
 

--- a/packages/template-engine/README.md
+++ b/packages/template-engine/README.md
@@ -200,7 +200,7 @@ const doc = template.render({
     },
     footer: { fontSize: '10px', textColor: '#666666' },
   },
-  theme,                              // EmailTheme from @rule/core
+  theme,                              // EmailTheme from @rule/rcml
   copy: { ctaButton: 'Check out' },   // optional partial override
 })
 ```

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rulecom/template-engine",
+  "name": "@rule/template-engine",
   "version": "0.4.0-beta.1",
   "description": "Minimal XML template compiler used by Rule.io vendor email-template packages. v1.4 uses XML Processing Instructions for directives, a flat data scope, and Transloco-style `t('key', { param: expr })` message calls.",
   "type": "module",
@@ -31,7 +31,7 @@
     "directory": "packages/template-engine"
   },
   "dependencies": {
-    "@rulecom/rcml": "*"
+    "@rule/rcml": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/template-engine/src/compile.ts
+++ b/packages/template-engine/src/compile.ts
@@ -1,5 +1,5 @@
 /**
- * Top-level orchestrator for `@rulecom/template-engine`.
+ * Top-level orchestrator for `@rule/template-engine`.
  *
  * Invokes the compile phases from spec §9:
  * 1. tokenise template

--- a/packages/template-engine/src/create-email-template.test.ts
+++ b/packages/template-engine/src/create-email-template.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { customField } from './refs/factories.js'
 import type { TemplateRefSerializer } from './refs/types.js'
 import { createEmailTemplate } from './create-email-template.js'
-import { createEmailTheme, EmailThemeImageType } from '@rulecom/rcml'
-import type { EmailTheme } from '@rulecom/rcml'
+import { createEmailTheme, EmailThemeImageType } from '@rule/rcml'
+import type { EmailTheme } from '@rule/rcml'
 
 interface FixtureCopy {
   greeting: string

--- a/packages/template-engine/src/create-email-template.ts
+++ b/packages/template-engine/src/create-email-template.ts
@@ -5,7 +5,7 @@
  * Captures four template-agnostic concerns:
  *
  * 1. Load the XML template + JSON copy at construction (via
- *    `loadTemplate` / `loadCopy` from `@rulecom/template-engine`).
+ *    `loadTemplate` / `loadCopy` from `@rule/template-engine`).
  * 2. Merge the caller-supplied copy override into the default copy.
  * 3. Project theme-driven context fields into the compile context so
  *    the XML's structural guards can see them:
@@ -30,8 +30,8 @@
  * @public
  */
 
-import type { EmailTheme, RcmlDocument } from '@rulecom/rcml'
-import { applyTheme, xmlToRcml } from '@rulecom/rcml'
+import type { EmailTheme, RcmlDocument } from '@rule/rcml'
+import { applyTheme, xmlToRcml } from '@rule/rcml'
 
 import { compileTemplate } from './compile.js'
 import { loadCopy } from './load-copy.js'
@@ -60,7 +60,7 @@ export interface EmailTemplateRenderArgs<TCopy, TContext> {
   readonly copy?: Partial<TCopy>
   /**
    * Optional custom `TemplateRef` serializer. Defaults to the RFM
-   * serializer shipped with `@rulecom/template-engine`.
+   * serializer shipped with `@rule/template-engine`.
    */
   readonly serializer?: TemplateRefSerializer
 }

--- a/packages/template-engine/src/errors.ts
+++ b/packages/template-engine/src/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Error surface for `@rulecom/template-engine`.
+ * Error surface for `@rule/template-engine`.
  *
  * @public
  */

--- a/packages/template-engine/src/index.ts
+++ b/packages/template-engine/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@rulecom/template-engine` — minimal XML template compiler.
+ * `@rule/template-engine` — minimal XML template compiler.
  *
  * See `docs/template-syntax.md` for the v3 specification and
  * `docs/typed-template-refs.md` for the TemplateRef rationale.

--- a/packages/template-engine/src/refs/serializer.ts
+++ b/packages/template-engine/src/refs/serializer.ts
@@ -3,7 +3,7 @@
  * placeholder format, plus a dispatcher and runtime type guard.
  *
  * The default output is byte-identical to the strings produced by
- * `email.createCustomField` / `email.createLoopValue` in `@rulecom/rcml` —
+ * `email.createCustomField` / `email.createLoopValue` in `@rule/rcml` —
  * so existing downstream parsers and snapshot assertions keep working
  * after callers switch from pre-rendered strings to typed refs.
  *

--- a/packages/template-engine/src/types.ts
+++ b/packages/template-engine/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public type surface for `@rulecom/template-engine` v3.
+ * Public type surface for `@rule/template-engine` v3.
  *
  * See `docs/template-syntax.md` for the full syntax specification.
  *

--- a/packages/vendor-bookzen/README.md
+++ b/packages/vendor-bookzen/README.md
@@ -1,4 +1,4 @@
-# @rulecom/vendor-bookzen
+# @rule/vendor-bookzen
 
 > **Under Development** — This package is not yet published to npm. It is under active development and will be included in a future release of the Rule.io SDK. The API is unstable and may change without notice.
 
@@ -7,7 +7,7 @@
 Bookzen preset for the Rule.io SDK. Hospitality automation flows — reservation confirmation / cancellation / reminder / feedback request / reservation request — wired to the Bookzen field-name schema.
 
 ```ts
-import { bookzenPreset, BOOKZEN_FIELD_SCHEMA, BOOKZEN_TAGS } from '@rulecom/vendor-bookzen';
+import { bookzenPreset, BOOKZEN_FIELD_SCHEMA, BOOKZEN_TAGS } from '@rule/vendor-bookzen';
 ```
 
-See the [main `@rulecom/sdk` README](../sdk/README.md) for full SDK docs.
+See the [main `@rule/sdk` README](../sdk/README.md) for full SDK docs.

--- a/packages/vendor-bookzen/package.json
+++ b/packages/vendor-bookzen/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rulecom/vendor-bookzen",
+  "name": "@rule/vendor-bookzen",
   "version": "0.4.0-beta.1",
   "description": "Bookzen preset for the Rule.io SDK \u2014 hospitality automation flows (reservation confirmation, cancellation, reminder, feedback, request).",
   "type": "module",
@@ -32,10 +32,10 @@
     "directory": "packages/vendor-bookzen"
   },
   "dependencies": {
-    "@rulecom/client": "*",
-    "@rulecom/rcml": "*",
-    "@rulecom/template-engine": "*",
-    "@rulecom/vendor": "*"
+    "@rule/client": "*",
+    "@rule/rcml": "*",
+    "@rule/template-engine": "*",
+    "@rule/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-bookzen/src/automations.ts
+++ b/packages/vendor-bookzen/src/automations.ts
@@ -1,5 +1,5 @@
-import type { EmailTheme, RcmlDocument } from '@rulecom/rcml';
-import type { EmailTemplate } from '@rulecom/template-engine';
+import type { EmailTheme, RcmlDocument } from '@rule/rcml';
+import type { EmailTemplate } from '@rule/template-engine';
 
 import {
   createReservationConfirmationTemplate

--- a/packages/vendor-bookzen/src/integration.ts
+++ b/packages/vendor-bookzen/src/integration.ts
@@ -1,11 +1,11 @@
-import { RuleApiError } from '@rulecom/client';
+import { RuleApiError } from '@rule/client';
 import type {
   CustomFieldGroupEntry,
   RuleApiResponse,
   RuleClient,
   Subscriber,
   WriteCustomFieldDataPayload,
-} from '@rulecom/client';
+} from '@rule/client';
 import {
   BOOKZEN_BOOKING_FIELD_SCHEMA,
   BOOKZEN_FIELD_SCHEMA,

--- a/packages/vendor-bookzen/src/preset.ts
+++ b/packages/vendor-bookzen/src/preset.ts
@@ -1,5 +1,5 @@
-import type { VendorConsumerConfig, VendorFieldInfo, AutomationConfigV2 } from '@rulecom/vendor';
-import { VendorPresetError } from '@rulecom/vendor';
+import type { VendorConsumerConfig, VendorFieldInfo, AutomationConfigV2 } from '@rule/vendor';
+import { VendorPresetError } from '@rule/vendor';
 import type { BookzenFieldSchema } from './fields.js';
 import type { BookzenTagSchema } from './tags.js';
 import { BOOKZEN_FIELD_SCHEMA } from './fields.js';

--- a/packages/vendor-bookzen/src/tags.ts
+++ b/packages/vendor-bookzen/src/tags.ts
@@ -4,14 +4,14 @@
  * Standard tags used by Bookzen hospitality integrations with Rule.io.
  */
 
-import type { VendorTagSchema } from '@rulecom/vendor';
+import type { VendorTagSchema } from '@rule/vendor';
 
 /**
  * Bookzen tags for Rule.io automations.
  *
  * @example
  * ```typescript
- * import { BOOKZEN_TAGS } from '@rulecom/sdk';
+ * import { BOOKZEN_TAGS } from '@rule/sdk';
  *
  * await client.syncSubscriber({
  *   email: 'guest@example.com',

--- a/packages/vendor-bookzen/src/templates/feedback-request/feedback-request.test.ts
+++ b/packages/vendor-bookzen/src/templates/feedback-request/feedback-request.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-bookzen/src/templates/feedback-request/feedback-request.ts
+++ b/packages/vendor-bookzen/src/templates/feedback-request/feedback-request.ts
@@ -1,7 +1,7 @@
 /**
  * Feedback-request template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * Works for post-stay, post-purchase, or any review request.
  */
 
@@ -9,8 +9,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface FeedbackRequestTemplateContext {
   recipient: {

--- a/packages/vendor-bookzen/src/templates/reservation-cancellation/reservation-cancellation.test.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-cancellation/reservation-cancellation.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-bookzen/src/templates/reservation-cancellation/reservation-cancellation.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-cancellation/reservation-cancellation.ts
@@ -1,15 +1,15 @@
 /**
  * Reservation-cancellation template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  */
 
 import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface ReservationCancellationTemplateContext {
   recipient: {

--- a/packages/vendor-bookzen/src/templates/reservation-confirmation/reservation-confirmation.test.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-confirmation/reservation-confirmation.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-bookzen/src/templates/reservation-confirmation/reservation-confirmation.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-confirmation/reservation-confirmation.ts
@@ -1,9 +1,9 @@
 /**
  * Reservation-confirmation template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * Caller assembles {@link ReservationConfirmationTemplateContext}
- * with `customField` from `@rulecom/template-engine`; the factory handles
+ * with `customField` from `@rule/template-engine`; the factory handles
  * loading, compile, theme projection, xmlToRcml, and applyTheme.
  */
 
@@ -11,8 +11,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `reservation-confirmation.xml`.

--- a/packages/vendor-bookzen/src/templates/reservation-reminder/reservation-reminder.test.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-reminder/reservation-reminder.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-bookzen/src/templates/reservation-reminder/reservation-reminder.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-reminder/reservation-reminder.ts
@@ -1,7 +1,7 @@
 /**
  * Reservation-reminder template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  *
  * Optional sections gate on context: omit `reservation.checkOutDate`
  * to render a single-date row; omit `reservation.roomName` to skip
@@ -13,8 +13,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface ReservationReminderTemplateContext {
   recipient: {

--- a/packages/vendor-bookzen/src/templates/reservation-request/reservation-request.test.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-request/reservation-request.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-bookzen/src/templates/reservation-request/reservation-request.ts
+++ b/packages/vendor-bookzen/src/templates/reservation-request/reservation-request.ts
@@ -4,15 +4,15 @@
  * Sent when a reservation request is received and awaiting manual
  * approval. Has no CTA — the email is purely informational.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  */
 
 import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface ReservationRequestTemplateContext {
   recipient: {

--- a/packages/vendor-bookzen/src/test-fixtures.ts
+++ b/packages/vendor-bookzen/src/test-fixtures.ts
@@ -7,10 +7,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 /** Default test theme. Has a logo, no social links. */
 export const TEST_THEME: EmailTheme = {

--- a/packages/vendor-bookzen/src/utils.ts
+++ b/packages/vendor-bookzen/src/utils.ts
@@ -1,4 +1,4 @@
-import { CustomFieldRef } from '@rulecom/template-engine';
+import { CustomFieldRef } from '@rule/template-engine';
 import type { ResolvedVendorField } from './types.js';
 
 

--- a/packages/vendor-bookzen/tests/bookzen.test.ts
+++ b/packages/vendor-bookzen/tests/bookzen.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { VendorPresetError } from '@rulecom/vendor';
-import type { CustomFieldMap, VendorConsumerConfig } from '@rulecom/vendor';
+import { VendorPresetError } from '@rule/vendor';
+import type { CustomFieldMap, VendorConsumerConfig } from '@rule/vendor';
 import { bookzenPreset, BOOKZEN_FIELD_SCHEMA, BOOKZEN_TAGS } from '../src/index.js';
 import { TEST_THEME } from './helpers.js';
 
@@ -106,7 +106,7 @@ describe('bookzenPreset', () => {
     // The pre-built automation entries have been retired. Template
     // authors now build contexts directly via the factory functions
     // (createReservationConfirmationTemplate, etc.) and wire
-    // automations through @rulecom/client. See
+    // automations through @rule/client. See
     // packages/templates/README.md for the authoring pattern.
     it('returns an empty list (pre-built automations retired)', () => {
       const automations = bookzenPreset.getAutomations(TEST_CONFIG);

--- a/packages/vendor-bookzen/tests/helpers.ts
+++ b/packages/vendor-bookzen/tests/helpers.ts
@@ -6,10 +6,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 // ============================================================================
 // Shared theme fixture

--- a/packages/vendor-samfora/README.md
+++ b/packages/vendor-samfora/README.md
@@ -1,4 +1,4 @@
-# @rulecom/vendor-samfora
+# @rule/vendor-samfora
 
 > **Under Development** — This package is not yet published to npm. It is under active development and will be included in a future release of the Rule.io SDK. The API is unstable and may change without notice.
 
@@ -7,7 +7,7 @@
 Samfora preset for the Rule.io SDK. Donation-platform automation flows for [Samfora](https://samfora.org). Default copy ships in Swedish.
 
 ```ts
-import { samforaPreset, SAMFORA_FIELDS, SAMFORA_TAGS } from '@rulecom/vendor-samfora';
+import { samforaPreset, SAMFORA_FIELDS, SAMFORA_TAGS } from '@rule/vendor-samfora';
 ```
 
-See the [main `@rulecom/sdk` README](../sdk/README.md) for full SDK docs.
+See the [main `@rule/sdk` README](../sdk/README.md) for full SDK docs.

--- a/packages/vendor-samfora/package.json
+++ b/packages/vendor-samfora/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rulecom/vendor-samfora",
+  "name": "@rule/vendor-samfora",
   "version": "0.4.0-beta.1",
   "description": "Samfora preset for the Rule.io SDK \u2014 Swedish donation-platform automation flows.",
   "type": "module",
@@ -32,9 +32,9 @@
     "directory": "packages/vendor-samfora"
   },
   "dependencies": {
-    "@rulecom/rcml": "*",
-    "@rulecom/template-engine": "*",
-    "@rulecom/vendor": "*"
+    "@rule/rcml": "*",
+    "@rule/template-engine": "*",
+    "@rule/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-samfora/src/automations.ts
+++ b/packages/vendor-samfora/src/automations.ts
@@ -12,10 +12,10 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { CustomFieldMap, FooterConfig } from '@rulecom/vendor';
-import { VendorPresetError } from '@rulecom/vendor';
-import type { EmailTheme } from '@rulecom/rcml';
-import type { VendorAutomation, VendorConsumerConfig } from '@rulecom/vendor';
+import type { CustomFieldMap, FooterConfig } from '@rule/vendor';
+import { VendorPresetError } from '@rule/vendor';
+import type { EmailTheme } from '@rule/rcml';
+import type { VendorAutomation, VendorConsumerConfig } from '@rule/vendor';
 import type {
   Json,
   RcmlBodyChild,
@@ -25,8 +25,8 @@ import type {
   RcmlHeading,
   RcmlSection,
   RcmlText,
-} from '@rulecom/rcml';
-import { applyTheme } from '@rulecom/rcml';
+} from '@rule/rcml';
+import { applyTheme } from '@rule/rcml';
 import { SAMFORA_FIELDS } from './fields.js';
 import { SAMFORA_TAGS } from './tags.js';
 

--- a/packages/vendor-samfora/src/fields.ts
+++ b/packages/vendor-samfora/src/fields.ts
@@ -5,7 +5,7 @@
  * Samfora is a Swedish charitable giving platform.
  */
 
-import type { VendorFieldSchema } from '@rulecom/vendor';
+import type { VendorFieldSchema } from '@rule/vendor';
 
 /**
  * Samfora field names for Rule.io custom fields.
@@ -24,7 +24,7 @@ import type { VendorFieldSchema } from '@rulecom/vendor';
  *
  * @example
  * ```typescript
- * import { SAMFORA_FIELDS } from '@rulecom/sdk';
+ * import { SAMFORA_FIELDS } from '@rule/sdk';
  *
  * const customFields = {
  *   [SAMFORA_FIELDS.donorFirstName]: 47736,   // pre-existing in account

--- a/packages/vendor-samfora/src/preset.ts
+++ b/packages/vendor-samfora/src/preset.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```typescript
- * import { samforaPreset, SAMFORA_FIELDS } from '@rulecom/sdk';
+ * import { samforaPreset, SAMFORA_FIELDS } from '@rule/sdk';
  *
  * const config = {
  *   brandStyle: myBrandStyle,
@@ -28,14 +28,14 @@
  * ```
  */
 
-import type { AutomationConfigV2, VendorPreset, VendorConsumerConfig, VendorFieldInfo } from '@rulecom/vendor';
-import { resolveVendorAutomations } from '@rulecom/vendor';
+import type { AutomationConfigV2, VendorPreset, VendorConsumerConfig, VendorFieldInfo } from '@rule/vendor';
+import { resolveVendorAutomations } from '@rule/vendor';
 import type { SamforaFieldSchema, SamforaFieldNames } from './fields.js';
 import type { SamforaTagSchema } from './tags.js';
 import { SAMFORA_FIELDS } from './fields.js';
 import { SAMFORA_TAGS } from './tags.js';
 import { createSamforaAutomations } from './automations.js';
-import { VendorPresetError } from '@rulecom/vendor';
+import { VendorPresetError } from '@rule/vendor';
 
 const FIELD_DESCRIPTIONS: Record<SamforaFieldNames, string> = {
   // Subscriber (standard Rule.io fields)

--- a/packages/vendor-samfora/src/tags.ts
+++ b/packages/vendor-samfora/src/tags.ts
@@ -8,14 +8,14 @@
  * returning donors) without triggering a new flow on their own.
  */
 
-import type { VendorTagSchema } from '@rulecom/vendor';
+import type { VendorTagSchema } from '@rule/vendor';
 
 /**
  * Samfora tags for Rule.io automations.
  *
  * @example
  * ```typescript
- * import { SAMFORA_TAGS } from '@rulecom/sdk';
+ * import { SAMFORA_TAGS } from '@rule/sdk';
  *
  * await client.syncSubscriber({
  *   email: 'donor@example.com',

--- a/packages/vendor-samfora/src/templates/annual-tax-summary/annual-tax-summary.test.ts
+++ b/packages/vendor-samfora/src/templates/annual-tax-summary/annual-tax-summary.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/annual-tax-summary/annual-tax-summary.ts
+++ b/packages/vendor-samfora/src/templates/annual-tax-summary/annual-tax-summary.ts
@@ -13,8 +13,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface AnnualTaxSummaryTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/templates/donation-confirmation-first/donation-confirmation-first.test.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-first/donation-confirmation-first.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/donation-confirmation-first/donation-confirmation-first.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-first/donation-confirmation-first.ts
@@ -12,8 +12,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface DonationConfirmationFirstTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/templates/donation-confirmation-returning/donation-confirmation-returning.test.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-returning/donation-confirmation-returning.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/donation-confirmation-returning/donation-confirmation-returning.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-returning/donation-confirmation-returning.ts
@@ -12,8 +12,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface DonationConfirmationReturningTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/templates/donation-confirmation-second/donation-confirmation-second.test.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-second/donation-confirmation-second.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/donation-confirmation-second/donation-confirmation-second.ts
+++ b/packages/vendor-samfora/src/templates/donation-confirmation-second/donation-confirmation-second.ts
@@ -12,8 +12,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface DonationConfirmationSecondTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/templates/monthly-donation-confirmation/monthly-donation-confirmation.test.ts
+++ b/packages/vendor-samfora/src/templates/monthly-donation-confirmation/monthly-donation-confirmation.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/monthly-donation-confirmation/monthly-donation-confirmation.ts
+++ b/packages/vendor-samfora/src/templates/monthly-donation-confirmation/monthly-donation-confirmation.ts
@@ -12,8 +12,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface MonthlyDonationConfirmationTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/templates/welcome/welcome.test.ts
+++ b/packages/vendor-samfora/src/templates/welcome/welcome.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-samfora/src/templates/welcome/welcome.ts
+++ b/packages/vendor-samfora/src/templates/welcome/welcome.ts
@@ -1,7 +1,7 @@
 /**
  * Samfora welcome template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * Sent when a new donor creates a Samfora account. Default copy is
  * Swedish; pass `copy: { ... }` at render time to localise.
  *
@@ -13,8 +13,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 export interface SamforaWelcomeTemplateContext {
   recipient: {

--- a/packages/vendor-samfora/src/test-fixtures.ts
+++ b/packages/vendor-samfora/src/test-fixtures.ts
@@ -7,10 +7,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 /** Default test theme. Has a logo, no social links. */
 export const TEST_THEME: EmailTheme = {

--- a/packages/vendor-samfora/tests/helpers.ts
+++ b/packages/vendor-samfora/tests/helpers.ts
@@ -6,10 +6,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 // ============================================================================
 // Shared theme fixture

--- a/packages/vendor-samfora/tests/samfora.test.ts
+++ b/packages/vendor-samfora/tests/samfora.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { VendorPresetError } from '@rulecom/vendor';
-import type { CustomFieldMap, VendorConsumerConfig } from '@rulecom/vendor';
-import type { RcmlDocument } from '@rulecom/rcml';
+import { VendorPresetError } from '@rule/vendor';
+import type { CustomFieldMap, VendorConsumerConfig } from '@rule/vendor';
+import type { RcmlDocument } from '@rule/rcml';
 import { samforaPreset, SAMFORA_FIELDS, SAMFORA_TAGS } from '../src/index.js';
 import { TEST_THEME, themeWithoutLogo, assertValidRCMLDocument, docToString } from './helpers.js';
 

--- a/packages/vendor-shopify/README.md
+++ b/packages/vendor-shopify/README.md
@@ -1,4 +1,4 @@
-# @rulecom/vendor-shopify
+# @rule/vendor-shopify
 
 > **Under Development** — This package is not yet published to npm. It is under active development and will be included in a future release of the Rule.io SDK. The API is unstable and may change without notice.
 
@@ -7,7 +7,7 @@
 Shopify preset for the Rule.io SDK. Ships pre-configured e-commerce automation flows — order confirmation, shipping update, abandoned cart, order cancellation, and a newsletter welcome — wired to the Shopify field-name schema and default English copy.
 
 ```ts
-import { shopifyPreset, SHOPIFY_FIELDS, SHOPIFY_TAGS } from '@rulecom/vendor-shopify';
+import { shopifyPreset, SHOPIFY_FIELDS, SHOPIFY_TAGS } from '@rule/vendor-shopify';
 ```
 
-See the [main `@rulecom/sdk` README](../sdk/README.md) for full SDK docs.
+See the [main `@rule/sdk` README](../sdk/README.md) for full SDK docs.

--- a/packages/vendor-shopify/package.json
+++ b/packages/vendor-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rulecom/vendor-shopify",
+  "name": "@rule/vendor-shopify",
   "version": "0.4.0-beta.1",
   "description": "Shopify preset for the Rule.io SDK \u2014 e-commerce automation flows (order confirmation, shipping, abandoned cart, cancellation, welcome).",
   "type": "module",
@@ -31,9 +31,9 @@
     "directory": "packages/vendor-shopify"
   },
   "dependencies": {
-    "@rulecom/rcml": "*",
-    "@rulecom/template-engine": "*",
-    "@rulecom/vendor": "*"
+    "@rule/rcml": "*",
+    "@rule/template-engine": "*",
+    "@rule/vendor": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor-shopify/src/automations.ts
+++ b/packages/vendor-shopify/src/automations.ts
@@ -3,16 +3,16 @@
  *
  * Placeholder. The pre-built shopify automations have been retired —
  * downstream code now builds template contexts explicitly (via
- * `customField` / `loopValue` from `@rulecom/template-engine`) and calls
+ * `customField` / `loopValue` from `@rule/template-engine`) and calls
  * the template factories (`createOrderConfirmationTemplate`,
  * `createShippingUpdateTemplate`, `createOrderCancellationTemplate`,
  * `createAbandonedCartTemplate`, `createWelcomeTemplate`) directly
- * when wiring automations through `@rulecom/client`.
+ * when wiring automations through `@rule/client`.
  *
  * @see https://help.rule.io/en/articles/349484-shopify-integration
  */
 
-import type { VendorAutomation } from '@rulecom/vendor';
+import type { VendorAutomation } from '@rule/vendor';
 
 /**
  * Shopify automation definitions. Currently empty; see module JSDoc.

--- a/packages/vendor-shopify/src/fields.ts
+++ b/packages/vendor-shopify/src/fields.ts
@@ -7,14 +7,14 @@
  * Consumers provide the numeric IDs from their Rule.io account.
  */
 
-import type { VendorFieldSchema } from '@rulecom/vendor';
+import type { VendorFieldSchema } from '@rule/vendor';
 
 /**
  * Shopify field names for Rule.io custom fields.
  *
  * @example
  * ```typescript
- * import { SHOPIFY_FIELDS } from '@rulecom/sdk';
+ * import { SHOPIFY_FIELDS } from '@rule/sdk';
  *
  * const customFields = {
  *   [SHOPIFY_FIELDS.firstName]: 169233,

--- a/packages/vendor-shopify/src/preset.ts
+++ b/packages/vendor-shopify/src/preset.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```typescript
- * import { shopifyPreset, SHOPIFY_FIELDS } from '@rulecom/sdk';
+ * import { shopifyPreset, SHOPIFY_FIELDS } from '@rule/sdk';
  *
  * const config = {
  *   brandStyle: myBrandStyle,
@@ -22,14 +22,14 @@
  * ```
  */
 
-import type { AutomationConfigV2, VendorPreset, VendorConsumerConfig, VendorFieldInfo } from '@rulecom/vendor';
-import { resolveVendorAutomations } from '@rulecom/vendor';
+import type { AutomationConfigV2, VendorPreset, VendorConsumerConfig, VendorFieldInfo } from '@rule/vendor';
+import { resolveVendorAutomations } from '@rule/vendor';
 import type { ShopifyFieldSchema, ShopifyFieldNames } from './fields.js';
 import type { ShopifyTagSchema } from './tags.js';
 import { SHOPIFY_FIELDS } from './fields.js';
 import { SHOPIFY_TAGS } from './tags.js';
 import { createShopifyAutomations } from './automations.js';
-import { VendorPresetError } from '@rulecom/vendor';
+import { VendorPresetError } from '@rule/vendor';
 
 const FIELD_DESCRIPTIONS: Record<ShopifyFieldNames, string> = {
   // Subscriber

--- a/packages/vendor-shopify/src/tags.ts
+++ b/packages/vendor-shopify/src/tags.ts
@@ -5,14 +5,14 @@
  * @see https://help.rule.io/en/articles/349484-shopify-integration
  */
 
-import type { VendorTagSchema } from '@rulecom/vendor';
+import type { VendorTagSchema } from '@rule/vendor';
 
 /**
  * Shopify tags for Rule.io automations.
  *
  * @example
  * ```typescript
- * import { SHOPIFY_TAGS } from '@rulecom/sdk';
+ * import { SHOPIFY_TAGS } from '@rule/sdk';
  *
  * await client.syncSubscriber({
  *   email: 'customer@example.com',

--- a/packages/vendor-shopify/src/templates/_helpers.ts
+++ b/packages/vendor-shopify/src/templates/_helpers.ts
@@ -16,8 +16,8 @@
  * @internal
  */
 
-import { VendorPresetError } from '@rulecom/vendor'
-import type { CustomFieldMap } from '@rulecom/vendor'
+import { VendorPresetError } from '@rule/vendor'
+import type { CustomFieldMap } from '@rule/vendor'
 
 export interface TemplateHelpers {
   field: (logicalName: string) => string

--- a/packages/vendor-shopify/src/templates/abandoned-cart/abandoned-cart.test.ts
+++ b/packages/vendor-shopify/src/templates/abandoned-cart/abandoned-cart.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField, loopValue } from '@rulecom/template-engine'
+import { customField, loopValue } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-shopify/src/templates/abandoned-cart/abandoned-cart.ts
+++ b/packages/vendor-shopify/src/templates/abandoned-cart/abandoned-cart.ts
@@ -1,10 +1,10 @@
 /**
  * Abandoned-cart template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * The caller owns context assembly (building the typed
  * {@link AbandonedCartTemplateContext} with `customField` / `loopValue`
- * from `@rulecom/template-engine`); the reusable factory handles loading
+ * from `@rule/template-engine`); the reusable factory handles loading
  * the XML + JSON copy, merging copy overrides, projecting
  * `theme.images.logo` / `theme.links` into context, compiling,
  * parsing to RCML, and applying the theme.
@@ -22,8 +22,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef, LoopValueRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef, LoopValueRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `abandoned-cart.xml`.
@@ -81,7 +81,7 @@ export interface AbandonedCartTemplateContext {
  * carry the full English text as literal strings, plus `{{slot}}`
  * substitutions for custom-field and loop-value refs supplied at
  * render time (built via `customField` / `loopValue` from
- * `@rulecom/template-engine`; the compiler serializes them to RFM
+ * `@rule/template-engine`; the compiler serializes them to RFM
  * placeholder strings automatically).
  *
  * Footer-link labels and styling live inline in the `footerLinks`
@@ -136,7 +136,7 @@ export type AbandonedCartTemplate =
 /**
  * Return a renderer bound to the abandoned-cart XML. Call
  * `render({ context, theme, copy? })` to produce the themed
- * {@link import('@rulecom/rcml').RcmlDocument}. Copy overrides apply
+ * {@link import('@rule/rcml').RcmlDocument}. Copy overrides apply
  * per-render, not per-factory — the same template instance can render
  * multiple locales/brand voices.
  */

--- a/packages/vendor-shopify/src/templates/order-cancellation/order-cancellation.test.ts
+++ b/packages/vendor-shopify/src/templates/order-cancellation/order-cancellation.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-shopify/src/templates/order-cancellation/order-cancellation.ts
+++ b/packages/vendor-shopify/src/templates/order-cancellation/order-cancellation.ts
@@ -1,10 +1,10 @@
 /**
  * Order-cancellation template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * The caller owns context assembly (building the typed
  * {@link OrderCancellationTemplateContext} with `customField` from
- * `@rulecom/template-engine`); the reusable factory handles loading the XML
+ * `@rule/template-engine`); the reusable factory handles loading the XML
  * + JSON copy, merging copy overrides, projecting
  * `theme.images.logo` / `theme.links` into context, compiling,
  * parsing to RCML, and applying the theme.
@@ -18,8 +18,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `order-cancellation.xml`.

--- a/packages/vendor-shopify/src/templates/order-confirmation/order-confirmation.test.ts
+++ b/packages/vendor-shopify/src/templates/order-confirmation/order-confirmation.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField, loopValue } from '@rulecom/template-engine'
+import { customField, loopValue } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-shopify/src/templates/order-confirmation/order-confirmation.ts
+++ b/packages/vendor-shopify/src/templates/order-confirmation/order-confirmation.ts
@@ -1,10 +1,10 @@
 /**
  * Order-confirmation template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * The caller owns context assembly (building the typed
  * {@link OrderConfirmationTemplateContext} with `customField` /
- * `loopValue` from `@rulecom/template-engine`); the factory handles
+ * `loopValue` from `@rule/template-engine`); the factory handles
  * loading, compile, theme projection, xmlToRcml, and applyTheme.
  *
  * Context is fully structural: optional sections are controlled by
@@ -16,8 +16,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef, LoopValueRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef, LoopValueRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `order-confirmation.xml`.

--- a/packages/vendor-shopify/src/templates/shipping-update/shipping-update.test.ts
+++ b/packages/vendor-shopify/src/templates/shipping-update/shipping-update.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField, loopValue } from '@rulecom/template-engine'
+import { customField, loopValue } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-shopify/src/templates/shipping-update/shipping-update.ts
+++ b/packages/vendor-shopify/src/templates/shipping-update/shipping-update.ts
@@ -1,10 +1,10 @@
 /**
  * Shipping-update template factory.
  *
- * Thin wrapper over {@link createEmailTemplate} from `@rulecom/rcml`.
+ * Thin wrapper over {@link createEmailTemplate} from `@rule/rcml`.
  * The caller owns context assembly (building the typed
  * {@link ShippingUpdateTemplateContext} with `customField` /
- * `loopValue` from `@rulecom/template-engine`); the factory handles
+ * `loopValue` from `@rule/template-engine`); the factory handles
  * loading, compile, theme projection, xmlToRcml, and applyTheme.
  *
  * Context is fully structural: optional sections are controlled by
@@ -17,8 +17,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef, LoopValueRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef, LoopValueRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `shipping-update.xml`.

--- a/packages/vendor-shopify/src/templates/welcome/welcome.test.ts
+++ b/packages/vendor-shopify/src/templates/welcome/welcome.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { customField } from '@rulecom/template-engine'
+import { customField } from '@rule/template-engine'
 
 import {
   TEST_THEME,

--- a/packages/vendor-shopify/src/templates/welcome/welcome.ts
+++ b/packages/vendor-shopify/src/templates/welcome/welcome.ts
@@ -3,7 +3,7 @@
  *
  * Vertical-agnostic template for newsletter signups, account
  * creation, or any opt-in acknowledgement. Thin wrapper over
- * {@link createEmailTemplate} from `@rulecom/rcml`.
+ * {@link createEmailTemplate} from `@rule/rcml`.
  *
  * Context is fully structural: optional sections are controlled by
  * the presence of their backing fields (omit `benefits` to skip the
@@ -15,8 +15,8 @@ import {
   createEmailTemplate,
   type EmailTemplate,
   type EmailTemplateRenderArgs,
-} from '@rulecom/template-engine'
-import type { CustomFieldRef } from '@rulecom/template-engine'
+} from '@rule/template-engine'
+import type { CustomFieldRef } from '@rule/template-engine'
 
 /**
  * Typed data context consumed by `welcome.xml`.

--- a/packages/vendor-shopify/src/test-fixtures.ts
+++ b/packages/vendor-shopify/src/test-fixtures.ts
@@ -6,10 +6,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 // ============================================================================
 // Shared theme fixture

--- a/packages/vendor-shopify/tests/helpers.ts
+++ b/packages/vendor-shopify/tests/helpers.ts
@@ -6,10 +6,10 @@
  */
 
 import { expect } from 'vitest';
-import type { EmailTheme } from '@rulecom/rcml';
-import { EmailThemeColorType, EmailThemeImageType } from '@rulecom/rcml';
-import type { RcmlDocument } from '@rulecom/rcml';
-import { createEmailTheme } from '@rulecom/rcml';
+import type { EmailTheme } from '@rule/rcml';
+import { EmailThemeColorType, EmailThemeImageType } from '@rule/rcml';
+import type { RcmlDocument } from '@rule/rcml';
+import { createEmailTheme } from '@rule/rcml';
 
 // ============================================================================
 // Shared theme fixture

--- a/packages/vendor-shopify/tests/shopify.test.ts
+++ b/packages/vendor-shopify/tests/shopify.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { VendorPresetError } from '@rulecom/vendor';
-import type { CustomFieldMap, VendorConsumerConfig } from '@rulecom/vendor';
+import { VendorPresetError } from '@rule/vendor';
+import type { CustomFieldMap, VendorConsumerConfig } from '@rule/vendor';
 import { shopifyPreset, SHOPIFY_FIELDS, SHOPIFY_TAGS } from '../src/index.js';
 import { TEST_THEME } from '../src/test-fixtures.js';
 
@@ -139,7 +139,7 @@ describe('shopifyPreset', () => {
     // The pre-built automation entries have been retired. Template
     // authors now build contexts directly via the factory functions
     // (createOrderConfirmationTemplate, etc.) and wire automations
-    // through @rulecom/client. See packages/templates/README.md for
+    // through @rule/client. See packages/templates/README.md for
     // the authoring pattern.
     it('returns an empty list (pre-built automations retired)', () => {
       const automations = shopifyPreset.getAutomations(TEST_CONFIG);

--- a/packages/vendor/README.md
+++ b/packages/vendor/README.md
@@ -1,9 +1,9 @@
-# @rulecom/vendor
+# @rule/vendor
 
 > **Under Development** — This package is not yet published to npm. It is under active development and will be included in a future release of the Rule.io SDK. The API is unstable and may change without notice.
 
 ---
 
-Shared vendor-preset infrastructure for the Rule.io SDK. Provides the `VendorPreset` interface, `VendorPresetError`, and common types (`CustomFieldMap`, `VendorConsumerConfig`, etc.) used by `@rulecom/vendor-shopify`, `@rulecom/vendor-bookzen`, and `@rulecom/vendor-samfora`.
+Shared vendor-preset infrastructure for the Rule.io SDK. Provides the `VendorPreset` interface, `VendorPresetError`, and common types (`CustomFieldMap`, `VendorConsumerConfig`, etc.) used by `@rule/vendor-shopify`, `@rule/vendor-bookzen`, and `@rule/vendor-samfora`.
 
 This is an infrastructure package — it is not intended to be installed directly by SDK consumers. It arrives as a transitive dependency of the vendor preset packages.

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rulecom/vendor",
+  "name": "@rule/vendor",
   "version": "0.4.0-beta.1",
   "description": "Shared vendor utilities for the Rule.io SDK.",
   "type": "module",
@@ -29,7 +29,7 @@
     "directory": "packages/vendor"
   },
   "dependencies": {
-    "@rulecom/rcml": "*"
+    "@rule/rcml": "*"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor/src/vendor-types.ts
+++ b/packages/vendor/src/vendor-types.ts
@@ -3,7 +3,7 @@
  * the Rule.io platform.
  *
  * Provides a two-layer abstraction:
- * - **Vendor Preset** (shipped by a `@rulecom/vendor-*` package): field
+ * - **Vendor Preset** (shipped by a `@rule/vendor-*` package): field
  *   names, tags, automation flows, default text.
  * - **Consumer Config** (provided at runtime): brand style, field IDs,
  *   URLs.
@@ -11,7 +11,7 @@
  * @module vendors
  */
 
-import type { EmailTheme, RCMLDocumentRoot } from '@rulecom/rcml'
+import type { EmailTheme, RCMLDocumentRoot } from '@rule/rcml'
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
@@ -68,7 +68,7 @@ export interface FooterConfig {
  * The `theme` field is an {@link EmailTheme} applied to rcml documents via
  * `applyTheme`. Consumers convert their brand-style source (Rule.io API
  * response, hand-rolled config) to an `EmailTheme` before passing it in.
- * `@rulecom/client` ships `emailThemeFromBrandStyle` for the API-response case.
+ * `@rule/client` ships `emailThemeFromBrandStyle` for the API-response case.
  */
 export interface TemplateConfigV2 {
   /** Typed email theme applied to the built RCML document. */
@@ -83,14 +83,14 @@ export interface TemplateConfigV2 {
  * Full automation configuration.
  *
  * `templateBuilder` returns {@link RCMLDocumentRoot} at the type level so the
- * contract doesn't depend on `@rulecom/rcml`; concrete implementations return
+ * contract doesn't depend on `@rule/rcml`; concrete implementations return
  * a full `RcmlDocument` (a subtype), which TypeScript accepts by
  * function-return covariance.
  *
  * @example
  * ```typescript
- * import { RuleTags, createAbandonedCartEmail } from '@rulecom/sdk';
- * import type { AutomationConfigV2 } from '@rulecom/sdk';
+ * import { RuleTags, createAbandonedCartEmail } from '@rule/sdk';
+ * import type { AutomationConfigV2 } from '@rule/sdk';
  *
  * const automation: AutomationConfigV2 = {
  *   id: 'abandoned-cart',
@@ -309,7 +309,7 @@ export interface VendorFieldInfo {
  *
  * @example
  * ```typescript
- * import { shopifyPreset, SHOPIFY_FIELDS } from '@rulecom/sdk';
+ * import { shopifyPreset, SHOPIFY_FIELDS } from '@rule/sdk';
  *
  * shopifyPreset.validateConfig(config);
  * const automations = shopifyPreset.getAutomations(config);

--- a/tests/integration/src/bookzen.integration.spec.ts
+++ b/tests/integration/src/bookzen.integration.spec.ts
@@ -1,17 +1,17 @@
-import { RuleClient } from '@rulecom/sdk';
+import { RuleClient } from '@rule/sdk';
 import {
   BookzenIntegration,
   BOOKZEN_FIELD_SCHEMA,
   BOOKZEN_SUBSCRIBER_SEED,
   BOOKZEN_SUBSCRIBER_FIELD_VALUES_SEED,
   BOOKZEN_BOOKING_FIELD_VALUES_SEED,
-} from '@rulecom/vendor-bookzen';
+} from '@rule/vendor-bookzen';
 import type {
   SeededBookzenSubscriber,
   BookzenSubscriberFieldName,
   BookzenBookingFieldName,
   BookzenFieldName,
-} from '@rulecom/vendor-bookzen';
+} from '@rule/vendor-bookzen';
 
 
 describe('integrate with Bookzen', () => {

--- a/tests/integration/src/meta-package.integration.spec.ts
+++ b/tests/integration/src/meta-package.integration.spec.ts
@@ -1,6 +1,6 @@
-import * as sdk from '@rulecom/sdk';
+import * as sdk from '@rule/sdk';
 
-describe('@rulecom/sdk', () => {
+describe('@rule/sdk', () => {
   it('loads without error', () => {
     expect(sdk).toBeDefined();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,14 +19,14 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "@rulecom/sdk": ["./packages/sdk/src/index.ts"],
-      "@rulecom/rcml": ["./packages/rcml/src/index.ts"],
-      "@rulecom/template-engine": ["./packages/template-engine/src/index.ts"],
-      "@rulecom/client": ["./packages/client/src/index.ts"],
-      "@rulecom/vendor-shopify": ["./packages/vendor-shopify/src/index.ts"],
-      "@rulecom/vendor-bookzen": ["./packages/vendor-bookzen/src/index.ts"],
-      "@rulecom/vendor-samfora": ["./packages/vendor-samfora/src/index.ts"],
-      "@rulecom/vendor": ["./packages/vendor/src/index.ts"]
+      "@rule/sdk": ["./packages/sdk/src/index.ts"],
+      "@rule/rcml": ["./packages/rcml/src/index.ts"],
+      "@rule/template-engine": ["./packages/template-engine/src/index.ts"],
+      "@rule/client": ["./packages/client/src/index.ts"],
+      "@rule/vendor-shopify": ["./packages/vendor-shopify/src/index.ts"],
+      "@rule/vendor-bookzen": ["./packages/vendor-bookzen/src/index.ts"],
+      "@rule/vendor-samfora": ["./packages/vendor-samfora/src/index.ts"],
+      "@rule/vendor": ["./packages/vendor/src/index.ts"]
     }
   },
   "files": [],


### PR DESCRIPTION
## Summary

- Renames all 8 packages from `@rulecom/*` to `@rule/*` (3 published + 5 private)
- Updates all import paths, `package.json` manifests, `tsconfig` paths, Verdaccio config, and CI allowlists
- Adds a migration guide page to the VitePress docs site (`/guide/migration`)
- Wires the migration page into the docs sidebar

## Test plan

- [ ] All packages build cleanly (`nx run-many -t build`)
- [ ] All tests pass (`nx run-many -t test`)
- [ ] Zero remaining `@rulecom` references in source/config files
- [ ] Docs build succeeds and migration page renders correctly

## Post-merge

After the first `@rule/*` release lands on npm, deprecate the old packages:
```bash
npm deprecate @rulecom/client "Renamed to @rule/client"
npm deprecate @rulecom/rcml "Renamed to @rule/rcml"
npm deprecate @rulecom/sdk "Renamed to @rule/sdk"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)