### PR TITLE
fix(docs): update GitHub Pages base URL after repo rename to sdk

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@
 #   2. The first run will create the gh-pages branch automatically.
 #
 # Deployment layout on gh-pages:
-#   /index.html      → redirect to /rule-io-sdk/latest/
+#   /index.html      → redirect to /sdk/latest/
 #   /latest/         → current docs (updated on every push to main)
 #   /vX.Y/           → immutable version snapshots (added in Phase 9)
 
@@ -46,7 +46,7 @@ jobs:
       - name: Build VitePress site
         run: npx nx run docs:build
         env:
-          DOCS_BASE: /rule-io-sdk/latest/
+          DOCS_BASE: /sdk/latest/
 
       - name: Stage deployment (redirect at root + docs at latest/)
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rule-io-sdk
+# sdk
 
 Nx monorepo for the Rule.io TypeScript SDK. Detailed usage docs live in [`packages/sdk`](packages/sdk/README.md) and the per-package READMEs; this README covers package selection, contributor workflow, and the release process.
 
@@ -204,7 +204,7 @@ The SDK documentation site lives in `apps/docs/` and is built with [VitePress](h
 
 ```bash
 npm run docs:generate   # generate API reference + sync package docs
-npm run docs:dev        # start dev server → http://localhost:5173/rule-io-sdk/
+npm run docs:dev        # start dev server → http://localhost:5173/sdk/
 ```
 
 To preview the production build:

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
   title: 'Rule.io SDK',
   description: 'Documentation for @rule/client, @rule/rcml, and @rule/sdk',
   srcDir: 'src',
-  base: (process.env['DOCS_BASE'] ?? '/rule-io-sdk/') as `/${string}/`,
+  base: (process.env['DOCS_BASE'] ?? '/sdk/') as `/${string}/`,
 
   markdown: {
     anchor: {

--- a/apps/docs/redirect/index.html
+++ b/apps/docs/redirect/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=/rule-io-sdk/latest/" />
-    <link rel="canonical" href="/rule-io-sdk/latest/" />
+    <meta http-equiv="refresh" content="0; url=/sdk/latest/" />
+    <link rel="canonical" href="/sdk/latest/" />
     <title>Rule.io SDK Docs</title>
   </head>
   <body>
-    <a href="/rule-io-sdk/latest/">Redirecting to latest docs…</a>
+    <a href="/sdk/latest/">Redirecting to latest docs…</a>
   </body>
 </html>

--- a/apps/docs/src/guide/contributing.md
+++ b/apps/docs/src/guide/contributing.md
@@ -17,7 +17,7 @@ Edit Markdown files directly under `apps/docs/src/guide/`. Run the dev server to
 npm run docs:dev
 ```
 
-Then open `http://localhost:5173/rule-io-sdk/` (or `DOCS_BASE=/ npm run docs:dev` for `http://localhost:5173/`).
+Then open `http://localhost:5173/sdk/` (or `DOCS_BASE=/ npm run docs:dev` for `http://localhost:5173/`).
 
 ## Editing package docs
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/client"
   },
   "dependencies": {

--- a/packages/rcml/package.json
+++ b/packages/rcml/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/rcml"
   },
   "dependencies": {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -32,7 +32,7 @@ Get your API key from [Rule.io Settings → API](https://app.rule.io/v5/#/app/se
 
 ## Documentation
 
-Full guides and API reference: see the [published documentation site](https://rulecom.github.io/rule-io-sdk/).
+Full guides and API reference: see the [published documentation site](https://rule.github.io/sdk/).
 
 ## License
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/sdk"
   },
   "dependencies": {

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/template-engine"
   },
   "dependencies": {

--- a/packages/vendor-bookzen/package.json
+++ b/packages/vendor-bookzen/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/vendor-bookzen"
   },
   "dependencies": {

--- a/packages/vendor-samfora/package.json
+++ b/packages/vendor-samfora/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/vendor-samfora"
   },
   "dependencies": {

--- a/packages/vendor-shopify/package.json
+++ b/packages/vendor-shopify/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/vendor-shopify"
   },
   "dependencies": {

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rulecom/rule-io-sdk.git",
+    "url": "https://github.com/rule/sdk.git",
     "directory": "packages/vendor"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Updates all hardcoded `/rule-io-sdk/` paths to `/sdk/` following the repo rename
- Fixes the broken GitHub Pages docs site at the new URL

## Changes

- `.github/workflows/docs.yml` — `DOCS_BASE` env var and comment
- `apps/docs/.vitepress/config.mts` — fallback `base`
- `apps/docs/redirect/index.html` — root redirect page

## Test plan

- [ ] Merge to main and confirm the Deploy Docs workflow completes successfully
- [ ] Verify `https://<org>.github.io/sdk/latest/` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)