### PR TITLE
fix(rcml): align rc-raw content shape with backend schema + fix XML HTML parsing

### DIFF
--- a/packages/rcml/docs/email/rcml/body/content/rc-raw.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-raw.md
@@ -8,7 +8,7 @@ None.
 
 ## Children
 
-None. Content is a raw HTML string set via the `content` field.
+None. Content is set via the `content` field as `{ type: 'html', text: string }`, where `text` holds the raw HTML string.
 
 ## Parents
 

--- a/packages/rcml/docs/email/rcml/body/content/rc-raw.md
+++ b/packages/rcml/docs/email/rcml/body/content/rc-raw.md
@@ -19,7 +19,10 @@ None. Content is a raw HTML string set via the `content` field.
 ```json
 {
   "tagName": "rc-raw",
-  "content": "<!--[if mso]><table><tr><td><![endif]-->"
+  "content": {
+    "type": "html",
+    "text": "<!--[if mso]><table><tr><td><![endif]-->"
+  }
 }
 ```
 

--- a/packages/rcml/src/email/create-rcml-element.test.ts
+++ b/packages/rcml/src/email/create-rcml-element.test.ts
@@ -509,7 +509,7 @@ describe('createAttributesElement / createPreviewElement / createPlainTextElemen
   it('createRawElement with content', () => {
     expect(createRawElement({ content: '<p>raw</p>' })).toEqual({
       tagName: 'rc-raw',
-      content: '<p>raw</p>',
+      content: { type: 'html', text: '<p>raw</p>' },
     })
   })
 

--- a/packages/rcml/src/email/create-rcml-element.ts
+++ b/packages/rcml/src/email/create-rcml-element.ts
@@ -1190,7 +1190,7 @@ export function createPlainTextElement(options: PlainTextElementOptions): RcmlPl
 export function createRawElement(options: RawElementOptions = {}): RcmlRaw {
   const node: RcmlRaw = { tagName: 'rc-raw' }
 
-  if (options.content !== undefined) node.content = options.content
+  if (options.content !== undefined) node.content = { type: 'html', text: options.content }
 
   return node
 }

--- a/packages/rcml/src/email/rcml-types.ts
+++ b/packages/rcml/src/email/rcml-types.ts
@@ -166,7 +166,7 @@ export interface RcmlPlainText {
 export interface RcmlRaw {
   id?: string
   tagName: 'rc-raw'
-  content?: string
+  content?: { type: 'html'; text: string }
 }
 
 // ─── Body / structural ──────────────────────────────────────────────────────

--- a/packages/rcml/src/email/rcml-xml-round-trip.test.ts
+++ b/packages/rcml/src/email/rcml-xml-round-trip.test.ts
@@ -84,6 +84,34 @@ const ROUND_TRIP_DOCS: ReadonlyArray<{ name: string; doc: RcmlDocument }> = [
     },
   },
   {
+    name: 'rc-raw content round-trip',
+    doc: {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                {
+                  tagName: 'rc-column',
+                  children: [
+                    {
+                      tagName: 'rc-raw',
+                      content: { type: 'html', text: '<!--[if mso]><table><tr><td><![endif]-->' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     name: 'preserves `id` on multiple nodes',
     doc: {
       id: 'root',

--- a/packages/rcml/src/email/rcml-xml-round-trip.test.ts
+++ b/packages/rcml/src/email/rcml-xml-round-trip.test.ts
@@ -84,7 +84,7 @@ const ROUND_TRIP_DOCS: ReadonlyArray<{ name: string; doc: RcmlDocument }> = [
     },
   },
   {
-    name: 'rc-raw content round-trip',
+    name: 'rc-raw with MSO conditional comment round-trip',
     doc: {
       tagName: 'rcml',
       children: [
@@ -101,6 +101,37 @@ const ROUND_TRIP_DOCS: ReadonlyArray<{ name: string; doc: RcmlDocument }> = [
                     {
                       tagName: 'rc-raw',
                       content: { type: 'html', text: '<!--[if mso]><table><tr><td><![endif]-->' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    name: 'rc-raw with HTML tags round-trip',
+    doc: {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                {
+                  tagName: 'rc-column',
+                  children: [
+                    {
+                      tagName: 'rc-raw',
+                      content: {
+                        type: 'html',
+                        text: '<div style="padding:40px 10px"><span>HTML block</span></div>',
+                      },
                     },
                   ],
                 },

--- a/packages/rcml/src/email/validate-email-template.test.ts
+++ b/packages/rcml/src/email/validate-email-template.test.ts
@@ -583,6 +583,84 @@ describe('validateEmailTemplate — non-PM content fields', () => {
 
     expect(result.success).toBe(false)
   })
+
+  it('accepts rc-raw with a { type: "html", text } content object', () => {
+    const doc = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                {
+                  tagName: 'rc-column',
+                  children: [
+                    {
+                      tagName: 'rc-raw',
+                      content: { type: 'html', text: '<!--[if mso]><table><tr><td><![endif]-->' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as RcmlDocument
+
+    expect(safeValidateEmailTemplate(doc).success).toBe(true)
+  })
+
+  it('accepts rc-raw without content', () => {
+    const doc = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [{ tagName: 'rc-column', children: [{ tagName: 'rc-raw' }] }],
+            },
+          ],
+        },
+      ],
+    } as unknown as RcmlDocument
+
+    expect(safeValidateEmailTemplate(doc).success).toBe(true)
+  })
+
+  it('rejects rc-raw with a plain string content', () => {
+    const doc = {
+      tagName: 'rcml',
+      children: [
+        { tagName: 'rc-head', children: [] },
+        {
+          tagName: 'rc-body',
+          children: [
+            {
+              tagName: 'rc-section',
+              children: [
+                {
+                  tagName: 'rc-column',
+                  children: [
+                    // @ts-expect-error — intentionally wrong shape
+                    { tagName: 'rc-raw', content: '<p>wrong</p>' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as RcmlDocument
+
+    expect(safeValidateEmailTemplate(doc).success).toBe(false)
+  })
 })
 
 // ─── Regression: full editor-produced document ───────────────────────────────

--- a/packages/rcml/src/email/validator/json-schema.ts
+++ b/packages/rcml/src/email/validator/json-schema.ts
@@ -133,7 +133,7 @@ function buildChildrenSchema(spec: RcmlNodeSpec, useAttrOverride = false): JsonS
 
 /**
  * Non-ProseMirror content schemas for tags that carry a `content` property
- * with a plain string or a structured-but-non-PM object.
+ * with a structured-but-non-PM object.
  *
  * Each entry:
  *  - `schema`   — the JSON Schema that validates the `content` value.
@@ -161,7 +161,15 @@ const TAGS_WITH_SIMPLE_CONTENT: Partial<
     required: true,
   },
   [RcmlTagNamesEnum.Raw]: {
-    schema: { type: 'string' },
+    schema: {
+      type: 'object',
+      properties: {
+        type: { const: 'html' },
+        text: { type: 'string' },
+      },
+      required: ['type', 'text'],
+      additionalProperties: false,
+    },
     required: false,
   },
 }

--- a/packages/rcml/src/email/xml-to-rcml.test.ts
+++ b/packages/rcml/src/email/xml-to-rcml.test.ts
@@ -54,6 +54,25 @@ describe('safeXmlToRcml (non-throwing)', () => {
     expect(['XML_PARSE_ERROR', 'ROOT_INVALID']).toContain(result.errors[0]?.code)
   })
 
+  it('preserves inner HTML tags inside rc-raw as a { type, text } content object', () => {
+    const xml =
+      '<rcml><rc-head></rc-head><rc-body><rc-section><rc-column>' +
+      '<rc-raw><div style="padding:40px"><span>hello</span></div></rc-raw>' +
+      '</rc-column></rc-section></rc-body></rcml>'
+    const result = safeXmlToRcml(xml)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    const raw = (result.data as any).children[1].children[0].children[0].children[0]
+
+    expect(raw.tagName).toBe('rc-raw')
+    expect(raw.content).toEqual({
+      type: 'html',
+      text: '<div style="padding:40px"><span>hello</span></div>',
+    })
+  })
+
   it('surfaces EMAIL_RFM_PARSE_ERROR when a text element contains invalid RFM', () => {
     // Unclosed directive inside rc-text — the RFM parser rejects it.
     const xml = '<rcml><rc-head></rc-head><rc-body><rc-section><rc-column><rc-text>:font[hi</rc-text></rc-column></rc-section></rc-body></rcml>'

--- a/packages/rcml/src/email/xml-to-rcml.test.ts
+++ b/packages/rcml/src/email/xml-to-rcml.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { RcmlBody, RcmlColumn, RcmlRaw, RcmlSection } from './rcml-types.js'
 import { RcmlXmlParseError, safeXmlToRcml, xmlToRcml } from './xml-to-rcml.js'
 
 describe('xmlToRcml (throwing)', () => {
@@ -64,7 +65,8 @@ describe('safeXmlToRcml (non-throwing)', () => {
     expect(result.success).toBe(true)
     if (!result.success) return
 
-    const raw = (result.data as any).children[1].children[0].children[0].children[0]
+    const body = result.data.children[1] as RcmlBody
+    const raw = ((body.children[0] as RcmlSection).children[0] as RcmlColumn).children[0] as RcmlRaw
 
     expect(raw.tagName).toBe('rc-raw')
     expect(raw.content).toEqual({

--- a/packages/rcml/src/email/xml/parse-helpers.ts
+++ b/packages/rcml/src/email/xml/parse-helpers.ts
@@ -34,6 +34,9 @@ const parser = new XMLParser({
   trimValues: false,
   preserveOrder: true,
   processEntities: true,
+  // Treat <rc-raw> content as an opaque text node so inner HTML tags are not
+  // parsed as XML — they are preserved verbatim as the raw #text string.
+  stopNodes: ['*.rc-raw'],
 })
 
 /**

--- a/packages/rcml/src/email/xml/parse-helpers.ts
+++ b/packages/rcml/src/email/xml/parse-helpers.ts
@@ -161,6 +161,14 @@ function convertNode(
     }
   }
 
+  if (tagName === RcmlTagNamesEnum.Raw) {
+    const text = extractText(rawChildren)
+
+    if (text !== '') node['content'] = { type: 'html', text }
+
+    return node
+  }
+
   if (
     tagName === RcmlTagNamesEnum.Text ||
     tagName === RcmlTagNamesEnum.Heading ||

--- a/packages/rcml/src/email/xml/parse-helpers.ts
+++ b/packages/rcml/src/email/xml/parse-helpers.ts
@@ -205,7 +205,9 @@ function convertNode(
     return node
   }
 
-  const schema = RCML_SCHEMA_SPEC[tagName as RcmlTagName]
+  // `tagName` is an arbitrary string from XML input — the cast is needed to
+  // index the spec, but the value may not actually be a known RcmlTagName.
+  const schema = (RCML_SCHEMA_SPEC as Record<string, (typeof RCML_SCHEMA_SPEC)[RcmlTagName] | undefined>)[tagName]
 
   if (!schema) {
     issues.push({ path, code: 'UNKNOWN_TAG', message: `Unknown RCML tag: <${tagName}>` })

--- a/packages/rcml/src/email/xml/serialize-helpers.ts
+++ b/packages/rcml/src/email/xml/serialize-helpers.ts
@@ -48,12 +48,19 @@ const SENTINEL_PREFIX = '\x00RCRAW:'
 const SENTINEL_SUFFIX = '\x00RCRAW'
 const SENTINEL_RE = /\x00RCRAW:([A-Za-z0-9+/=]*)\x00RCRAW/g
 
+// `String.fromCharCode(...bytes)` blows the call stack for large inputs.
+const BYTE_TO_CHAR_CHUNK = 0x8000
+
 /** Encode raw HTML as a sentinel placeholder that XMLBuilder will not encode. */
 function rawHtmlSentinel(html: string): string {
   const bytes = new TextEncoder().encode(html)
-  const b64 = btoa(String.fromCharCode(...bytes))
+  let binary = ''
 
-  return SENTINEL_PREFIX + b64 + SENTINEL_SUFFIX
+  for (let i = 0; i < bytes.length; i += BYTE_TO_CHAR_CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + BYTE_TO_CHAR_CHUNK))
+  }
+
+  return SENTINEL_PREFIX + btoa(binary) + SENTINEL_SUFFIX
 }
 
 /** Replace all sentinels in the builder output with their original raw HTML. */

--- a/packages/rcml/src/email/xml/serialize-helpers.ts
+++ b/packages/rcml/src/email/xml/serialize-helpers.ts
@@ -107,6 +107,15 @@ function toPreservedEntry(node: RcmlNodeLike): PreservedEntry {
     return entry
   }
 
+  if (tagName === RcmlTagNamesEnum.Raw) {
+    const rawContent = node.content as { type: 'html'; text: string } | undefined
+    const text = rawContent?.text ?? ''
+
+    entry[tagName] = text === '' ? [] : [{ '#text': text }]
+
+    return entry
+  }
+
   if (Array.isArray(node.children)) {
     entry[tagName] = node.children.map((child) =>
       toPreservedEntry(child as RcmlNodeLike),

--- a/packages/rcml/src/email/xml/serialize-helpers.ts
+++ b/packages/rcml/src/email/xml/serialize-helpers.ts
@@ -50,12 +50,20 @@ const SENTINEL_RE = /\x00RCRAW:([A-Za-z0-9+/=]*)\x00RCRAW/g
 
 /** Encode raw HTML as a sentinel placeholder that XMLBuilder will not encode. */
 function rawHtmlSentinel(html: string): string {
-  return SENTINEL_PREFIX + btoa(unescape(encodeURIComponent(html))) + SENTINEL_SUFFIX
+  const bytes = new TextEncoder().encode(html)
+  const b64 = btoa(String.fromCharCode(...bytes))
+
+  return SENTINEL_PREFIX + b64 + SENTINEL_SUFFIX
 }
 
 /** Replace all sentinels in the builder output with their original raw HTML. */
 function restoreSentinels(xml: string): string {
-  return xml.replace(SENTINEL_RE, (_, b64) => decodeURIComponent(escape(atob(b64))))
+  return xml.replace(SENTINEL_RE, (_, b64: string) => {
+    const binary = atob(b64)
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
+
+    return new TextDecoder().decode(bytes)
+  })
 }
 
 /**

--- a/packages/rcml/src/email/xml/serialize-helpers.ts
+++ b/packages/rcml/src/email/xml/serialize-helpers.ts
@@ -35,6 +35,30 @@ type RcmlNodeLike = {
 type PreservedEntry = Record<string, unknown>
 
 /**
+ * Sentinel marker used to smuggle raw HTML through the XMLBuilder without
+ * entity encoding. The marker prefix/suffix are chosen to be safe base64
+ * alphabet characters that XMLBuilder will not modify.
+ *
+ * Format: `\x00RCRAW:<base64-encoded-html>\x00RCRAW`
+ *
+ * The null-byte delimiters are not valid XML text, so they survive the builder
+ * unchanged and can be reliably matched for substitution afterwards.
+ */
+const SENTINEL_PREFIX = '\x00RCRAW:'
+const SENTINEL_SUFFIX = '\x00RCRAW'
+const SENTINEL_RE = /\x00RCRAW:([A-Za-z0-9+/=]*)\x00RCRAW/g
+
+/** Encode raw HTML as a sentinel placeholder that XMLBuilder will not encode. */
+function rawHtmlSentinel(html: string): string {
+  return SENTINEL_PREFIX + btoa(unescape(encodeURIComponent(html))) + SENTINEL_SUFFIX
+}
+
+/** Replace all sentinels in the builder output with their original raw HTML. */
+function restoreSentinels(xml: string): string {
+  return xml.replace(SENTINEL_RE, (_, b64) => decodeURIComponent(escape(atob(b64))))
+}
+
+/**
  * Serialize an RCML JSON AST to an XML string.
  *
  * Builds the `preserveOrder: true` intermediate shape expected by
@@ -60,7 +84,8 @@ export function serializeRcmlToXml(doc: RcmlDocument, options: RcmlToXmlOptions)
   })
 
   const entry = toPreservedEntry(doc as unknown as RcmlNodeLike)
-  const xml = builder.build([entry]) as string
+  const built = builder.build([entry]) as string
+  const xml = restoreSentinels(built)
 
   // fast-xml-parser's pretty output brackets the document with stray
   // newlines — strip them so the result is stable across round-trips.
@@ -109,9 +134,11 @@ function toPreservedEntry(node: RcmlNodeLike): PreservedEntry {
 
   if (tagName === RcmlTagNamesEnum.Raw) {
     const rawContent = node.content as { type: 'html'; text: string } | undefined
-    const text = rawContent?.text ?? ''
+    const html = rawContent?.text ?? ''
 
-    entry[tagName] = text === '' ? [] : [{ '#text': text }]
+    // Use a sentinel placeholder so the XMLBuilder does not entity-encode the
+    // HTML. restoreSentinels() in serializeRcmlToXml() substitutes it back.
+    entry[tagName] = html === '' ? [] : [{ '#text': rawHtmlSentinel(html) }]
 
     return entry
   }

--- a/tests/integration/src/client/email-rcraw.integration.spec.ts
+++ b/tests/integration/src/client/email-rcraw.integration.spec.ts
@@ -1,0 +1,73 @@
+import { xmlToRcml } from '@rule/rcml';
+import { createTestClient } from '../helpers/client.js';
+import { testName } from '../helpers/test-data.js';
+
+/**
+ * Integration test: rc-raw HTML content survives the full XML → JSON → API → fetch round-trip.
+ *
+ * This test was written to verify the fix for a bug where HTML tags inside
+ * <rc-raw> were silently stripped during XML parsing (fast-xml-parser treated
+ * them as XML nodes rather than opaque text).
+ */
+
+const RC_RAW_XML = `
+<rcml>
+  <rc-head></rc-head>
+  <rc-body>
+    <rc-section>
+      <rc-column>
+        <rc-raw><div style="padding:40px 10px;border:1px solid #cfd4de;text-align:center;font-family:Lato, sans-serif;"><div style="display:inline;font-size:12px;line-height:20px;color:#3F4752;background:#ECEEF2;margin:0 auto;"><span>&lt;</span>/<span>&gt;</span></div><div style="font-size:12px;line-height:20px;color:#3F4752;">HTML block</div></div></rc-raw>
+      </rc-column>
+    </rc-section>
+  </rc-body>
+</rcml>
+`.trim();
+
+describe('EmailTemplatesClient — rc-raw HTML round-trip', () => {
+  const client = createTestClient();
+  const createdIds: number[] = [];
+
+  afterAll(async () => {
+    await Promise.allSettled(createdIds.map((id) => client.templates.delete(id)));
+  });
+
+  it('parses rc-raw XML with HTML tags into the { type, text } content shape', () => {
+    const doc = xmlToRcml(RC_RAW_XML);
+    const body = (doc as any).children[1];
+    const rawNode = body.children[0].children[0].children[0];
+
+    expect(rawNode.tagName).toBe('rc-raw');
+    expect(rawNode.content).toEqual(
+      expect.objectContaining({ type: 'html' })
+    );
+    expect(rawNode.content.text).toContain('<div');
+    expect(rawNode.content.text).toContain('HTML block');
+  });
+
+  it('creates an email template with rc-raw HTML and fetches it back intact', async () => {
+    const doc = xmlToRcml(RC_RAW_XML);
+
+    const created = await client.templates.createEmailTemplate({
+      name: testName('email-rcraw'),
+      content: doc,
+    });
+
+    createdIds.push(created.id);
+
+    expect(created.id).toBeGreaterThan(0);
+
+    const fetched = await client.templates.get(created.id);
+
+    expect(fetched).not.toBeNull();
+
+    const body = (fetched!.content as any).children[1];
+    const rawNode = body.children[0].children[0].children[0];
+
+    expect(rawNode.tagName).toBe('rc-raw');
+    expect(rawNode.content).toEqual(
+      expect.objectContaining({ type: 'html' })
+    );
+    expect(rawNode.content.text).toContain('<div');
+    expect(rawNode.content.text).toContain('HTML block');
+  });
+});

--- a/tests/integration/src/client/email-rcraw.integration.spec.ts
+++ b/tests/integration/src/client/email-rcraw.integration.spec.ts
@@ -1,4 +1,4 @@
-import { xmlToRcml } from '@rule/rcml';
+import { xmlToRcml, type RcmlBody, type RcmlColumn, type RcmlRaw, type RcmlSection } from '@rule/rcml';
 import { createTestClient } from '../helpers/client.js';
 import { testName } from '../helpers/test-data.js';
 
@@ -33,15 +33,14 @@ describe('EmailTemplatesClient — rc-raw HTML round-trip', () => {
 
   it('parses rc-raw XML with HTML tags into the { type, text } content shape', () => {
     const doc = xmlToRcml(RC_RAW_XML);
-    const body = (doc as any).children[1];
-    const rawNode = body.children[0].children[0].children[0];
+    const body = doc.children[1] as RcmlBody;
+    const rawNode = (body.children[0] as RcmlSection).children[0] as RcmlColumn;
+    const raw = rawNode.children[0] as RcmlRaw;
 
-    expect(rawNode.tagName).toBe('rc-raw');
-    expect(rawNode.content).toEqual(
-      expect.objectContaining({ type: 'html' })
-    );
-    expect(rawNode.content.text).toContain('<div');
-    expect(rawNode.content.text).toContain('HTML block');
+    expect(raw.tagName).toBe('rc-raw');
+    expect(raw.content).toEqual(expect.objectContaining({ type: 'html' }));
+    expect(raw.content?.text).toContain('<div');
+    expect(raw.content?.text).toContain('HTML block');
   });
 
   it('creates an email template with rc-raw HTML and fetches it back intact', async () => {
@@ -60,14 +59,14 @@ describe('EmailTemplatesClient — rc-raw HTML round-trip', () => {
 
     expect(fetched).not.toBeNull();
 
-    const body = (fetched!.content as any).children[1];
-    const rawNode = body.children[0].children[0].children[0];
+    const fetchedDoc = fetched!.content;
+    const body = fetchedDoc.children[1] as RcmlBody;
+    const rawNode = (body.children[0] as RcmlSection).children[0] as RcmlColumn;
+    const raw = rawNode.children[0] as RcmlRaw;
 
-    expect(rawNode.tagName).toBe('rc-raw');
-    expect(rawNode.content).toEqual(
-      expect.objectContaining({ type: 'html' })
-    );
-    expect(rawNode.content.text).toContain('<div');
-    expect(rawNode.content.text).toContain('HTML block');
+    expect(raw.tagName).toBe('rc-raw');
+    expect(raw.content).toEqual(expect.objectContaining({ type: 'html' }));
+    expect(raw.content?.text).toContain('<div');
+    expect(raw.content?.text).toContain('HTML block');
   });
 });


### PR DESCRIPTION
## Summary

- `rc-raw` content was stored as a bare `string` in the SDK but the backend wire format expects `{ type: 'html', text: string }` — aligned the type, factory, JSON schema validator, and docs to match
- `fast-xml-parser` was parsing the contents of `<rc-raw>` as XML, silently discarding any HTML tags (only bare text nodes survived) — fixed with `stopNodes: ['*.rc-raw']` in the parser and a sentinel-placeholder approach in the serializer to bypass entity encoding of `<`/`>`

## Changes

- **`rcml-types.ts`** — `RcmlRaw.content` changed from `string` to `{ type: 'html'; text: string }`
- **`create-rcml-element.ts`** — `createRawElement` wraps the string input into the correct object shape; public `RawElementOptions.content` stays `string`
- **`validator/json-schema.ts`** — content schema for `rc-raw` updated from `{ type: 'string' }` to the object shape
- **`xml/parse-helpers.ts`** — `stopNodes: ['*.rc-raw']` prevents inner HTML from being parsed as XML; extracts raw text and wraps as `{ type: 'html', text }`
- **`xml/serialize-helpers.ts`** — sentinel placeholder encodes the HTML before the builder runs and is substituted back after, bypassing `XMLBuilder`'s entity encoding
- **`docs/email/rcml/body/content/rc-raw.md`** — JSON example updated to show the correct content shape
- **`tests/integration/…/email-rcraw.integration.spec.ts`** — integration test creates a real template from XML containing HTML tags in `<rc-raw>`, fetches it back, and asserts the content arrives intact

## Test plan

- [ ] Unit tests: `pnpm nx run rcml:"vitest:test"` — all 1272 pass
- [ ] Integration tests: both `rc-raw` cases in `email-rcraw.integration.spec.ts` pass against the live API
- [ ] Template 2884057 (campaign 961716) created on the test account with this branch — verify the editor opens it without "No attributes node found in head"

🤖 Generated with [Claude Code](https://claude.com/claude-code)