### PR TITLE
Release: merge develop into main

### DIFF
--- a/packages/client/docs/email-messages.md
+++ b/packages/client/docs/email-messages.md
@@ -106,6 +106,26 @@ await client.messages.updateEmailAutomationMessage(messageId, {
 
 *→ [`UpdateEmailAutomationMessagePayload`](/api/client/src/interfaces/UpdateEmailAutomationMessagePayload)*
 
+## Reading the automail setting
+
+`get()` and `listAutomationMessages()` return `automailSetting` on automation messages so you can inspect the current delivery state. The field is a discriminated union on `type` — trigger-relative delays and segment-driven delivery are modelled separately:
+
+```typescript
+const message = await client.messages.get(messageId);
+
+if (message?.automailSetting?.type === 'delay') {
+  // Trigger-relative delivery. delayInSeconds is a string; '0' = immediate.
+  console.log('Delay:', message.automailSetting.delayInSeconds, 'seconds');
+} else if (message?.automailSetting?.type === 'custom') {
+  // Segment-driven delivery configured in the Rule.io UI. No delay field.
+  console.log('Segment-driven delivery, active:', message.automailSetting.active);
+}
+```
+
+Campaign messages omit `automailSetting`.
+
+*→ [`AutomailSettingRead`](/api/client/src/type-aliases/AutomailSettingRead)*
+
 ## Listing messages
 
 Retrieve all messages for a campaign or automation. A dispatcher typically has one message, but the API supports multiple (e.g. for A/B variants).

--- a/packages/client/docs/sms-messages.md
+++ b/packages/client/docs/sms-messages.md
@@ -100,6 +100,26 @@ await client.messages.updateSmsAutomationMessage(messageId, {
 
 *→ [`UpdateSmsAutomationMessagePayload`](/api/client/src/interfaces/UpdateSmsAutomationMessagePayload)*
 
+## Reading the automail setting
+
+`get()` and `listAutomationMessages()` return `automailSetting` on automation messages so you can inspect the current delivery state. The field is a discriminated union on `type` — trigger-relative delays and segment-driven delivery are modelled separately:
+
+```typescript
+const message = await client.messages.get(messageId);
+
+if (message?.automailSetting?.type === 'delay') {
+  // Trigger-relative delivery. delayInSeconds is a string; '0' = immediate.
+  console.log('Delay:', message.automailSetting.delayInSeconds, 'seconds');
+} else if (message?.automailSetting?.type === 'custom') {
+  // Segment-driven delivery configured in the Rule.io UI. No delay field.
+  console.log('Segment-driven delivery, active:', message.automailSetting.active);
+}
+```
+
+Campaign messages omit `automailSetting`.
+
+*→ [`AutomailSettingRead`](/api/client/src/type-aliases/AutomailSettingRead)*
+
 ## Listing messages
 
 Retrieve all messages for a campaign or automation. A dispatcher typically has one message, but the API supports multiple (e.g. for A/B variants).

--- a/packages/client/src/resources/messages/messages.client.test.ts
+++ b/packages/client/src/resources/messages/messages.client.test.ts
@@ -178,6 +178,75 @@ describe('MessagesClient', () => {
 
       await expect(client.get(5)).rejects.toBeInstanceOf(RuleApiError);
     });
+
+    describe('automail_setting mapping', () => {
+      it('maps type=delay with non-zero delay to entity discriminant with string delayInSeconds', async () => {
+        const wire = {
+          ...WIRE_MESSAGE,
+          dispatcher: { id: 77, type: -2 },
+          automail_setting: { type: 'delay', active: true, delay: 259200 },
+        };
+
+        fetchMock.mockResolvedValueOnce(createMockResponse({ data: wire }));
+        const client = createClient(fetchMock);
+
+        const result = await client.get(10);
+
+        expect(result!.automailSetting).toEqual({
+          type: 'delay',
+          active: true,
+          delayInSeconds: '259200',
+        });
+        expect(typeof (result!.automailSetting as { delayInSeconds: string }).delayInSeconds).toBe(
+          'string'
+        );
+      });
+
+      it('maps type=delay with delay=0 to delayInSeconds="0" (immediate delivery)', async () => {
+        const wire = {
+          ...WIRE_MESSAGE,
+          dispatcher: { id: 77, type: -2 },
+          automail_setting: { type: 'delay', active: true, delay: 0 },
+        };
+
+        fetchMock.mockResolvedValueOnce(createMockResponse({ data: wire }));
+        const client = createClient(fetchMock);
+
+        const result = await client.get(10);
+
+        expect(result!.automailSetting).toEqual({
+          type: 'delay',
+          active: true,
+          delayInSeconds: '0',
+        });
+      });
+
+      it('maps type=custom without delay to entity discriminant without delayInSeconds', async () => {
+        const wire = {
+          ...WIRE_MESSAGE,
+          dispatcher: { id: 77, type: -2 },
+          automail_setting: { type: 'custom', active: false },
+        };
+
+        fetchMock.mockResolvedValueOnce(createMockResponse({ data: wire }));
+        const client = createClient(fetchMock);
+
+        const result = await client.get(10);
+
+        expect(result!.automailSetting).toEqual({ type: 'custom', active: false });
+        expect(result!.automailSetting).not.toHaveProperty('delayInSeconds');
+      });
+
+      it('leaves automailSetting undefined for campaign messages (no automail_setting on wire)', async () => {
+        fetchMock.mockResolvedValueOnce(createMockResponse({ data: WIRE_MESSAGE }));
+        const client = createClient(fetchMock);
+
+        const result = await client.get(10);
+
+        expect(result!.automailSetting).toBeUndefined();
+        expect(result).not.toHaveProperty('automail_setting');
+      });
+    });
   });
 
   describe('updateEmailCampaignMessage', () => {

--- a/packages/client/src/resources/messages/messages.client.test.ts
+++ b/packages/client/src/resources/messages/messages.client.test.ts
@@ -246,6 +246,19 @@ describe('MessagesClient', () => {
         expect(result!.automailSetting).toBeUndefined();
         expect(result).not.toHaveProperty('automail_setting');
       });
+
+      it('throws on an unknown automail_setting.type (contract-drift guard)', async () => {
+        const wire = {
+          ...WIRE_MESSAGE,
+          dispatcher: { id: 77, type: -2 },
+          automail_setting: { type: 'trigger-event', active: true },
+        };
+
+        fetchMock.mockResolvedValueOnce(createMockResponse({ data: wire }));
+        const client = createClient(fetchMock);
+
+        await expect(client.get(10)).rejects.toThrow(/Unexpected automail_setting\.type/);
+      });
     });
   });
 

--- a/packages/client/src/resources/messages/messages.client.test.ts
+++ b/packages/client/src/resources/messages/messages.client.test.ts
@@ -364,5 +364,24 @@ describe('MessagesClient', () => {
       expect(url).toContain('id=77');
       expect(url).toContain('dispatcher_type=automail');
     });
+
+    it('maps automail_setting on list items through the same mapper as get()', async () => {
+      const wire = {
+        ...WIRE_MESSAGE,
+        dispatcher: { id: 77, type: -2 },
+        automail_setting: { type: 'delay', active: true, delay: 3600 },
+      };
+
+      fetchMock.mockResolvedValueOnce(createMockResponse({ data: [wire] }));
+      const client = createClient(fetchMock);
+
+      const result = await client.listAutomationMessages(77);
+
+      expect(result[0]!.automailSetting).toEqual({
+        type: 'delay',
+        active: true,
+        delayInSeconds: '3600',
+      });
+    });
   });
 });

--- a/packages/client/src/resources/messages/messages.client.ts
+++ b/packages/client/src/resources/messages/messages.client.ts
@@ -420,7 +420,13 @@ function mapAutomailSettingFromWire(w: AutomailSettingReadWire): AutomailSetting
     return { type: 'delay', active: w.active, delayInSeconds: String(w.delay) };
   }
 
-  return { type: 'custom', active: w.active };
+  if (w.type === 'custom') {
+    return { type: 'custom', active: w.active };
+  }
+
+  throw new Error(
+    `Unexpected automail_setting.type on wire: ${JSON.stringify((w as { type: unknown }).type)}`
+  );
 }
 
 function mapCampaignPayloadToBody(

--- a/packages/client/src/resources/messages/messages.client.ts
+++ b/packages/client/src/resources/messages/messages.client.ts
@@ -16,7 +16,9 @@ import { BaseResource } from '../../core/base-resource.js';
 import { buildQueryString } from '../../core/query-string.js';
 import type {
   AutomailSetting,
-  AutomailSettingWire,
+  AutomailSettingReadWire,
+  AutomailSettingRead,
+  AutomailSettingWriteWire,
   CreateEmailAutomationMessagePayload,
   CreateEmailCampaignMessagePayload,
   CreateMessageBody,
@@ -391,6 +393,9 @@ function mapMessageWireToEntity(wire: MessageWire): Message {
     dispatcher: wire.dispatcher,
     createdAt: wire.created_at,
     updatedAt: wire.updated_at,
+    automailSetting: wire.automail_setting
+      ? mapAutomailSettingFromWire(wire.automail_setting)
+      : undefined,
   };
 }
 
@@ -403,11 +408,19 @@ function mapSender(
   return { name: fromName, email: fromEmail };
 }
 
-function mapAutomailSetting(s: AutomailSetting): AutomailSettingWire {
+function mapAutomailSetting(s: AutomailSetting): AutomailSettingWriteWire {
   return {
     active: s.active,
     delay_in_seconds: parseInt(s.delayInSeconds, 10),
   };
+}
+
+function mapAutomailSettingFromWire(w: AutomailSettingReadWire): AutomailSettingRead {
+  if (w.type === 'delay') {
+    return { type: 'delay', active: w.active, delayInSeconds: String(w.delay) };
+  }
+
+  return { type: 'custom', active: w.active };
 }
 
 function mapCampaignPayloadToBody(

--- a/packages/client/src/resources/messages/messages.types.ts
+++ b/packages/client/src/resources/messages/messages.types.ts
@@ -152,9 +152,13 @@ export type SmsAutomationMessage = Message;
 // ── Supporting types ──────────────────────────────────────────────────────────
 
 /**
- * Automail delivery settings attached to an automation message.
+ * Automail delivery settings for the write path (POST / PUT).
  *
- * Controls when the automation fires relative to its trigger event.
+ * Only trigger-relative delays can be set through the SDK: pass
+ * `delayInSeconds` as a string of seconds since the trigger event
+ * (`"0"` for immediate delivery). Date-based (UI-configured) delays cannot
+ * be created or modified through the SDK — configure them in the Rule.io
+ * UI.
  */
 export interface AutomailSetting {
   /**
@@ -176,16 +180,21 @@ export interface AutomailSetting {
 }
 
 /**
- * Automail delivery state as returned by the API on automation messages.
+ * Automail delivery state as returned by the Rule.io v3 API on automation
+ * messages.
  *
- * Discriminated union on `type`. `AutomailSetting` (used for write payloads)
- * is the flat shape the API accepts on create/update; on read, the API
- * projects it into this union depending on how the automation is configured.
+ * Discriminated union on `type`. `AutomailSetting` (the write payload) is
+ * the flat shape the API accepts on create/update; on read, the API
+ * projects delivery state into this union.
  *
  * - `"delay"` — trigger-relative delay in seconds. Carries `delayInSeconds`
  *   (`"0"` for immediate delivery).
- * - `"custom"` — segment-driven delivery configured in the Rule.io UI.
- *   Carries no delay because timing is determined by segment membership.
+ * - `"custom"` — date-based delivery configured in the Rule.io UI (e.g.
+ *   "send N days before/after a subscriber's date field"). The API does not
+ *   expose the underlying rules (which custom field, offset, direction,
+ *   timezone, repeat behaviour), so the SDK can only report *that* a custom
+ *   delay is set and whether the message is `active`. To view or modify a
+ *   custom delay, use the Rule.io UI.
  */
 export type AutomailSettingRead =
   | {

--- a/packages/client/src/resources/messages/messages.types.ts
+++ b/packages/client/src/resources/messages/messages.types.ts
@@ -83,6 +83,14 @@ export interface Message {
   createdAt?: string;
   /** ISO 8601 timestamp of when the message was last updated. */
   updatedAt?: string;
+  /**
+   * Automail delivery state, present only on automation messages.
+   *
+   * A discriminated union on `type`: `"delay"` carries a `delayInSeconds`
+   * value; `"custom"` indicates segment-driven delivery configured in the
+   * Rule.io UI and does not carry a delay. Campaign messages omit this field.
+   */
+  automailSetting?: AutomailSettingRead;
 }
 
 /**
@@ -166,6 +174,39 @@ export interface AutomailSetting {
    */
   delayInSeconds: string;
 }
+
+/**
+ * Automail delivery state as returned by the API on automation messages.
+ *
+ * Discriminated union on `type`. `AutomailSetting` (used for write payloads)
+ * is the flat shape the API accepts on create/update; on read, the API
+ * projects it into this union depending on how the automation is configured.
+ *
+ * - `"delay"` — trigger-relative delay in seconds. Carries `delayInSeconds`
+ *   (`"0"` for immediate delivery).
+ * - `"custom"` — segment-driven delivery configured in the Rule.io UI.
+ *   Carries no delay because timing is determined by segment membership.
+ */
+export type AutomailSettingRead =
+  | {
+      /** Trigger-relative delay. */
+      type: 'delay';
+      /** Whether this automation message is active. */
+      active: boolean;
+      /**
+       * Delay between the trigger event and the send, expressed in seconds.
+       *
+       * `"0"` means the message is sent as soon as the trigger fires. Returned
+       * as a string to match the SDK's write-side `AutomailSetting` shape.
+       */
+      delayInSeconds: string;
+    }
+  | {
+      /** Segment-driven delivery configured in the Rule.io UI. */
+      type: 'custom';
+      /** Whether this automation message is active. */
+      active: boolean;
+    };
 
 // ── Create payloads ───────────────────────────────────────────────────────────
 
@@ -424,19 +465,36 @@ export interface MessageWire {
   dispatcher?: { id: number; type: number };
   created_at?: string;
   updated_at?: string;
+  /** Present only on automation messages; omitted for campaigns. */
+  automail_setting?: AutomailSettingReadWire;
 }
 
 /**
- * Wire-format automail setting.
+ * Wire-format automail setting accepted by create/update request bodies.
  *
  * `delay_in_seconds` is an integer on the wire (the SDK public API uses a
- * string; the mapper converts with `parseInt`).
+ * string; the mapper converts with `parseInt`). This is the flat shape the
+ * v3 API expects on write; on read the API returns a discriminated union,
+ * modelled separately by `AutomailSettingReadWire`.
  * @internal
  */
-export interface AutomailSettingWire {
+export interface AutomailSettingWriteWire {
   active: boolean;
   delay_in_seconds: number;
 }
+
+/**
+ * Wire-format automail setting returned by GET `/editor/message/:id`.
+ *
+ * Discriminated union on `type`. For `"delay"` the response carries an
+ * integer `delay` (seconds since the trigger, `0` for immediate delivery).
+ * For `"custom"` the delay field is absent because delivery is driven by a
+ * segment configured in the Rule.io UI.
+ * @internal
+ */
+export type AutomailSettingReadWire =
+  | { type: 'delay'; active: boolean; delay: number }
+  | { type: 'custom'; active: boolean };
 
 /**
  * Wire body for POST `/editor/message`.
@@ -452,7 +510,7 @@ export interface CreateMessageBody {
   sender?: MessageSenderWire;
   utm_campaign?: string | null;
   utm_term?: string | null;
-  automail_setting?: AutomailSettingWire;
+  automail_setting?: AutomailSettingWriteWire;
 }
 
 /**
@@ -465,7 +523,7 @@ export interface UpdateMessageBody {
   sender?: MessageSenderWire;
   utm_campaign?: string | null;
   utm_term?: string | null;
-  automail_setting?: AutomailSettingWire;
+  automail_setting?: AutomailSettingWriteWire;
 }
 
 /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -84,6 +84,7 @@ export type {
 // ── Messages ─────────────────────────────────────────────────────────────────
 export type {
   AutomailSetting,
+  AutomailSettingRead,
   CreateEmailAutomationMessagePayload,
   CreateEmailCampaignMessagePayload,
   CreateSmsAutomationMessagePayload,


### PR DESCRIPTION
## Summary

Consolidates the changes from #165 into `main` for the next release.

- Adds `Message.automailSetting` on the read-path — the v3 API's `automail_setting` field is now surfaced through `client.messages.get()` and `client.messages.listAutomationMessages()`.
- Introduces public `AutomailSettingRead` as a discriminated union on `type` (`"delay"` with `delayInSeconds`, `"custom"` without) — mirrors the actual v3 response shape verified against email, SMS, and RCS automation messages.
- Splits the internal wire type into read/write variants to model the backend's read/write asymmetry (write accepts `{active, delay_in_seconds}`, read returns `{type, active, delay?}`).
- Adds defensive throw on unknown `automail_setting.type` in the mapper so future contract drift fails loudly rather than silently mismapping.
- Adds explicit JSDoc on both `AutomailSetting` (write) and `AutomailSettingRead` (read) documenting the SDK boundary around custom (date-based) delays — only trigger-relative delays are settable via the SDK; custom delays are UI-configured and read-only.
- Updates `email-messages.md` and `sms-messages.md` guides with a "Reading the automail setting" section.
- Existing `AutomailSetting` (write payload) is untouched — no breaking change for `create*`/`update*` callers.

## Test plan

- [x] `nx run client:vitest:test` — 556 pass (was 550; +6 new tests covering delay/custom/campaign/unknown-type/list-path)
- [x] `nx run client:eslint:lint` — 0 errors
- [x] `nx run client:build` — tsc succeeds
- [x] `nx run docs:dev` visual check — guide pages render new section, `Message.automailSetting` and `AutomailSettingRead` type-alias pages generate correctly
- [x] Real API shapes verified against Postman responses for email, SMS, and RCS automation messages (both `delay` and `custom` variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)