### PR TITLE
fix(rcml): enforce rc-section child exclusivity in JSON Schema

### DIFF
--- a/packages/rcml/src/email/validate-email-template.test.ts
+++ b/packages/rcml/src/email/validate-email-template.test.ts
@@ -194,7 +194,17 @@ describe('validateEmailTemplate — JSON AST input', () => {
 
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.errors.length).toBeGreaterThan(0)
+    // The section's children fail the top-level oneOf: neither an
+    // all-column array nor a single-group array. Assert that we see
+    // this specific failure mode reported on the section's children
+    // path, so the test can't pass on unrelated validation errors.
+    const sectionChildrenIssue = result.errors.find(
+      (e) =>
+        e.path === '/children/1/children/0/children' &&
+        e.code === EmailTemplateErrorCodes.CHILD_INVALID,
+    )
+
+    expect(sectionChildrenIssue).toBeDefined()
   })
 })
 

--- a/packages/rcml/src/email/validate-email-template.test.ts
+++ b/packages/rcml/src/email/validate-email-template.test.ts
@@ -163,6 +163,39 @@ describe('validateEmailTemplate — JSON AST input', () => {
     if (result.success) return
     expect(result.errors.some((e) => e.code === EmailTemplateErrorCodes.CHILD_TOO_MANY)).toBe(true)
   })
+
+  it('rejects rc-section with a mix of rc-column and rc-group (exclusivity)', () => {
+    // rc-section allows either an array of rc-columns OR a single-item
+    // array containing exactly one rc-group. Mixed shapes like
+    // [column, group] are rejected by createSectionElement at build
+    // time; the JSON Schema mirrors that contract so raw JSON built
+    // outside the factory is caught here too. The doc is intentionally
+    // typed as `unknown` to bypass TypeScript's narrower RcmlSection
+    // children union.
+    const bad: unknown = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                { tagName: 'rc-column', children: [] },
+                { tagName: 'rc-group', children: [{ tagName: 'rc-column', children: [] }] },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const result = safeValidateEmailTemplate(bad as RcmlDocument)
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
 })
 
 describe('validateEmailTemplate — ProseMirror content delegation', () => {

--- a/packages/rcml/src/email/validator/json-schema.test.ts
+++ b/packages/rcml/src/email/validator/json-schema.test.ts
@@ -42,14 +42,33 @@ describe('RCML_JSON_SCHEMA — $defs coverage', () => {
 })
 
 describe('RCML_JSON_SCHEMA — rc-section fragment', () => {
-  it('constrains rc-section to at most 20 columns', () => {
+  it('constrains rc-section children to exclusive shapes (columns[] or [group]) with at most 20 columns', () => {
     const $defs = RCML_JSON_SCHEMA['$defs'] as Record<string, Record<string, unknown>>
     const section = $defs['rc-section'] as Record<string, unknown>
     const properties = section['properties'] as Record<string, Record<string, unknown>>
     const children = properties['children'] as Record<string, unknown>
 
-    expect(children['type']).toBe('array')
-    expect(children['maxItems']).toBe(20)
+    // rc-section has exclusive children shapes — a union of two array shapes.
+    expect(children['oneOf']).toBeInstanceOf(Array)
+
+    const shapes = children['oneOf'] as Record<string, unknown>[]
+
+    expect(shapes).toHaveLength(2)
+
+    // First shape: array of rc-column, capped at maxChildCount (20).
+    const columnsShape = shapes[0]
+
+    expect(columnsShape['type']).toBe('array')
+    expect(columnsShape['maxItems']).toBe(20)
+    expect(columnsShape['items']).toEqual({ $ref: '#/$defs/rc-column' })
+
+    // Second shape: single-item array containing exactly one rc-group.
+    const groupShape = shapes[1]
+
+    expect(groupShape['type']).toBe('array')
+    expect(groupShape['minItems']).toBe(1)
+    expect(groupShape['maxItems']).toBe(1)
+    expect(groupShape['items']).toEqual({ $ref: '#/$defs/rc-group' })
   })
 
   it('pins rc-section `tagName` to a const', () => {

--- a/packages/rcml/src/email/validator/json-schema.ts
+++ b/packages/rcml/src/email/validator/json-schema.ts
@@ -132,6 +132,44 @@ function buildChildrenSchema(spec: RcmlNodeSpec, useAttrOverride = false): JsonS
 }
 
 /**
+ * Build the `children` array schema specifically for `rc-section`.
+ *
+ * `rc-section` has exclusive child shapes:
+ *   - a list of `rc-column[]` (0–maxChildCount), OR
+ *   - a single-item array containing one `rc-group`
+ *
+ * Mixed arrays like `[rc-column, rc-group]` and multi-group arrays are
+ * rejected by `createSectionElement` at build time; this schema mirrors
+ * that contract so `safeValidateEmailTemplate` rejects them too. The
+ * factory-level cardinality rules and the JSON Schema now agree.
+ *
+ * The generic `buildChildrenSchema` treats children as an array with
+ * per-item discriminated union — enough for tags whose children shape
+ * is uniform (e.g. rc-column, rc-body), but not expressive enough for
+ * rc-section's exclusivity.
+ */
+function buildSectionChildrenSchema(spec: RcmlNodeSpec): JsonSchema {
+  const maxItems = spec.maxChildCount
+
+  const columnsShape: JsonSchema = {
+    type: 'array',
+    items: { $ref: `#/$defs/${RcmlTagNamesEnum.Column}` },
+    ...(typeof maxItems === 'number' ? { maxItems } : {}),
+  }
+
+  const groupShape: JsonSchema = {
+    type: 'array',
+    minItems: 1,
+    maxItems: 1,
+    items: { $ref: `#/$defs/${RcmlTagNamesEnum.Group}` },
+  }
+
+  return {
+    oneOf: [columnsShape, groupShape],
+  }
+}
+
+/**
  * Non-ProseMirror content schemas for tags that carry a `content` property
  * with a plain string or a structured-but-non-PM object.
  *
@@ -185,8 +223,14 @@ function buildTagSchema(tagName: RcmlTagName, spec: RcmlNodeSpec): JsonSchema {
     // permissive *-attr override schemas so editor-generated nodes that lack
     // children/content still pass.
     const isAttrParent = tagName === RcmlTagNamesEnum.Attributes
+    // rc-section has exclusive child shapes (columns[] OR [group]); the
+    // generic per-item union isn't expressive enough to reject mixed
+    // arrays, so use the specialised schema builder here.
+    const isSection = tagName === RcmlTagNamesEnum.Section
 
-    properties['children'] = buildChildrenSchema(spec, isAttrParent)
+    properties['children'] = isSection
+      ? buildSectionChildrenSchema(spec)
+      : buildChildrenSchema(spec, isAttrParent)
     required.push('children')
   }
 


### PR DESCRIPTION
## Summary

Address Copilot review comment on release PR #161: rc-section's children shape is exclusive at the SDK factory level (either \`rc-column[]\` or a single \`rc-group\`), but the generated JSON Schema modelled children as an array with per-item discriminated union. \`safeValidateEmailTemplate\` accepted invalid shapes like \`[rc-column, rc-group]\` and \`[rc-group, rc-group]\` even though \`createSectionElement\` rejected them.

## Changes

- \`json-schema.ts\` — new \`buildSectionChildrenSchema\` helper generating \`oneOf\` of two array shapes: (1) an array of rc-column capped at \`maxChildCount\`, (2) a single-item array containing one rc-group. \`buildTagSchema\` branches on \`tagName === 'rc-section'\` to use this specialised builder.
- \`json-schema.test.ts\` — updated the rc-section fragment test to assert the new \`oneOf\` shape (two array shapes with the expected constraints).
- \`validate-email-template.test.ts\` — added downstream acceptance test proving \`safeValidateEmailTemplate\` now rejects \`[rc-column, rc-group]\` raw JSON.

Other tags keep using the generic per-item discriminated union — only rc-section needs shape-level exclusivity.

## Test plan

- [x] \`npx nx build rcml\` — clean
- [x] \`npx nx vitest:test rcml\` — 1267/1267 pass (existing 1266 + 1 new)
- [x] \`npx nx eslint:lint rcml\` — 0 errors

## Related

Fixes Copilot review comment at [rulecom/rule-io-sdk#161 (comment)](https://github.com/rulecom/rule-io-sdk/pull/161#discussion_r3663779189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)